### PR TITLE
feat: Lead Time for Changes 측정 자동화 워크플로우 추가

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,0 +1,51 @@
+name: Lead Time for Changes Tracker
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+      - develop
+
+jobs:
+  calculate-lead-time:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Calculate Lead Time
+        id: calc
+        shell: bash
+        run: |
+          # PR 병합 시간 (ISO 8601 -> Unix Timestamp)
+          MERGED_AT=$(date -d "${{ github.event.pull_request.merged_at }}" +%s)
+          
+          # PR의 첫 번째 커밋 해시 가져오기
+          FIRST_COMMIT_HASH=$(git log origin/${{ github.event.pull_request.base.ref }}..origin/${{ github.event.pull_request.head.ref }} --reverse --format=format:%H | head -n 1)
+          
+          # 첫 번째 커밋의 작성 시간 가져오기
+          FIRST_COMMIT_AT=$(git log -1 --format=%ct $FIRST_COMMIT_HASH)
+          
+          # 소요 시간 계산 (초 단위)
+          DIFF_SECONDS=$((MERGED_AT - FIRST_COMMIT_AT))
+          
+          # 시간/분 단위 변환
+          HOURS=$((DIFF_SECONDS / 3600))
+          MINUTES=$(( (DIFF_SECONDS % 3600) / 60 ))
+          
+          echo "### 🚀 Lead Time for Changes" >> $GITHUB_STEP_SUMMARY
+          echo "- **PR Title:** ${{ github.event.pull_request.title }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **PR Number:** #${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **First Commit:** $(date -d @$FIRST_COMMIT_AT -u)" >> $GITHUB_STEP_SUMMARY
+          echo "- **Merged At:** $(date -d @$MERGED_AT -u)" >> $GITHUB_STEP_SUMMARY
+          echo "- **Total Lead Time:** ${HOURS}h ${MINUTES}m (${DIFF_SECONDS} seconds)" >> $GITHUB_STEP_SUMMARY
+          
+          if [ $HOURS -lt 24 ]; then
+            echo "✅ Great job! Lead time is under 24 hours." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "⚠️ Consider breaking down PRs into smaller chunks for faster delivery." >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
GitHub Actions를 활용하여 PR 병합 시 첫 번째 커밋부터 병합까지의 소요 시간을 자동으로 계산하여 Job Summary에 기록하는 워크플로우를 추가했습니다.