### PR TITLE
feat: 다중 인덱스 관리 및 메타데이터 스키마 확장 (M3 RAG Phase 1)

### DIFF
--- a/src/inference/index_manager.py
+++ b/src/inference/index_manager.py
@@ -8,7 +8,7 @@ MultiIndexManager: ADR-004 기반 다중 FAISS 인덱스 관리 모듈.
 import json
 import os
 from dataclasses import asdict, dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
@@ -56,8 +56,9 @@ class DocumentMetadata:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "DocumentMetadata":
         """딕셔너리에서 DocumentMetadata 인스턴스를 생성한다."""
-        known_fields = {f.name for f in cls.__dataclass_fields__.values()}
-        filtered = {k: v for k, v in data.items() if k in known_fields}
+        if not hasattr(cls, "_known_fields"):
+            cls._known_fields = {f.name for f in cls.__dataclass_fields__.values()}
+        filtered = {k: v for k, v in data.items() if k in cls._known_fields}
         return cls(**filtered)
 
 
@@ -127,7 +128,7 @@ class MultiIndexManager:
 
     def _save_registry(self) -> None:
         """index_registry.json 을 갱신한다."""
-        self._registry["updated_at"] = datetime.utcnow().isoformat()
+        self._registry["updated_at"] = datetime.now(timezone.utc).isoformat()
         with open(self._registry_path, "w", encoding="utf-8") as f:
             json.dump(self._registry, f, ensure_ascii=False, indent=2)
 
@@ -199,7 +200,7 @@ class MultiIndexManager:
         logger.info(f"메타데이터 저장: {meta_path}")
 
         # 레지스트리 갱신
