### PR TITLE
chore: GitHub 이슈 템플릿 추가

### DIFF
--- a/.github/ISSUE_TEMPLATE/aioss_task.yml
+++ b/.github/ISSUE_TEMPLATE/aioss_task.yml
@@ -1,0 +1,52 @@
+name: "AIOSS 수업 과제"
+description: "AI OSS 수업 주차별 과제 이슈에 사용합니다."
+title: "[AIOSS-Wxx] "
+labels: ["aioss"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > 제목 형식: `[AIOSS-W01]` ~ `[AIOSS-W14]` 중 해당 주차를 작성해 주세요.
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: "과제 목표"
+      description: "이번 주차 과제의 목표를 작성해 주세요."
+      placeholder: "예: GitHub 기반 개발 환경을 구축하고 프로젝트 제안서를 작성한다."
+    validations:
+      required: true
+
+  - type: textarea
+    id: project_relation
+    attributes:
+      label: "프로젝트 연관성"
+      description: "이 과제가 본 프로젝트(GovOn)와 어떻게 연결되는지 설명해 주세요."
+      placeholder: |
+        - 민원 시스템의 어떤 기능/구조에 적용되는지
+        - 기술 스택 선정 근거 등
+    validations:
+      required: false
+
+  - type: textarea
+    id: checklist
+    attributes:
+      label: "과제 체크리스트"
+      description: "완료해야 할 항목을 체크리스트로 작성해 주세요."
+      value: |
+        - [ ]
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+
+  - type: textarea
+    id: outputs
+    attributes:
+      label: "산출물"
+      description: "과제 결과로 제출하거나 생성할 파일/문서를 작성해 주세요."
+      placeholder: |
+        - docs/outputs/...
+        - GitHub 저장소 설정 완료
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: "버그 리포트"
+description: "버그 또는 예상치 못한 동작을 보고할 때 사용합니다."
+title: "[BUG] "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: "버그 설명"
+      description: "어떤 문제가 발생했는지 명확하게 설명해 주세요."
+      placeholder: "예: vLLM 서버 기동 시 CUDA OOM 오류 발생"
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: "재현 방법"
+      description: "버그를 재현하는 단계를 작성해 주세요."
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: "기대 동작"
+      description: "정상적으로 동작했다면 어떤 결과가 나와야 했나요?"
+      placeholder: "예: 모델이 정상적으로 로드되고 추론 결과를 반환해야 함"
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: "실제 동작"
+      description: "실제로 어떤 결과가 나왔나요? 에러 로그나 스크린샷을 첨부해 주세요."
+      placeholder: "예: RuntimeError: CUDA out of memory..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: "환경 정보"
+      description: "발생 환경을 작성해 주세요."
+      value: |
+        - OS:
+        - GPU / VRAM:
+        - Python 버전:
+        - 관련 패키지 버전 (vLLM, PyTorch 등):
+        - 브랜치:
+    validations:
+      required: false
+
+  - type: textarea
+    id: related
+    attributes:
+      label: "관련 이슈 / PR"
+      placeholder: "- #"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/docs_chore.yml
+++ b/.github/ISSUE_TEMPLATE/docs_chore.yml
@@ -1,0 +1,48 @@
+name: "문서화 / 기타 작업"
+description: "문서 작성, 발표 자료 준비, 환경 설정 등 기타 작업에 사용합니다."
+title: "docs/chore: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > 제목 prefix 예시: `docs:` (문서화), `chore:` (환경설정/기타)
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: "목표"
+      description: "이 작업의 목적을 간략히 작성해 주세요."
+      placeholder: "예: 3/16 미팅 발표자료 준비"
+    validations:
+      required: true
+
+  - type: textarea
+    id: tasks
+    attributes:
+      label: "작업 내용"
+      description: "수행할 작업을 체크리스트로 작성해 주세요."
+      value: |
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+
+  - type: textarea
+    id: outputs
+    attributes:
+      label: "산출물"
+      description: "작업 결과 파일이나 링크를 작성해 주세요."
+      placeholder: |
+        - docs/presentations/...
+        - README.md 업데이트
+    validations:
+      required: false
+
+  - type: textarea
+    id: related
+    attributes:
+      label: "관련 이슈 / PR"
+      placeholder: "- #"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_task.yml
+++ b/.github/ISSUE_TEMPLATE/feature_task.yml
@@ -1,0 +1,82 @@
+name: "기능 구현 / 마일스톤 태스크"
+description: "마일스톤 기능 구현, 실험, 개선 작업에 사용합니다."
+title: "[Mx] "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > 제목 형식: `[M1]`, `[M2]`, `[M3]`, `[M4]` 중 해당 마일스톤을 선택해 작성해 주세요.
+
+  - type: textarea
+    id: background
+    attributes:
+      label: "배경"
+      description: "이 작업이 필요한 배경 또는 문제 상황을 설명해 주세요."
+      placeholder: "예: M2 평가에서 데이터 품질 문제가 확인되었습니다..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: "목표"
+      description: "이 이슈를 통해 달성하려는 목표를 한 줄로 작성해 주세요."
+      placeholder: "예: EXAONE-Deep-7.8B 모델을 민원 도메인에 특화하여 QLoRA 파인튜닝 실행"
+    validations:
+      required: true
+
+  - type: textarea
+    id: tasks
+    attributes:
+      label: "작업 내용"
+      description: "수행할 작업을 체크리스트 형태로 작성해 주세요."
+      value: |
+        - [ ]
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+
+  - type: textarea
+    id: done_criteria
+    attributes:
+      label: "완료 기준"
+      description: "이슈가 완료되었다고 볼 수 있는 기준을 작성해 주세요."
+      value: |
+        - [ ]
+        - [ ]
+    validations:
+      required: false
+
+  - type: textarea
+    id: outputs
+    attributes:
+      label: "산출물"
+      description: "작업 결과로 생성되는 파일, 문서, 모델 등을 작성해 주세요."
+      placeholder: |
+        - src/training/train_qlora.py
+        - docs/outputs/M2_MVP/...
+    validations:
+      required: false
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: "의존성"
+      description: "이 이슈와 연관된 다른 이슈를 작성해 주세요."
+      placeholder: |
+        - #67 QLoRA 하이퍼파라미터 최적화
+        - #68 답변 생성 품질 고도화
+    validations:
+      required: false
+
+  - type: textarea
+    id: related
+    attributes:
+      label: "관련 이슈 / PR"
+      description: "참고할 이슈나 PR 번호를 작성해 주세요."
+      placeholder: |
+        - #10, #11
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

- 기존 이슈 작성 패턴을 분석해 팀 공통 이슈 템플릿 4종 추가
- GitHub 이슈 생성 시 템플릿 선택 화면 활성화

## 추가된 템플릿

| 템플릿 | 용도 | 제목 형식 |
|--------|------|-----------|
| `feature_task.yml` | 마일스톤 기능 구현 / 실험 태스크 | `[Mx] 제목` |
| `bug_report.yml` | 버그 리포트 | `[BUG] 제목` |
| `aioss_task.yml` | AIOSS 수업 주차별 과제 | `[AIOSS-Wxx] 제목` |
| `docs_chore.yml` | 문서화 및 기타 작업 | `docs/chore: 제목` |

## Test plan

- [x] GitHub 저장소에서 New Issue 클릭 시 템플릿 선택 화면 표시 확인
- [x] 각 템플릿 선택 후 양식 항목 정상 표시 확인