### PR TITLE
fix: DORA 워크플로우 Node.js 경고 알림 억제

### DIFF
--- a/.github/workflows/dora-metrics.yml
+++ b/.github/workflows/dora-metrics.yml
@@ -18,6 +18,8 @@ permissions:
 jobs:
   collect-dora-metrics:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` 환경변수 추가하여 Node.js 20 deprecation 경고 제거

## Test plan
- [x] 워크플로우 실행 시 경고 알림 미발생 확인