-        now_iso = datetime.utcnow().isoformat()
+        now_iso = datetime.now(timezone.utc).isoformat()
         self._registry.setdefault("indexes", {})[index_type.value] = {
             "doc_count": self.indexes[index_type].ntotal,
             "index_class": type(self.indexes[index_type]).__name__,

--- a/src/inference/schemas.py
+++ b/src/inference/schemas.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 from typing import List, Optional, Dict, Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from src.inference.index_manager import IndexType
+from src.inference.index_manager import DocumentMetadata, IndexType
 
 class RetrievedCase(BaseModel):
     id: Optional[str] = None
@@ -58,11 +58,20 @@ class DocumentMetadataSchema(BaseModel):
     total_chunks: int = 1
     created_at: datetime
     updated_at: datetime
+    valid_from: Optional[datetime] = None
     valid_until: Optional[datetime] = None
     reliability_score: float = Field(default=1.0, ge=0.0, le=1.0)
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
     model_config = ConfigDict(from_attributes=True)
+
+    @model_validator(mode="after")
+    def _check_chunk_bounds(self) -> "DocumentMetadataSchema":
+        if self.chunk_index >= self.total_chunks:
+            raise ValueError(
+                f"chunk_index({self.chunk_index})는 total_chunks({self.total_chunks})보다 작아야 합니다"
+            )
+        return self
 
 
 class SearchResult(BaseModel):
@@ -77,7 +86,7 @@ class SearchResult(BaseModel):
     title: str
     content: str
     score: float
-    reliability_score: float = 1.0
+    reliability_score: float = Field(default=1.0, ge=0.0, le=1.0)
     metadata: Dict[str, Any] = Field(default_factory=dict)
     chunk_index: int = 0
     total_chunks: int = 1
@@ -89,7 +98,7 @@ class SearchResult(BaseModel):
 
 
 def from_internal_metadata(
-    meta: "index_manager.DocumentMetadata",
+    meta: "DocumentMetadata",
     content: str = "",
 ) -> DocumentMetadataSchema:
     """index_manager.DocumentMetadata (dataclass) -> DocumentMetadataSchema (Pydantic) 변환.
@@ -107,8 +116,6 @@ def from_internal_metadata(
     DocumentMetadataSchema
         Pydantic 모델 인스턴스.
     """
-    from src.inference.index_manager import DocumentMetadata as _DM  # noqa: F811
-
     return DocumentMetadataSchema(
         doc_id=meta.doc_id,
         source_type=IndexType(meta.doc_type),
@@ -119,6 +126,11 @@ def from_internal_metadata(
         total_chunks=meta.chunk_total,
         created_at=datetime.fromisoformat(meta.created_at),
         updated_at=datetime.fromisoformat(meta.updated_at),
+        valid_from=(
+            datetime.fromisoformat(meta.valid_from)
+            if meta.valid_from
+            else None
+        ),
         valid_until=(
             datetime.fromisoformat(meta.valid_until)
             if meta.valid_until

--- a/tests/test_inference/test_schemas.py
+++ b/tests/test_inference/test_schemas.py
@@ -87,6 +87,14 @@ class TestDocumentMetadataSchema:
         with pytest.raises(ValidationError):
             _make_metadata_schema(IndexType.CASE, reliability_score=-0.1)
 
+    def test_chunk_index_exceeds_total_raises(self):
+        """chunk_index >= total_chunks이면 ValidationError."""
+        with pytest.raises(ValidationError):
+            _make_metadata_schema(IndexType.CASE, chunk_index=5, total_chunks=3)
+
+        with pytest.raises(ValidationError):
+            _make_metadata_schema(IndexType.CASE, chunk_index=1, total_chunks=1)
+
     def test_default_values(self):
         """기본값 확인 (chunk_index=0, total_chunks=1, reliability_score=1.0)."""
         schema = _make_metadata_schema(IndexType.MANUAL)
@@ -94,6 +102,7 @@ class TestDocumentMetadataSchema:
         assert schema.total_chunks == 1
         assert schema.reliability_score == 1.0
         assert schema.metadata == {}
+        assert schema.valid_from is None
         assert schema.valid_until is None
 
 
@@ -118,6 +127,40 @@ class TestSearchResult:
         assert result.score == 0.95
         assert result.reliability_score == 1.0
         assert result.metadata == {}
+
+    def test_reliability_score_valid_range(self):
+        """SearchResult reliability_score 범위 검증 (0.0~1.0)."""
+        result = SearchResult(
+            doc_id="doc-001",
+            source_type=IndexType.NOTICE,
+            title="공시 정보",
+            content="공시 본문",
+            score=0.95,
+            reliability_score=0.0,
+        )
+        assert result.reliability_score == 0.0
+
+    def test_reliability_score_out_of_range_raises(self):
+        """SearchResult reliability_score 범위 밖 값은 ValidationError."""
+        with pytest.raises(ValidationError):
+            SearchResult(
+                doc_id="doc-001",
+                source_type=IndexType.NOTICE,
+                title="공시",
+                content="본문",
+                score=0.9,
+                reliability_score=1.5,
+            )
+
+        with pytest.raises(ValidationError):
+            SearchResult(
+                doc_id="doc-001",
+                source_type=IndexType.NOTICE,
+                title="공시",
+                content="본문",
+                score=0.9,
+                reliability_score=-0.1,
+            )
 
     def test_with_metadata(self):
         """metadata 필드에 임의 데이터 저장 확인."""
@@ -291,3 +334,40 @@ class TestFromInternalMetadata:
         )
         result = from_internal_metadata(internal)
         assert result.metadata == {}
+
+    def test_conversion_with_valid_from(self):
+        """valid_from이 있는 경우 변환 확인."""
+        valid_from_dt = datetime(2026, 1, 1, 0, 0, 0)
+        valid_until_dt = datetime(2027, 12, 31, 23, 59, 59)
+        internal = DocumentMetadata(
+            doc_id="doc-500",
+            doc_type="law",
+            source="법제처",
+            title="환경보전법",
+            category="법령",
+            reliability_score=1.0,
+            created_at=_NOW_ISO,
+            updated_at=_NOW_ISO,
+            valid_from=valid_from_dt.isoformat(),
+            valid_until=valid_until_dt.isoformat(),
+        )
+        result = from_internal_metadata(internal)
+
+        assert result.source_type == IndexType.LAW
+        assert result.valid_from == valid_from_dt
+        assert result.valid_until == valid_until_dt
+
+    def test_conversion_invalid_doc_type_raises(self):
+        """유효하지 않은 doc_type은 ValueError."""
+        internal = DocumentMetadata(
+            doc_id="doc-600",
+            doc_type="unknown",
+            source="테스트",
+            title="테스트",
+            category="테스트",
+            reliability_score=0.5,
+            created_at=_NOW_ISO,
+            updated_at=_NOW_ISO,
+        )
+        with pytest.raises(ValueError):
+            from_internal_metadata(internal)


### PR DESCRIPTION
## Summary

M3 고도화 단계 RAG Phase 1의 핵심 구현 2건을 포함합니다.

- **MultiIndexManager 클래스 구현** (Closes #150): 4종 FAISS 인덱스(CASE, LAW, MANUAL, NOTICE) 독립 관리, IVFFlat 자동 전환
- **DocumentMetadata 스키마 확장** (Closes #151): Pydantic v2 기반 통합 메타데이터 모델, SearchResult 확장, 하위 호환성 유지

## Changes

### #150 MultiIndexManager
- `src/inference/index_manager.py`: IndexType enum, DocumentMetadata dataclass, MultiIndexManager 클래스
- `tests/test_inference/test_index_manager.py`: 단위 테스트 25개

### #151 DocumentMetadata 스키마 확장
- `src/inference/schemas.py`: DocumentMetadataSchema, SearchResult, from_internal_metadata() 헬퍼
- `tests/test_inference/test_schemas.py`: 단위 테스트 23개 (기존 18 + 추가 5)

### 코드리뷰 반영 수정사항
- **valid_from 필드 추가**: DocumentMetadataSchema에 누락된 valid_from 필드 추가 및 변환 헬퍼 매핑
- **타입 어노테이션 수정**: from_internal_metadata 함수의 타입 힌트 오류 수정, 미사용 import 제거
- **검증 강화**: SearchResult.reliability_score 범위 검증(0.0~1.0), chunk_index/total_chunks 교차 검증 추가
- **성능 개선**: datetime.utcnow() deprecated 수정, from_dict 필드셋 클래스 레벨 캐싱

## Test plan

- [x] MultiIndexManager 단위 테스트 25개 통과
- [x] DocumentMetadata 스키마 테스트 23개 통과
- [x] 전체 48개 테스트 통과 확인
- [x] 기존 RetrievedCase/GenerateResponse 하위 호환성 검증
- [x] valid_from 변환 테스트 통과
- [x] 에러 케이스(잘못된 doc_type) 테스트 통과
- [x] SearchResult reliability_score 범위 검증 테스트 통과