### PR TITLE
feat: M3 vLLM AWQ KPI 평가 결과 파일 추가

### DIFF
--- a/docs/outputs/kpi_evaluation/kpi_eval_awq_vllm_20260320_121929.json
+++ b/docs/outputs/kpi_evaluation/kpi_eval_awq_vllm_20260320_121929.json
@@ -1,0 +1,80 @@
+{
+  "metadata": {
+    "timestamp": "20260320_121929",
+    "prd_version": "v3.4",
+    "model": "umyunsang/GovOn-EXAONE-AWQ-v2",
+    "base_model": "LGAI-EXAONE/EXAONE-Deep-7.8B",
+    "quantization": "awq_marlin",
+    "dtype": "bfloat16",
+    "gpu": "NVIDIA A100-SXM4-40GB",
+    "n_test_samples": 1265,
+    "evaluation_type": "kpi_evaluation_awq_vllm"
+  },
+  "kpi_results": {
+    "all_passed": false,
+    "details": [
+      {
+        "kpi": "AC-002: 답변 생성 p95",
+        "measured": 2.84881589529989,
+        "target": 3.0,
+        "unit": "초",
+        "passed": "True"
+      },
+      {
+        "kpi": "AC-003: 검색 p95",
+        "measured": 0.0397559950000982,
+        "target": 1.0,
+        "unit": "초",
+        "passed": "True"
+      },
+      {
+        "kpi": "VRAM 사용량",
+        "measured": 29.4111328125,
+        "target": 5.0,
+        "unit": "GB",
+        "passed": false
+      }
+    ]
+  },
+  "generation_latency": {
+    "n_samples": 200,
+    "p50_sec": 1.5586658224998473,
+    "p95_sec": 2.84881589529989,
+    "p99_sec": 2.903941503729957,
+    "mean_sec": 1.569741670459996,
+    "std_sec": 0.7273023408297863,
+    "throughput_tps": 178.40094497873125
+  },
+  "retrieval_latency": {
+    "n_queries": 200,
+    "p50_ms": 23.079178999978467,
+    "p95_ms": 39.7559950000982,
+    "p99_ms": 41.23654463994625,
+    "mean_ms": 24.933692524995195,
+    "recall_at1": 39.0,
+    "index_size": 10148
+  },
+  "quality_metrics": {
+    "sacrebleu": 7.735847412133685,
+    "sacrebleu_bp": 0.9908693410515427,
+    "rouge_l_f1": 18.76351967983033,
+    "bertscore_f1": 71.0391104221344,
+    "eos_rate": 88.61660079051383,
+    "length_ratio": 0.9868987365737294
+  },
+  "resource_usage": {
+    "model_vram_gb": 24.369140625,
+    "inference_vram_gb": 29.4111328125,
+    "total_vram_gb": 40.0,
+    "model_load_time_sec": 45.95156426599988,
+    "batch_inference_time_sec": 77.71261919800008
+  },
+  "generation_config": {
+    "max_new_tokens": 512,
+    "temperature": 0.0,
+    "top_p": 1.0,
+    "repetition_penalty": 1.1,
+    "max_model_len": 2048,
+    "gpu_memory_utilization": 0.6
+  }
+}


### PR DESCRIPTION
## 요약
M3 Phase vLLM + AWQ KPI 평가 결과 파일을 산출물 폴더에 추가

## 변경사항
- 파일 추가: `docs/outputs/kpi_evaluation/kpi_eval_awq_vllm_20260320_121929.json`
- 포함 정보:
  - 실험 환경 (GPU: A100, 시간: 2026-03-20 12:19:29)
  - 설정 (모델, 양자화, 생성 파라미터)
  - KPI 달성도 (AC-002 PASS, AC-003 PASS, VRAM 분석 필요)
  - 성능 메트릭 (레이턴시, 처리량, 품질, 리소스)

## 참고
- GitHub Issue #125: W&B Report 작성 계획
- 평가 노트북: `notebooks/M3_issue26/06_evaluate_awq_vllm_kpi.ipynb`
- KPI 기준: PRD v3.4