### PR TITLE
feat: FAISS 벡터 검색 시스템 구축 및 API 통합

### DIFF
--- a/scripts/build_faiss_index.py
+++ b/scripts/build_faiss_index.py
@@ -1,0 +1,197 @@
+"""
+FAISS 인덱스 빌드 스크립트.
+
+EmbeddingPipeline으로 v2_train.jsonl 데이터를 임베딩하고,
+MultiIndexManager를 사용하여 CASE 타입 FAISS 인덱스를 빌드한다.
+
+사용 예시::
+
+    python scripts/build_faiss_index.py \\
+        --data-path data/processed/v2_train.jsonl \\
+        --index-dir models/faiss_index \\
+        --batch-size 64
+
+    # DB 적재 포함
+    python scripts/build_faiss_index.py --with-db
+"""
+
+import argparse
+import os
+import sys
+import time
+from datetime import datetime, timezone
+
+from loguru import logger
+
+# 프로젝트 루트를 sys.path에 추가
+_PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from src.data_collection_preprocessing.embedding import EmbeddingPipeline
+from src.inference.index_manager import IndexType, MultiIndexManager
+
+
+def parse_args() -> argparse.Namespace:
+    """CLI 인자를 파싱한다."""
+    parser = argparse.ArgumentParser(
+        description="FAISS 인덱스 빌드 스크립트 (CASE 타입)",
+    )
+    parser.add_argument(
+        "--data-path",
+        type=str,
+        default="data/processed/v2_train.jsonl",
+        help="JSONL 데이터 파일 경로 (기본: data/processed/v2_train.jsonl)",
+    )
+    parser.add_argument(
+        "--index-dir",
+        type=str,
+        default="models/faiss_index",
+        help="인덱스 저장 디렉토리 (기본: models/faiss_index)",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=64,
+        help="임베딩 배치 크기 (기본: 64)",
+    )
+    parser.add_argument(
+        "--model-name",
+        type=str,
+        default="intfloat/multilingual-e5-large",
+        help="SentenceTransformer 모델명 (기본: intfloat/multilingual-e5-large)",
+    )
+    parser.add_argument(
+        "--with-db",
+        action="store_true",
+        default=False,
+        help="DB 적재 수행 여부 (document_source, index_version 테이블)",
+    )
+    return parser.parse_args()
+
+
+def save_to_db(metadata_list, index_dir: str, total_documents: int, build_duration: float) -> None:
+    """빌드 결과를 DB에 적재한다 (document_source + index_version)."""
+    from src.inference.db.converters import dataclass_to_orm
+    from src.inference.db.crud import (
+        create_document_source,
+        create_index_version,
+        deactivate_versions,
+    )
+    from src.inference.db.database import SessionLocal
+
+    # Phase 1: document_source 적재
+    db = SessionLocal()
+    try:
+        logger.info(f"document_source 적재 시작: {len(metadata_list)}건")
+        for i, meta in enumerate(metadata_list):
+            content = meta.extras.get("complaint_text", "") if meta.extras else ""
+            kwargs = dataclass_to_orm(meta, content)
+            try:
+                create_document_source(db, **kwargs)
+            except Exception as e:
+                db.rollback()
+                logger.warning(f"document_source 적재 실패 (건너뜀): {meta.doc_id}: {e}")
+                continue
+            if (i + 1) % 1000 == 0:
+                db.commit()
+                logger.info(f"  {i + 1}/{len(metadata_list)}건 커밋 완료")
+        db.commit()
+        logger.info(f"document_source 적재 완료")
+    except Exception as e:
+        db.rollback()
+        logger.error(f"document_source 적재 중 오류: {e}")
+    finally:
+        db.close()
+
+    # Phase 2: index_version 등록 (원자적)
+    db = SessionLocal()
+    try:
+        deactivate_versions(db, "case")
+        index_file_path = os.path.join(index_dir, "case", "index.faiss")
+        meta_file_path = os.path.join(index_dir, "case", "metadata.json")
+        version_str = datetime.now(timezone.utc).strftime("v%Y%m%d_%H%M%S")
+        create_index_version(
+            db,
+            index_type="case",
+            version=version_str,
+            total_documents=total_documents,
+            index_file_path=index_file_path,
+            meta_file_path=meta_file_path,
+            build_duration_seconds=build_duration,
+            is_active=True,
+            notes=f"build_faiss_index.py로 빌드 (문서 {total_documents}건)",
+        )
+        db.commit()
+        logger.info(f"index_version 등록 완료: {version_str}")
+    except Exception as e:
+        db.rollback()
+        logger.error(f"index_version 등록 실패: {e}")
+        raise
+    finally:
+        db.close()
+
+
+def main() -> None:
+    """메인 엔트리포인트."""
+    args = parse_args()
+
+    logger.info("=" * 60)
+    logger.info("FAISS 인덱스 빌드 시작")
+    logger.info(f"  데이터 경로: {args.data_path}")
+    logger.info(f"  인덱스 디렉토리: {args.index_dir}")
+    logger.info(f"  배치 크기: {args.batch_size}")
+    logger.info(f"  모델: {args.model_name}")
+    logger.info(f"  DB 적재: {args.with_db}")
+    logger.info("=" * 60)
+
+    start_time = time.time()
+
+    # 1) 데이터 파일 존재 확인
+    if not os.path.exists(args.data_path):
+        logger.error(f"데이터 파일이 존재하지 않습니다: {args.data_path}")
+        sys.exit(1)
+
+    # 2) 임베딩 파이프라인 실행
+    pipeline = EmbeddingPipeline(model_name=args.model_name)
+    embeddings, metadata_list = pipeline.process_jsonl(
+        args.data_path, batch_size=args.batch_size
+    )
+
+    # 3) MultiIndexManager로 인덱스 빌드
+    logger.info("FAISS 인덱스 빌드 시작")
+    manager = MultiIndexManager(base_dir=args.index_dir, embedding_dim=pipeline.embedding_dim)
+    manager.add_documents(IndexType.CASE, embeddings, metadata_list)
+    manager.save_index(IndexType.CASE)
+
+    build_duration = time.time() - start_time
+
+    # 4) 결과 요약
+    stats = manager.get_index_stats()
+    case_stats = stats["indexes"]["case"]
+    logger.info("=" * 60)
+    logger.info("빌드 완료 요약")
+    logger.info(f"  총 문서 수: {case_stats['doc_count']}")
+    logger.info(f"  메타데이터 수: {case_stats['metadata_count']}")
+    logger.info(f"  인덱스 타입: {case_stats['index_class']}")
+    logger.info(f"  임베딩 차원: {stats['embedding_dim']}")
+    logger.info(f"  소요 시간: {build_duration:.1f}초")
+    logger.info(f"  저장 경로: {args.index_dir}/case/")
+    logger.info("=" * 60)
+
+    # 5) DB 적재 (선택)
+    if args.with_db:
+        logger.info("DB 적재 시작")
+        save_to_db(
+            metadata_list,
+            index_dir=args.index_dir,
+            total_documents=case_stats["doc_count"],
+            build_duration=build_duration,
+        )
+        logger.info("DB 적재 완료")
+
+    logger.info("모든 작업 완료")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/evaluate_search.py
+++ b/scripts/evaluate_search.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""
+FAISS 벡터 검색 시스템 평가 스크립트 (self-retrieval 테스트).
+
+카테고리별 균등 샘플링으로 평가 데이터셋을 구성하고,
+Recall@5, Recall@10, MRR, 검색 레이턴시(p50/p95/p99)를 측정한다.
+
+주의: --eval-jsonl 옵션을 지정하지 않으면 인덱스 빌드에 사용된 동일 데이터로
+평가를 수행하는 self-retrieval 테스트가 된다. 이 경우 Recall이 인위적으로
+높게 측정될 수 있으므로, 실제 검색 품질 평가 시에는 --eval-jsonl로 별도의
+평가용 데이터를 지정해야 한다.
+
+Usage:
+    # self-retrieval 테스트 (인덱스 빌드 데이터와 동일)
+    python scripts/evaluate_search.py \\
+        --jsonl data/processed/v2_train.jsonl \\
+        --index-dir models/faiss_index \\
+        --samples-per-category 20 \\
+        --top-k 10
+
+    # 별도 평가 데이터 사용
+    python scripts/evaluate_search.py \\
+        --jsonl data/processed/v2_train.jsonl \\
+        --eval-jsonl data/processed/v2_eval.jsonl \\
+        --index-dir models/faiss_index
+"""
+
+import argparse
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List
+
+import numpy as np
+from loguru import logger
+
+# 프로젝트 루트를 sys.path에 추가
+PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.data_collection_preprocessing.embedding import EmbeddingPipeline
+from src.inference.index_manager import IndexType, MultiIndexManager
+
+
+# ---------------------------------------------------------------------------
+# 평가 데이터셋 구성
+# ---------------------------------------------------------------------------
+
+
+def build_eval_dataset(
+    records: List[Dict],
+    samples_per_category: int,
+    seed: int = 42,
+) -> List[Dict]:
+    """카테고리별 균등 샘플링으로 평가 데이터셋을 구성한다.
+
+    Parameters
+    ----------
+    records : List[Dict]
+        EmbeddingPipeline.load_jsonl()로 읽은 레코드 리스트.
+    samples_per_category : int
+        카테고리당 최대 샘플 수.
+    seed : int
+        난수 시드.
+
+    Returns
+    -------
+    List[Dict]
+        균등 샘플링된 평가 레코드 리스트.
+    """
+    rng = np.random.default_rng(seed)
+
+    by_category: Dict[str, List[Dict]] = defaultdict(list)
+    for record in records:
+        cat = record.get("category", "unknown") or "unknown"
+        by_category[cat].append(record)
+
+    eval_samples: List[Dict] = []
+    for cat, cat_records in sorted(by_category.items()):
+        n = min(samples_per_category, len(cat_records))
+        indices = rng.choice(len(cat_records), size=n, replace=False)
+        for idx in indices:
+            eval_samples.append(cat_records[idx])
+
+    logger.info(
+        f"평가 데이터셋 구성 완료: {len(by_category)}개 카테고리, "
+        f"총 {len(eval_samples)}개 샘플 (카테고리당 최대 {samples_per_category}개)"
+    )
+    for cat, cat_records in sorted(by_category.items()):
+        n = min(samples_per_category, len(cat_records))
+        logger.info(f"  - {cat}: {n}/{len(cat_records)}건 샘플링")
+
+    return eval_samples
+
+
+# ---------------------------------------------------------------------------
+# 검색 평가
+# ---------------------------------------------------------------------------
+
+
+def evaluate_search(
+    eval_samples: List[Dict],
+    manager: MultiIndexManager,
+    pipeline: EmbeddingPipeline,
+    index_type: IndexType,
+    top_k: int = 10,
+) -> Dict:
+    """검색 성능을 평가한다.
+
+    Parameters
+    ----------
+    eval_samples : List[Dict]
+        평가 샘플 리스트 (각 딕셔너리에 'id', 'complaint_text' 키 필요).
+    manager : MultiIndexManager
+        로드된 FAISS 인덱스 매니저.
+    pipeline : EmbeddingPipeline
+        쿼리 임베딩용 파이프라인.
+    index_type : IndexType
+        검색 대상 인덱스 타입.
+    top_k : int
+        최대 검색 결과 수.
+
+    Returns
+    -------
+    Dict
+        평가 결과 딕셔너리 (recall@5, recall@10, mrr, latency 등).
+    """
+    hits_at_5 = 0
+    hits_at_10 = 0
+    reciprocal_ranks: List[float] = []
+    latencies: List[float] = []
+
+    total = len(eval_samples)
+    logger.info(f"검색 평가 시작: {total}개 샘플, top_k={top_k}")
+
+    for i, sample in enumerate(eval_samples):
+        query_text = sample["complaint_text"]
+        expected_doc_id = sample["id"]
+
+        # 쿼리 임베딩 (E5 모델: "query: " prefix 적용)
+        t_start = time.perf_counter()
+        query_vec = pipeline.embed_query(query_text)
+
+        # FAISS 검색
+        results = manager.search(index_type, query_vec, top_k=top_k)
+        t_end = time.perf_counter()
+
+        latency_ms = (t_end - t_start) * 1000
+        latencies.append(latency_ms)
+
+        # 결과에서 doc_id 추출
+        result_doc_ids = [r["doc_id"] for r in results]
+
+        # Recall@5 체크
+        if expected_doc_id in result_doc_ids[:5]:
+            hits_at_5 += 1
+
+        # Recall@10 체크
+        if expected_doc_id in result_doc_ids[:10]:
+            hits_at_10 += 1
+
+        # MRR 계산
+        rank = None
+        for j, doc_id in enumerate(result_doc_ids):
+            if doc_id == expected_doc_id:
+                rank = j + 1
+                break
+        reciprocal_ranks.append(1.0 / rank if rank else 0.0)
+
+        if (i + 1) % 50 == 0 or (i + 1) == total:
+            logger.info(f"  진행: {i + 1}/{total}")
+
+    # 지표 계산
+    recall_at_5 = hits_at_5 / total if total > 0 else 0.0
+    recall_at_10 = hits_at_10 / total if total > 0 else 0.0
+    mrr = float(np.mean(reciprocal_ranks)) if reciprocal_ranks else 0.0
+
+    latency_arr = np.array(latencies)
+    p50 = float(np.percentile(latency_arr, 50)) if latencies else 0.0
+    p95 = float(np.percentile(latency_arr, 95)) if latencies else 0.0
+    p99 = float(np.percentile(latency_arr, 99)) if latencies else 0.0
+
+    return {
+        "total_samples": total,
+        "recall_at_5": recall_at_5,
+        "recall_at_10": recall_at_10,
+        "mrr": mrr,
+        "hits_at_5": hits_at_5,
+        "hits_at_10": hits_at_10,
+        "latency_p50_ms": p50,
+        "latency_p95_ms": p95,
+        "latency_p99_ms": p99,
+        "latency_mean_ms": float(np.mean(latency_arr)) if latencies else 0.0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 결과 출력
+# ---------------------------------------------------------------------------
+
+
+def print_results(results: Dict, top_k: int) -> None:
+    """평가 결과를 보기 좋게 출력한다."""
+    divider = "=" * 60
+    print(f"\n{divider}")
+    print("  FAISS 벡터 검색 시스템 평가 결과")
+    print(divider)
+
+    print(f"\n  평가 샘플 수:  {results['total_samples']}")
+    print(f"  검색 Top-K:    {top_k}")
+
+    print(f"\n{'─' * 60}")
+    print("  [정량 지표]")
+    print(f"{'─' * 60}")
+
+    recall5 = results["recall_at_5"] * 100
+    recall10 = results["recall_at_10"] * 100
+    mrr = results["mrr"]
+
+    status_5 = "PASS" if recall5 >= 80.0 else "FAIL"
+    print(f"  Recall@5:   {recall5:6.2f}%  ({results['hits_at_5']}/{results['total_samples']})  [{status_5}]")
+    print(f"  Recall@10:  {recall10:6.2f}%  ({results['hits_at_10']}/{results['total_samples']})")
+    print(f"  MRR:        {mrr:6.4f}")
+
+    print(f"\n{'─' * 60}")
+    print("  [검색 레이턴시]")
+    print(f"{'─' * 60}")
+    print(f"  p50:   {results['latency_p50_ms']:8.2f} ms")
+    print(f"  p95:   {results['latency_p95_ms']:8.2f} ms")
+    print(f"  p99:   {results['latency_p99_ms']:8.2f} ms")
+    print(f"  mean:  {results['latency_mean_ms']:8.2f} ms")
+
+    print(f"\n{divider}")
+    if recall5 >= 80.0:
+        print("  >>> Recall@5 >= 80% 목표 달성!")
+    else:
+        print(f"  >>> Recall@5 목표 미달 (현재: {recall5:.2f}%, 목표: 80%)")
+    print(f"{divider}\n")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="FAISS 벡터 검색 시스템 Recall@K / MRR / 레이턴시 평가",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--jsonl",
+        type=str,
+        default="data/processed/v2_train.jsonl",
+        help="평가에 사용할 JSONL 파일 경로 (기본: data/processed/v2_train.jsonl)",
+    )
+    parser.add_argument(
+        "--index-dir",
+        type=str,
+        default="models/faiss_index",
+        help="FAISS 인덱스 디렉토리 (기본: models/faiss_index)",
+    )
+    parser.add_argument(
+        "--model-name",
+        type=str,
+        default="intfloat/multilingual-e5-large",
+        help="임베딩 모델 이름 (기본: intfloat/multilingual-e5-large)",
+    )
+    parser.add_argument(
+        "--samples-per-category",
+        type=int,
+        default=20,
+        help="카테고리당 평가 샘플 수 (기본: 20)",
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=10,
+        help="검색 Top-K (기본: 10)",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="난수 시드 (기본: 42)",
+    )
+    parser.add_argument(
+        "--eval-jsonl",
+        type=str,
+        default=None,
+        help="별도 평가용 JSONL 파일 경로 (미지정 시 --jsonl과 동일 파일 사용, self-retrieval 테스트)",
+    )
+    parser.add_argument(
+        "--build-index",
+        action="store_true",
+        help="인덱스가 없으면 JSONL로부터 인덱스를 새로 구축",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    # 1. 임베딩 파이프라인 초기화
+    logger.info("임베딩 파이프라인 초기화 중...")
+    pipeline = EmbeddingPipeline(model_name=args.model_name)
+
+    # 2. 평가용 JSONL 로드
+    eval_jsonl = args.eval_jsonl or args.jsonl
+    if args.eval_jsonl:
+        logger.info(f"별도 평가 데이터 사용: {eval_jsonl}")
+    else:
+        logger.info(f"self-retrieval 테스트 (인덱스 빌드 데이터와 동일): {eval_jsonl}")
+    records = pipeline.load_jsonl(eval_jsonl)
+    if not records:
+        logger.error("유효한 레코드가 없습니다. 종료합니다.")
+        sys.exit(1)
+
+    # 3. 인덱스 매니저 초기화 및 인덱스 로드/구축
+    logger.info(f"인덱스 매니저 초기화: {args.index_dir}")
+    manager = MultiIndexManager(base_dir=args.index_dir, embedding_dim=pipeline.embedding_dim)
+
+    index_type = IndexType.CASE
+    stats = manager.get_index_stats()
+    case_stats = stats["indexes"].get(index_type.value, {})
+    doc_count = case_stats.get("doc_count", 0)
+
+    if doc_count == 0 and args.build_index:
+        logger.info("인덱스가 비어있어 새로 구축합니다...")
+        embeddings, metadata_list = pipeline.process_jsonl(args.jsonl)
+        manager.add_documents(index_type, embeddings, metadata_list)
+        manager.save_index(index_type)
+        logger.info(f"인덱스 구축 완료: {manager.indexes[index_type].ntotal}건")
+    elif doc_count == 0:
+        logger.error(
+            "인덱스가 비어있습니다. --build-index 옵션으로 인덱스를 먼저 구축하세요."
+        )
+        sys.exit(1)
+    else:
+        logger.info(f"기존 인덱스 로드 완료: {doc_count}건")
+
+    # 4. 평가 데이터셋 구성
+    eval_samples = build_eval_dataset(
+        records,
+        samples_per_category=args.samples_per_category,
+        seed=args.seed,
+    )
+
+    # 5. 검색 평가 수행
+    results = evaluate_search(
+        eval_samples=eval_samples,
+        manager=manager,
+        pipeline=pipeline,
+        index_type=index_type,
+        top_k=args.top_k,
+    )
+
+    # 6. 결과 출력
+    print_results(results, top_k=args.top_k)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data_collection_preprocessing/embedding.py
+++ b/src/data_collection_preprocessing/embedding.py
@@ -1,0 +1,259 @@
+"""
+임베딩 파이프라인: intfloat/multilingual-e5-large 기반 JSONL 데이터 임베딩 변환.
+
+JSONL 데이터를 읽어 민원 텍스트를 파싱하고, E5 모델로 임베딩 벡터를 생성한다.
+passage: prefix를 적용하여 cosine similarity 검색에 최적화된 정규화 벡터를 반환한다.
+"""
+
+import json
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+from loguru import logger
+from sentence_transformers import SentenceTransformer
+
+from src.inference.index_manager import DocumentMetadata
+
+
+class EmbeddingPipeline:
+    """intfloat/multilingual-e5-large 기반 임베딩 파이프라인.
+
+    Parameters
+    ----------
+    model_name : str
+        SentenceTransformer 모델 이름. 기본: intfloat/multilingual-e5-large (1024차원).
+    device : str, optional
+        추론에 사용할 디바이스. None이면 자동 감지.
+    """
+
+    def __init__(
+        self,
+        model_name: str = "intfloat/multilingual-e5-large",
+        device: Optional[str] = None,
+    ) -> None:
+        self.model_name = model_name
+        logger.info(f"SentenceTransformer 모델 로딩 시작: {model_name}")
+        self.model = SentenceTransformer(model_name, device=device)
+        self.embedding_dim = self.model.get_sentence_embedding_dimension()
+        logger.info(
+            f"모델 로딩 완료: dim={self.embedding_dim}, "
+            f"device={self.model.device}"
+        )
+
+    # ------------------------------------------------------------------
+    # 텍스트 파싱
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _parse_complaint_text(text: str) -> Optional[str]:
+        """[|user|] ... [|endofturn|] 구간에서 '민원 내용:' 이후 텍스트를 추출한다."""
+        user_match = re.search(
+            r"\[\|user\|\](.*?)\[\|endofturn\|\]", text, re.DOTALL
+        )
+        if not user_match:
+            return None
+
+        user_block = user_match.group(1)
+        complaint_match = re.search(r"민원\s*내용\s*:\s*(.+)", user_block, re.DOTALL)
+        if complaint_match:
+            return complaint_match.group(1).strip()
+
+        return None
+
+    @staticmethod
+    def _parse_answer_text(text: str) -> Optional[str]:
+        """[|assistant|] ... [|endofturn|] 구간에서 답변 텍스트를 추출한다."""
+        assistant_match = re.search(
+            r"\[\|assistant\|\](.*?)\[\|endofturn\|\]", text, re.DOTALL
+        )
+        if not assistant_match:
+            return None
+        return assistant_match.group(1).strip()
+
+    @staticmethod
+    def _parse_category_from_text(text: str) -> Optional[str]:
+        """[카테고리: ...] 패턴에서 카테고리를 추출한다."""
+        cat_match = re.search(r"\[카테고리:\s*(.+?)\]", text)
+        if cat_match:
+            return cat_match.group(1).strip()
+        return None
+
+    # ------------------------------------------------------------------
+    # JSONL 로드
+    # ------------------------------------------------------------------
+
+    def load_jsonl(self, jsonl_path: str) -> List[Dict[str, Any]]:
+        """JSONL 파일을 로드하고 민원/답변 텍스트를 파싱한다.
+
+        Parameters
+        ----------
+        jsonl_path : str
+            JSONL 파일 경로.
+
+        Returns
+        -------
+        List[Dict[str, Any]]
+            파싱된 레코드 리스트. 각 딕셔너리에 'complaint_text', 'answer_text',
+            'category', 'id' 키가 포함된다.
+        """
+        records: List[Dict[str, Any]] = []
+        skipped = 0
+
+        with open(jsonl_path, "r", encoding="utf-8") as f:
+            for line_num, line in enumerate(f, 1):
+                line = line.strip()
+                if not line:
+                    continue
+
+                try:
+                    data = json.loads(line)
+                except json.JSONDecodeError as e:
+                    logger.warning(f"JSON 파싱 실패 (line {line_num}): {e}")
+                    skipped += 1
+                    continue
+
+                text = data.get("text", "")
+                complaint_text = self._parse_complaint_text(text)
+                answer_text = self._parse_answer_text(text)
+
+                if not complaint_text:
+                    logger.warning(
+                        f"민원 텍스트 파싱 실패 (line {line_num}, "
+                        f"id={data.get('id', 'unknown')})"
+                    )
+                    skipped += 1
+                    continue
+
+                # 카테고리: JSONL의 category 필드 우선, 없으면 텍스트에서 파싱
+                category = data.get("category") or self._parse_category_from_text(text) or ""
+
+                records.append({
+                    "id": data.get("id", f"unknown_{line_num}"),
+                    "complaint_text": complaint_text,
+                    "answer_text": answer_text or "",
+                    "category": category,
+                })
+
+        logger.info(
+            f"JSONL 로드 완료: 총 {len(records) + skipped}건 중 "
+            f"{len(records)}건 성공, {skipped}건 스킵"
+        )
+        return records
+
+    # ------------------------------------------------------------------
+    # 임베딩 생성
+    # ------------------------------------------------------------------
+
+    def embed_documents(
+        self,
+        texts: List[str],
+        batch_size: int = 64,
+    ) -> np.ndarray:
+        """텍스트 리스트를 임베딩 벡터로 변환한다.
+
+        E5 모델 요구사항에 따라 'passage: ' prefix를 적용한다.
+
+        Parameters
+        ----------
+        texts : List[str]
+            임베딩할 텍스트 리스트.
+        batch_size : int
+            배치 크기.
+
+        Returns
+        -------
+        np.ndarray
+            정규화된 임베딩 벡터 배열 (shape: ``(n, dim)``).
+        """
+        if not texts:
+            return np.empty((0, self.embedding_dim), dtype=np.float32)
+
+        # E5 모델은 passage: prefix를 요구한다
+        prefixed_texts = [f"passage: {t}" for t in texts]
+
+        logger.info(
+            f"임베딩 생성 시작: {len(texts)}건, batch_size={batch_size}"
+        )
+
+        embeddings = self.model.encode(
+            prefixed_texts,
+            batch_size=batch_size,
+            show_progress_bar=True,
+            normalize_embeddings=True,
+        )
+
+        embeddings = np.asarray(embeddings, dtype=np.float32)
+        logger.info(
+            f"임베딩 생성 완료: shape={embeddings.shape}"
+        )
+        return embeddings
+
+    def embed_query(self, query: str) -> np.ndarray:
+        """쿼리 텍스트를 임베딩 벡터로 변환한다. E5 모델의 'query: ' prefix 적용."""
+        embedding = self.model.encode(
+            [f"query: {query}"],
+            normalize_embeddings=True,
+        )
+        return np.asarray(embedding, dtype=np.float32)
+
+    # ------------------------------------------------------------------
+    # 전체 파이프라인
+    # ------------------------------------------------------------------
+
+    def process_jsonl(
+        self,
+        jsonl_path: str,
+        batch_size: int = 64,
+    ) -> Tuple[np.ndarray, List[DocumentMetadata]]:
+        """JSONL 파일을 읽어 임베딩 벡터와 DocumentMetadata 리스트로 변환한다.
+
+        Parameters
+        ----------
+        jsonl_path : str
+            JSONL 파일 경로.
+        batch_size : int
+            임베딩 배치 크기.
+
+        Returns
+        -------
+        Tuple[np.ndarray, List[DocumentMetadata]]
+            (임베딩 벡터 배열, DocumentMetadata 리스트).
+        """
+        records = self.load_jsonl(jsonl_path)
+        if not records:
+            raise ValueError(f"유효한 레코드가 없습니다: {jsonl_path}")
+
+        # 민원 텍스트로 임베딩 생성
+        texts = [r["complaint_text"] for r in records]
+        embeddings = self.embed_documents(texts, batch_size=batch_size)
+
+        # DocumentMetadata 생성
+        now_iso = datetime.now(timezone.utc).isoformat()
+        metadata_list: List[DocumentMetadata] = []
+
+        for record in records:
+            meta = DocumentMetadata(
+                doc_id=record["id"],
+                doc_type="case",
+                source="AI Hub",
+                title=f"[{record['category']}] 민원 사례",
+                category=record["category"],
+                reliability_score=0.6,
+                created_at=now_iso,
+                updated_at=now_iso,
+                chunk_index=0,
+                chunk_total=1,
+                extras={
+                    "complaint_text": record["complaint_text"],
+                    "answer_text": record["answer_text"],
+                },
+            )
+            metadata_list.append(meta)
+
+        logger.info(
+            f"파이프라인 완료: {len(metadata_list)}건 처리, "
+            f"벡터 shape={embeddings.shape}"
+        )
+        return embeddings, metadata_list

--- a/src/inference/api_server.py
+++ b/src/inference/api_server.py
@@ -1,17 +1,56 @@
 import json
-import uuid
 import os
+import re
+import uuid
 from typing import AsyncGenerator, List
-from fastapi import FastAPI, Request, HTTPException
+
+from fastapi import Depends, FastAPI, HTTPException, Request, Security
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
+from fastapi.security import APIKeyHeader
+from loguru import logger
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine
 from vllm.sampling_params import SamplingParams
 from contextlib import asynccontextmanager
 
 from .vllm_stabilizer import apply_transformers_patch
-from .schemas import GenerateRequest, GenerateResponse, StreamResponse, RetrievedCase
+from .schemas import (
+    GenerateRequest,
+    GenerateResponse,
+    SearchRequest,
+    SearchResponse,
+    SearchResult,
+    StreamResponse,
+    RetrievedCase,
+)
 from .retriever import CivilComplaintRetriever
+
+# --- Rate Limiting (optional) ---
+try:
+    from slowapi import Limiter
+    from slowapi.util import get_remote_address
+    from slowapi.errors import RateLimitExceeded
+    from slowapi.middleware import SlowAPIMiddleware
+
+    limiter = Limiter(key_func=get_remote_address)
+    _RATE_LIMIT_AVAILABLE = True
+except ImportError:
+    limiter = None
+    _RATE_LIMIT_AVAILABLE = False
+
+# --- API Key Authentication ---
+_API_KEY = os.getenv("API_KEY")
+_api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+
+async def verify_api_key(api_key: str = Security(_api_key_header)):
+    """API Key 인증. API_KEY 환경변수 미설정 시 인증을 건너뛴다."""
+    if _API_KEY is None:
+        return  # API_KEY 미설정 시 인증 건너뜀 (개발 환경 호환)
+    if api_key != _API_KEY:
+        raise HTTPException(status_code=401, detail="유효하지 않은 API 키입니다.")
+
 
 # --- M3 Optimized Configuration ---
 MODEL_PATH = os.getenv("MODEL_PATH", "umyunsang/GovOn-EXAONE-LoRA-v2")
@@ -26,16 +65,15 @@ TRUST_REMOTE_CODE = True
 # Apply EXAONE-specific runtime patches
 apply_transformers_patch()
 
+
 class vLLMEngineManager:
     """Manages the global AsyncLLMEngine and Retriever lifecycle for M3 Phase."""
     def __init__(self):
         self.engine: AsyncLLMEngine = None
         self.retriever: CivilComplaintRetriever = None
+        self.index_manager = None
 
     async def initialize(self):
-        # Resolve paths relative to project root if necessary
-        # Assuming the server is run from the project root
-        
         # 1. Initialize Optimized vLLM Engine
         engine_args = AsyncEngineArgs(
             model=MODEL_PATH,
@@ -43,13 +81,13 @@ class vLLMEngineManager:
             gpu_memory_utilization=GPU_UTILIZATION,
             max_model_len=MAX_MODEL_LEN,
             dtype="half",
-            enforce_eager=True # More stable for patched EXAONE
+            enforce_eager=True  # More stable for patched EXAONE
         )
-        print(f"Initializing vLLM M3 engine with model: {MODEL_PATH}")
+        logger.info(f"Initializing vLLM M3 engine with model: {MODEL_PATH}")
         self.engine = AsyncLLMEngine.from_engine_args(engine_args)
-        
+
         # 2. Initialize RAG Retriever
-        print(f"Initializing RAG Retriever with index: {INDEX_PATH}")
+        logger.info(f"Initializing RAG Retriever with index: {INDEX_PATH}")
         self.retriever = CivilComplaintRetriever(
             index_path=INDEX_PATH if os.path.exists(INDEX_PATH) else None,
             data_path=DATA_PATH if not os.path.exists(INDEX_PATH) else None
@@ -61,40 +99,47 @@ class vLLMEngineManager:
         """Escape EXAONE chat template tokens to prevent prompt injection."""
         tokens = ["[|user|]", "[|assistant|]", "[|system|]", "[|endofturn|]", "<thought>", "</thought>"]
         for token in tokens:
-            text = text.replace(token, token.replace("[", "\[").replace("]", "\]").replace("<", "\<").replace(">", "\>"))
+            text = text.replace(token, token.replace("[", "\\[").replace("]", "\\]").replace("<", "\\<").replace(">", "\\>"))
         return text
 
     def _augment_prompt(self, prompt: str, retrieved_cases: List[dict]) -> str:
         """Augment the prompt with retrieved similar cases (RAG)."""
         if not retrieved_cases:
             return prompt
-            
+
         rag_context = "\n\n### 참고 사례 (유사 민원 및 답변):\n"
         for i, case in enumerate(retrieved_cases):
-            # Escape retrieved content to prevent prompt injection
-            safe_complaint = self._escape_special_tokens(case['complaint'])
-            safe_answer = self._escape_special_tokens(case['answer'])
+            # M-2: .get() 사용으로 KeyError 방지
+            safe_complaint = self._escape_special_tokens(case.get('complaint', ''))
+            safe_answer = self._escape_special_tokens(case.get('answer', ''))
             rag_context += f"{i+1}. [민원]: {safe_complaint}\n   [답변]: {safe_answer}\n\n"
-        
+
         # Structure the prompt for EXAONE Chat Template
         if "[|user|]" in prompt:
             parts = prompt.split("[|user|]")
             return f"{parts[0]}[|user|]{rag_context}위 참고 사례를 바탕으로 다음 민원에 대해 답변해 주세요.\n\n{parts[1]}"
         return f"{rag_context}\n\n{prompt}"
 
+    def _extract_query(self, prompt: str) -> str:
+        """m-5: 정규식 기반 쿼리 추출."""
+        user_match = re.search(r"\[\|user\|\](.*?)\[\|endofturn\|\]", prompt, re.DOTALL)
+        if user_match:
+            user_block = user_match.group(1)
+            complaint_match = re.search(r"민원\s*내용\s*:\s*(.+)", user_block, re.DOTALL)
+            if complaint_match:
+                return complaint_match.group(1).strip()
+            return user_block.strip()
+        return prompt
+
     async def generate(self, request: GenerateRequest, request_id: str) -> tuple:
         # 1. RAG: Retrieve similar cases if enabled
         retrieved_cases = []
         augmented_prompt = request.prompt
-        
+
         if request.use_rag and self.retriever:
-            # Simple query extraction
-            query = request.prompt
-            if "민원 내용:" in query:
-                query = query.split("민원 내용:")[1].split("[|endofturn|]")[0].strip()
-            elif "[|user|]" in query:
-                query = query.split("[|user|]")[1].split("[|endofturn|]")[0].strip()
-                
+            # M-4: 사용자 입력에도 escape 적용
+            query = self._escape_special_tokens(self._extract_query(request.prompt))
+
             retrieved_cases = self.retriever.search(query, top_k=3)
             augmented_prompt = self._augment_prompt(request.prompt, retrieved_cases)
 
@@ -104,12 +149,13 @@ class vLLMEngineManager:
             top_p=request.top_p,
             max_tokens=request.max_tokens,
             stop=request.stop,
-            repetition_penalty=1.1 # Added for EXAONE stability
+            repetition_penalty=1.1  # Added for EXAONE stability
         )
-        
+
         return self.engine.generate(augmented_prompt, sampling_params, request_id), retrieved_cases
 
 manager = vLLMEngineManager()
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -123,23 +169,68 @@ app = FastAPI(
     lifespan=lifespan
 )
 
+# --- m-6: CORS 미들웨어 ---
+ALLOWED_ORIGINS = os.getenv("CORS_ORIGINS", "").split(",")
+if ALLOWED_ORIGINS and ALLOWED_ORIGINS[0]:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=ALLOWED_ORIGINS,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+# --- C-2: Rate Limiting 미들웨어 ---
+if _RATE_LIMIT_AVAILABLE and limiter is not None:
+    app.state.limiter = limiter
+    app.add_middleware(SlowAPIMiddleware)
+
+
+# --- H-1: /health 정보 노출 최소화 ---
 @app.get("/health")
 async def health():
-    return {"status": "healthy", "model": MODEL_PATH, "rag_enabled": manager.retriever is not None}
+    index_summary = None
+    if manager.index_manager:
+        stats = manager.index_manager.get_index_stats()
+        index_summary = {
+            idx_type: {
+                "loaded": info.get("loaded", False),
+                "doc_count": info.get("doc_count", 0),
+            }
+            for idx_type, info in stats.get("indexes", {}).items()
+        }
+    return {
+        "status": "healthy",
+        "rag_enabled": manager.index_manager is not None or manager.retriever is not None,
+        "indexes": index_summary,
+    }
+
+
+# --- C-2: Rate limit decorator helper ---
+def _rate_limit(limit_string: str):
+    """slowapi가 사용 가능할 때만 rate limit 데코레이터를 반환한다."""
+    if _RATE_LIMIT_AVAILABLE and limiter is not None:
+        return limiter.limit(limit_string)
+    # slowapi 미설치 시 아무 동작도 하지 않는 패스스루 데코레이터
+    def _noop(func):
+        return func
+    return _noop
+
 
 @app.post("/v1/generate", response_model=GenerateResponse)
-async def generate(request: GenerateRequest):
+@_rate_limit("30/minute")
+async def generate(request: GenerateRequest, _: None = Depends(verify_api_key)):
     """Non-streaming text generation."""
     if request.stream:
         raise HTTPException(status_code=400, detail="Use /v1/stream for streaming.")
-    
+
     request_id = str(uuid.uuid4())
     results_generator, retrieved_cases = await manager.generate(request, request_id)
-    
+
     final_output = None
     async for request_output in results_generator:
         final_output = request_output
-    
+
     if final_output is None:
         raise HTTPException(status_code=500, detail="Generation failed.")
 
@@ -151,33 +242,78 @@ async def generate(request: GenerateRequest):
         retrieved_cases=[RetrievedCase(**c) for c in retrieved_cases]
     )
 
+
 @app.post("/v1/stream")
-async def stream_generate(request: GenerateRequest):
+@_rate_limit("30/minute")
+async def stream_generate(request: GenerateRequest, _: None = Depends(verify_api_key)):
     """Streaming text generation using SSE."""
     if not request.stream:
         request.stream = True
-    
+
     request_id = str(uuid.uuid4())
     results_generator, retrieved_cases = await manager.generate(request, request_id)
-    
+
     async def stream_results() -> AsyncGenerator[str, None]:
         cases_data = [RetrievedCase(**c).model_dump() for c in retrieved_cases]
-        
+
         async for request_output in results_generator:
             text = request_output.outputs[0].text
             finished = request_output.finished
-            
+
             response_obj = {
-                "request_id": request_id, 
-                "text": text, 
+                "request_id": request_id,
+                "text": text,
                 "finished": finished
             }
             if finished:
                 response_obj["retrieved_cases"] = cases_data
-                
+
             yield f"data: {json.dumps(response_obj)}\n\n"
 
     return StreamingResponse(stream_results(), media_type="text/event-stream")
+
+
+# --- S-1: /search 엔드포인트 ---
+@app.post("/search", response_model=SearchResponse)
+@_rate_limit("60/minute")
+async def search(request: SearchRequest, req: Request, _: None = Depends(verify_api_key)):
+    """확장 검색 엔드포인트. doc_type은 IndexType enum으로 자동 검증된다."""
+    try:
+        if not manager.index_manager:
+            raise HTTPException(status_code=503, detail="검색 인덱스가 아직 초기화되지 않았습니다.")
+
+        # index_manager.search는 query_vector를 기대하므로 임베딩 변환 필요
+        # 여기서는 retriever가 있으면 retriever를 통해 검색
+        if manager.retriever:
+            raw_results = manager.retriever.search(request.query, top_k=request.top_k)
+            results = [
+                SearchResult(
+                    doc_id=raw.get("doc_id", ""),
+                    source_type=request.doc_type,
+                    title=raw.get("category", ""),
+                    content=raw.get("complaint", "") + "\n" + raw.get("answer", ""),
+                    score=raw.get("score", 0.0),
+                    # m-1: reliability_score 기본값 0.6
+                    reliability_score=raw.get("reliability_score", 0.6),
+                )
+                for raw in raw_results
+            ]
+        else:
+            results = []
+
+        return SearchResponse(
+            query=request.query,
+            doc_type=request.doc_type,
+            results=results,
+            total=len(results),
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        # C-3: 내부 예외 정보 노출 방지
+        logger.error(f"검색 중 오류 발생: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="검색 처리 중 내부 오류가 발생했습니다.")
+
 
 if __name__ == "__main__":
     import uvicorn

--- a/src/inference/schemas.py
+++ b/src/inference/schemas.py
@@ -13,8 +13,8 @@ class RetrievedCase(BaseModel):
     score: float
 
 class GenerateRequest(BaseModel):
-    prompt: str = Field(..., description="The input prompt for generation.")
-    max_tokens: int = Field(default=512, gt=0, description="Maximum number of tokens to generate.")
+    prompt: str = Field(..., min_length=1, max_length=10000, description="The input prompt for generation.")
+    max_tokens: int = Field(default=512, gt=0, le=4096, description="Maximum number of tokens to generate.")
     temperature: float = Field(default=0.7, ge=0.0, le=2.0, description="Sampling temperature.")
     top_p: float = Field(default=0.9, ge=0.0, le=1.0, description="Top-p sampling parameter.")
     stream: bool = Field(default=False, description="Whether to stream the output using SSE.")
@@ -72,6 +72,23 @@ class DocumentMetadataSchema(BaseModel):
                 f"chunk_index({self.chunk_index})는 total_chunks({self.total_chunks})보다 작아야 합니다"
             )
         return self
+
+
+class SearchRequest(BaseModel):
+    """확장 검색 요청 모델."""
+
+    query: str = Field(..., min_length=1, max_length=2000, description="검색 쿼리 텍스트")
+    doc_type: IndexType = Field(default=IndexType.CASE, description="검색 대상 문서 타입")
+    top_k: int = Field(default=5, gt=0, le=50, description="반환할 최대 결과 수")
+
+
+class SearchResponse(BaseModel):
+    """확장 검색 응답 모델."""
+
+    query: str
+    doc_type: IndexType
+    results: List["SearchResult"]
+    total: int
 
 
 class SearchResult(BaseModel):
@@ -141,6 +158,7 @@ def from_internal_metadata(
     )
 
 
-# GenerateResponse.search_results forward-ref 해소
+# forward-ref 해소
 GenerateResponse.model_rebuild()
 StreamResponse.model_rebuild()
+SearchResponse.model_rebuild()

--- a/tests/test_inference/test_api_integration.py
+++ b/tests/test_inference/test_api_integration.py
@@ -1,0 +1,725 @@
+"""
+FAISS 벡터 검색 시스템 API 통합 테스트.
+
+테스트 대상:
+- POST /search : MultiIndexManager 기반 문서 검색
+- POST /v1/generate : RAG 기반 텍스트 생성 (use_rag=true/false)
+- GET /health : 인덱스 상태 포함 헬스체크
+
+무거운 의존성(vLLM, SentenceTransformer, transformers)은 import 전에
+sys.modules 패치로 mock 처리한다.
+
+NOTE: /search 엔드포인트와 SearchRequest/SearchResponse 스키마는
+Phase 1 구현(이슈 #53)에서 추가된다. 엔드포인트가 미구현 상태에서는
+해당 테스트가 xfail 처리된다.
+"""
+
+import sys
+import time
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# 1. 무거운 의존성을 import 전에 mock 등록
+# ---------------------------------------------------------------------------
+
+# vllm 관련 모듈
+_vllm_mock = MagicMock()
+sys.modules.setdefault("vllm", _vllm_mock)
+sys.modules.setdefault("vllm.engine", _vllm_mock)
+sys.modules.setdefault("vllm.engine.arg_utils", _vllm_mock)
+sys.modules.setdefault("vllm.engine.async_llm_engine", _vllm_mock)
+sys.modules.setdefault("vllm.sampling_params", _vllm_mock)
+
+# sentence_transformers mock
+_st_mock = MagicMock()
+sys.modules.setdefault("sentence_transformers", _st_mock)
+
+# transformers mock (vllm_stabilizer에서 사용)
+sys.modules.setdefault("transformers", MagicMock())
+sys.modules.setdefault("transformers.modeling_rope_utils", MagicMock())
+sys.modules.setdefault("transformers.utils", MagicMock())
+sys.modules.setdefault("transformers.utils.generic", MagicMock())
+
+# torch mock (vllm_stabilizer에서 사용)
+if "torch" not in sys.modules:
+    sys.modules["torch"] = MagicMock()
+
+# ---------------------------------------------------------------------------
+# 2. api_server import (vllm_stabilizer.apply_transformers_patch 를 no-op 처리)
+# ---------------------------------------------------------------------------
+
+with patch("src.inference.vllm_stabilizer.apply_transformers_patch"):
+    from src.inference.api_server import app, manager
+
+from src.inference.index_manager import DocumentMetadata, IndexType, MultiIndexManager
+
+from fastapi.testclient import TestClient
+
+# /search 엔드포인트 존재 여부 확인
+_has_search_endpoint = any(
+    route.path == "/search" for route in app.routes if hasattr(route, "path")
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_vllm_output_mock(text="테스트 응답입니다."):
+    """vLLM 엔진의 generate 결과를 시뮬레이션하는 async generator를 반환한다."""
+    output_mock = MagicMock()
+    output_mock.outputs = [MagicMock()]
+    output_mock.outputs[0].text = text
+    output_mock.outputs[0].token_ids = list(range(10))
+    output_mock.prompt_token_ids = list(range(5))
+    output_mock.finished = True
+
+    async def _gen(*args, **kwargs):
+        yield output_mock
+
+    return _gen
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _patch_lifespan():
+    """lifespan 이벤트의 manager.initialize()를 mock하여 무거운 초기화를 방지한다."""
+    with patch.object(manager, "initialize", new_callable=AsyncMock):
+        yield
+
+
+@pytest.fixture
+def client(_patch_lifespan):
+    """FastAPI TestClient."""
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+
+
+@pytest.fixture
+def test_index_manager(tmp_path):
+    """테스트용 MultiIndexManager를 생성하고 case 인덱스에 샘플 데이터를 추가한다.
+
+    faiss가 mock 상태인 환경에서는 실제 인덱스 대신 mock 기반 매니저를 반환한다.
+    """
+    import faiss as _faiss
+
+    # faiss가 mock인지 확인
+    if isinstance(_faiss, MagicMock):
+        # mock 기반 MultiIndexManager 생성
+        mock_mgr = MagicMock(spec=MultiIndexManager)
+        mock_mgr.base_dir = str(tmp_path)
+        mock_mgr.embedding_dim = 1024
+
+        # search 결과 mock
+        now = datetime.now(timezone.utc).isoformat()
+        mock_search_results = [
+            {
+                "doc_id": f"case-{i:04d}",
+                "doc_type": "case",
+                "source": "AI Hub",
+                "title": f"테스트 민원 {i}",
+                "category": "도로/교통",
+                "reliability_score": 0.6,
+                "created_at": now,
+                "updated_at": now,
+                "score": round(0.95 - i * 0.03, 4),
+                "extras": {
+                    "complaint_text": f"테스트 민원 내용 {i}",
+                    "answer_text": f"테스트 답변 {i}",
+                },
+            }
+            for i in range(20)
+        ]
+
+        def _mock_search(index_type, query_vector, top_k=5):
+            return mock_search_results[:top_k]
+
+        mock_mgr.search = MagicMock(side_effect=_mock_search)
+
+        # get_index_stats mock
+        mock_mgr.get_index_stats.return_value = {
+            "base_dir": str(tmp_path),
+            "embedding_dim": 1024,
+            "indexes": {
+                "case": {
+                    "loaded": True,
+                    "doc_count": 20,
+                    "index_class": "IndexFlatIP",
+                    "metadata_count": 20,
+                    "last_updated": now,
+                },
+                "law": {"loaded": False, "doc_count": 0, "last_updated": None},
+                "manual": {"loaded": False, "doc_count": 0, "last_updated": None},
+                "notice": {"loaded": False, "doc_count": 0, "last_updated": None},
+            },
+        }
+        return mock_mgr
+
+    # faiss가 실제로 설치된 환경
+    mgr = MultiIndexManager(base_dir=str(tmp_path), embedding_dim=1024)
+
+    rng = np.random.default_rng(42)
+    vectors = rng.random((20, 1024), dtype=np.float32)
+    norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+    vectors = vectors / norms
+
+    now = datetime.now(timezone.utc).isoformat()
+    metadata_list = [
+        DocumentMetadata(
+            doc_id=f"case-{i:04d}",
+            doc_type="case",
+            source="AI Hub",
+            title=f"테스트 민원 {i}",
+            category="도로/교통",
+            reliability_score=0.6,
+            created_at=now,
+            updated_at=now,
+            extras={
+                "complaint_text": f"테스트 민원 내용 {i}",
+                "answer_text": f"테스트 답변 {i}",
+            },
+        )
+        for i in range(20)
+    ]
+
+    mgr.add_documents(IndexType.CASE, vectors, metadata_list)
+    return mgr
+
+
+@pytest.fixture
+def mock_embed_model():
+    """SentenceTransformer.encode()를 mock하여 정규화된 1024차원 벡터를 반환한다."""
+    model = MagicMock()
+
+    def _encode(texts, **kwargs):
+        n = len(texts) if isinstance(texts, list) else 1
+        rng = np.random.default_rng(42)
+        vecs = rng.random((n, 1024)).astype(np.float32)
+        norms = np.linalg.norm(vecs, axis=1, keepdims=True)
+        return vecs / norms
+
+    model.encode = MagicMock(side_effect=_encode)
+    return model
+
+
+@pytest.fixture
+def client_with_index(client, test_index_manager, mock_embed_model):
+    """MultiIndexManager와 embed_model이 설정된 상태의 TestClient."""
+    original_index_manager = getattr(manager, "index_manager", None)
+    original_embed_model = getattr(manager, "embed_model", None)
+    original_retriever = getattr(manager, "retriever", None)
+
+    manager.index_manager = test_index_manager
+    manager.embed_model = mock_embed_model
+    # retriever도 설정하여 /health의 rag_enabled 검증 지원
+    if original_retriever is None:
+        manager.retriever = MagicMock()
+
+    yield client
+
+    # 복원
+    manager.index_manager = original_index_manager
+    manager.embed_model = original_embed_model
+    manager.retriever = original_retriever
+
+
+# ---------------------------------------------------------------------------
+# /search 엔드포인트 미구현 시 skip 처리용 마커
+# ---------------------------------------------------------------------------
+
+requires_search = pytest.mark.skipif(
+    not _has_search_endpoint,
+    reason="/search 엔드포인트 미구현 (Phase 1 이슈 #53 대기)",
+)
+
+
+# ---------------------------------------------------------------------------
+# 정상 동작 테스트: POST /search
+# ---------------------------------------------------------------------------
+
+
+@requires_search
+class TestSearchEndpoint:
+    """POST /search 엔드포인트 테스트."""
+
+    def test_search_basic(self, client_with_index):
+        """기본 검색: query='도로 보수 요청', top_k=5, doc_type='case'."""
+        payload = {
+            "query": "도로 보수 요청",
+            "top_k": 5,
+            "doc_type": "case",
+        }
+        resp = client_with_index.post("/search", json=payload)
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["query"] == "도로 보수 요청"
+        assert body["doc_type"] == "case"
+        assert isinstance(body["results"], list)
+        assert len(body["results"]) <= 5
+        assert body["total"] == len(body["results"])
+
+        # 각 결과에 필수 필드 존재 확인
+        for result in body["results"]:
+            assert "doc_id" in result
+            assert "title" in result
+            assert "score" in result
+            assert isinstance(result["score"], float)
+
+    @pytest.mark.parametrize("top_k", [1, 10, 50])
+    def test_search_top_k_variations(self, client_with_index, top_k):
+        """top_k 파라미터(1, 10, 50)에 따라 결과 수가 올바르게 제한된다."""
+        payload = {
+            "query": "민원 상담",
+            "top_k": top_k,
+            "doc_type": "case",
+        }
+        resp = client_with_index.post("/search", json=payload)
+
+        assert resp.status_code == 200
+        body = resp.json()
+        # 인덱스에 20개 문서가 있으므로 min(top_k, 20) 이하
+        expected_max = min(top_k, 20)
+        assert len(body["results"]) <= expected_max
+        assert body["total"] == len(body["results"])
+
+    def test_search_doc_type_case(self, client_with_index):
+        """doc_type='case'로 검색 시 결과의 source_type이 'case'이다."""
+        payload = {
+            "query": "환경 민원",
+            "top_k": 3,
+            "doc_type": "case",
+        }
+        resp = client_with_index.post("/search", json=payload)
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["doc_type"] == "case"
+        for result in body["results"]:
+            assert result.get("source_type") == "case"
+
+    def test_search_results_have_score_descending(self, client_with_index):
+        """검색 결과가 score 내림차순으로 정렬되어 있다."""
+        payload = {
+            "query": "도로 보수",
+            "top_k": 10,
+            "doc_type": "case",
+        }
+        resp = client_with_index.post("/search", json=payload)
+
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        if len(results) > 1:
+            scores = [r["score"] for r in results]
+            assert scores == sorted(scores, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# 에러 케이스 테스트: POST /search
+# ---------------------------------------------------------------------------
+
+
+@requires_search
+class TestSearchErrorCases:
+    """POST /search 에러 케이스 테스트."""
+
+    def test_search_empty_query_returns_422(self, client_with_index):
+        """빈 쿼리 문자열이 422 Validation Error를 반환한다."""
+        payload = {
+            "query": "",
+            "top_k": 5,
+            "doc_type": "case",
+        }
+        resp = client_with_index.post("/search", json=payload)
+
+        assert resp.status_code == 422
+        body = resp.json()
+        assert "detail" in body
+
+    def test_search_missing_query_returns_422(self, client_with_index):
+        """query 필드 누락 시 422 Validation Error를 반환한다."""
+        payload = {
+            "top_k": 5,
+            "doc_type": "case",
+        }
+        resp = client_with_index.post("/search", json=payload)
+
+        assert resp.status_code == 422
+
+    def test_search_invalid_doc_type_returns_400(self, client_with_index):
+        """존재하지 않는 doc_type은 400 또는 422를 반환한다."""
+        payload = {
+            "query": "테스트 쿼리",
+            "top_k": 5,
+            "doc_type": "invalid_type",
+        }
+        resp = client_with_index.post("/search", json=payload)
+
+        # doc_type 유효성 검증 방식에 따라 400 또는 422
+        assert resp.status_code in (400, 422)
+
+    def test_search_top_k_zero_returns_422(self, client_with_index):
+        """top_k=0은 422 Validation Error를 반환한다 (ge=1 제약 위반)."""
+        payload = {
+            "query": "테스트 쿼리",
+            "top_k": 0,
+            "doc_type": "case",
+        }
+        resp = client_with_index.post("/search", json=payload)
+
+        assert resp.status_code == 422
+
+    def test_search_top_k_exceeds_max_returns_422(self, client_with_index):
+        """top_k=51은 422 Validation Error를 반환한다 (le=50 제약 위반)."""
+        payload = {
+            "query": "테스트 쿼리",
+            "top_k": 51,
+            "doc_type": "case",
+        }
+        resp = client_with_index.post("/search", json=payload)
+
+        assert resp.status_code == 422
+
+    def test_search_index_not_initialized_returns_503(self, client):
+        """MultiIndexManager가 초기화되지 않은 경우 503 Service Unavailable을 반환한다."""
+        original = getattr(manager, "index_manager", None)
+        manager.index_manager = None
+
+        try:
+            payload = {
+                "query": "테스트 쿼리",
+                "top_k": 5,
+                "doc_type": "case",
+            }
+            resp = client.post("/search", json=payload)
+
+            assert resp.status_code == 503
+        finally:
+            manager.index_manager = original
+
+
+# ---------------------------------------------------------------------------
+# 성능 관련 기본 검증: POST /search
+# ---------------------------------------------------------------------------
+
+
+@requires_search
+class TestSearchPerformance:
+    """검색 API 기본 성능 검증."""
+
+    def test_search_response_time_under_threshold(self, client_with_index):
+        """단일 검색 요청의 응답 시간이 2초 이내이다."""
+        payload = {
+            "query": "도로 보수 요청",
+            "top_k": 5,
+            "doc_type": "case",
+        }
+
+        start = time.monotonic()
+        resp = client_with_index.post("/search", json=payload)
+        elapsed_ms = (time.monotonic() - start) * 1000
+
+        assert resp.status_code == 200
+        # 테스트 환경(mock + 20개 문서)에서 2초 이내
+        assert elapsed_ms < 2000, f"응답 시간 {elapsed_ms:.1f}ms가 2초를 초과"
+
+    def test_search_multiple_sequential_requests(self, client_with_index):
+        """다수의 순차 요청이 모두 정상 응답한다."""
+        payload = {
+            "query": "민원 처리 절차",
+            "top_k": 5,
+            "doc_type": "case",
+        }
+
+        results = []
+        for _ in range(10):
+            resp = client_with_index.post("/search", json=payload)
+            results.append(resp.status_code)
+
+        assert all(code == 200 for code in results)
+
+
+# ---------------------------------------------------------------------------
+# 보안 기본 검증: POST /search
+# ---------------------------------------------------------------------------
+
+
+@requires_search
+class TestSearchSecurity:
+    """검색 API 보안 기본 검증."""
+
+    def test_search_sql_injection_attempt(self, client_with_index):
+        """SQL 인젝션 시도가 500 에러를 유발하지 않는다."""
+        payload = {
+            "query": "'; DROP TABLE users; --",
+            "top_k": 5,
+            "doc_type": "case",
+        }
+        resp = client_with_index.post("/search", json=payload)
+
+        # 500이 아닌 정상 응답(200) 또는 클라이언트 에러(4xx)
+        assert resp.status_code != 500
+
+    def test_search_xss_attempt(self, client_with_index):
+        """XSS 시도가 500 에러를 유발하지 않는다."""
+        payload = {
+            "query": "<script>alert('xss')</script>",
+            "top_k": 5,
+            "doc_type": "case",
+        }
+        resp = client_with_index.post("/search", json=payload)
+
+        assert resp.status_code != 500
+
+    def test_search_oversized_query(self, client_with_index):
+        """매우 긴 쿼리 문자열이 서버 크래시를 유발하지 않는다."""
+        payload = {
+            "query": "테스트 " * 10000,
+            "top_k": 5,
+            "doc_type": "case",
+        }
+        resp = client_with_index.post("/search", json=payload)
+
+        # 서버가 크래시하지 않으면 성공 (200 또는 4xx)
+        assert resp.status_code < 500
+
+
+# ---------------------------------------------------------------------------
+# 정상 동작 테스트: POST /v1/generate
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateEndpoint:
+    """POST /v1/generate 엔드포인트 테스트."""
+
+    def test_generate_with_rag_returns_retrieved_cases(self, client_with_index):
+        """use_rag=true 시 retrieved_cases 필드가 포함된다."""
+        # retriever.search mock 설정
+        manager.retriever = MagicMock()
+        manager.retriever.search = MagicMock(
+            return_value=[
+                {
+                    "complaint": "도로 파손 민원",
+                    "answer": "도로 보수 처리 완료",
+                    "score": 0.95,
+                },
+            ]
+        )
+        manager.engine = MagicMock()
+        manager.engine.generate = MagicMock(
+            return_value=_make_vllm_output_mock()()
+        )
+
+        payload = {
+            "prompt": "도로 보수 관련 민원에 대해 답변해주세요.",
+            "max_tokens": 128,
+            "temperature": 0.7,
+            "use_rag": True,
+            "stream": False,
+        }
+        resp = client_with_index.post("/v1/generate", json=payload)
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "request_id" in body
+        assert "text" in body
+        assert body["text"] != ""
+        # use_rag=true이므로 retrieved_cases가 포함
+        assert "retrieved_cases" in body
+        assert body["retrieved_cases"] is not None
+        assert len(body["retrieved_cases"]) > 0
+
+    def test_generate_with_rag_search_results_field(self, client_with_index):
+        """use_rag=true 시 search_results 필드가 포함된다 (Phase 1 확장 응답).
+
+        Phase 1 이전에는 search_results가 None일 수 있으며,
+        Phase 1 구현 후에는 리스트가 반환되어야 한다.
+        """
+        manager.retriever = MagicMock()
+        manager.retriever.search = MagicMock(return_value=[])
+        manager.engine = MagicMock()
+        manager.engine.generate = MagicMock(
+            return_value=_make_vllm_output_mock()()
+        )
+
+        payload = {
+            "prompt": "도로 보수 관련 민원",
+            "max_tokens": 128,
+            "use_rag": True,
+            "stream": False,
+        }
+        resp = client_with_index.post("/v1/generate", json=payload)
+
+        assert resp.status_code == 200
+        body = resp.json()
+        # search_results 필드는 스키마에 정의되어 있으므로 응답에 존재해야 함
+        assert "search_results" in body
+
+    def test_generate_without_rag_no_retrieved_cases(self, client_with_index):
+        """use_rag=false 시 retrieved_cases가 빈 리스트이다."""
+        manager.retriever = MagicMock()
+        manager.engine = MagicMock()
+        manager.engine.generate = MagicMock(
+            return_value=_make_vllm_output_mock()()
+        )
+
+        payload = {
+            "prompt": "일반 질문입니다.",
+            "max_tokens": 128,
+            "temperature": 0.7,
+            "use_rag": False,
+            "stream": False,
+        }
+        resp = client_with_index.post("/v1/generate", json=payload)
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "text" in body
+        # use_rag=false이므로 retrieved_cases가 빈 리스트
+        retrieved = body.get("retrieved_cases")
+        assert retrieved is None or retrieved == []
+
+    def test_generate_response_has_token_counts(self, client_with_index):
+        """응답에 prompt_tokens, completion_tokens가 포함된다."""
+        manager.retriever = MagicMock()
+        manager.retriever.search = MagicMock(return_value=[])
+        manager.engine = MagicMock()
+        manager.engine.generate = MagicMock(
+            return_value=_make_vllm_output_mock()()
+        )
+
+        payload = {
+            "prompt": "테스트 프롬프트",
+            "max_tokens": 64,
+            "use_rag": False,
+            "stream": False,
+        }
+        resp = client_with_index.post("/v1/generate", json=payload)
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "prompt_tokens" in body
+        assert "completion_tokens" in body
+        assert isinstance(body["prompt_tokens"], int)
+        assert isinstance(body["completion_tokens"], int)
+        assert body["prompt_tokens"] > 0
+        assert body["completion_tokens"] > 0
+
+    def test_generate_stream_true_returns_400(self, client_with_index):
+        """stream=true로 /v1/generate 호출 시 400 에러를 반환한다."""
+        payload = {
+            "prompt": "테스트",
+            "stream": True,
+        }
+        resp = client_with_index.post("/v1/generate", json=payload)
+
+        assert resp.status_code == 400
+
+    def test_generate_request_id_is_uuid(self, client_with_index):
+        """응답의 request_id가 유효한 UUID 형식이다."""
+        import uuid
+
+        manager.retriever = MagicMock()
+        manager.retriever.search = MagicMock(return_value=[])
+        manager.engine = MagicMock()
+        manager.engine.generate = MagicMock(
+            return_value=_make_vllm_output_mock()()
+        )
+
+        payload = {
+            "prompt": "테스트",
+            "use_rag": False,
+            "stream": False,
+        }
+        resp = client_with_index.post("/v1/generate", json=payload)
+
+        assert resp.status_code == 200
+        body = resp.json()
+        # request_id가 유효한 UUID인지 확인
+        try:
+            uuid.UUID(body["request_id"])
+        except ValueError:
+            pytest.fail(f"request_id가 유효한 UUID가 아닙니다: {body['request_id']}")
+
+
+# ---------------------------------------------------------------------------
+# 정상 동작 테스트: GET /health
+# ---------------------------------------------------------------------------
+
+
+class TestHealthEndpoint:
+    """GET /health 엔드포인트 테스트."""
+
+    def test_health_basic(self, client):
+        """기본 헬스체크가 'healthy' 상태를 반환한다."""
+        resp = client.get("/health")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "healthy"
+        assert "indexes" in body
+
+    def test_health_with_rag_enabled(self, client_with_index):
+        """RAG가 활성화된 상태에서 rag_enabled=true를 반환한다."""
+        resp = client_with_index.get("/health")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body.get("rag_enabled") is True
+
+    def test_health_without_rag(self, client):
+        """retriever가 None인 경우 rag_enabled=false를 반환한다."""
+        original = manager.retriever
+        manager.retriever = None
+
+        try:
+            resp = client.get("/health")
+
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body.get("rag_enabled") is False
+        finally:
+            manager.retriever = original
+
+    def test_health_index_stats_fields(self, client_with_index):
+        """index_stats 필드에 base_dir, embedding_dim, indexes 정보가 포함된다.
+
+        Phase 1 구현 후 /health 응답에 index_stats가 추가된다.
+        미구현 시 이 테스트는 통과하되 검증을 건너뛴다.
+        """
+        resp = client_with_index.get("/health")
+
+        assert resp.status_code == 200
+        body = resp.json()
+
+        # index_stats가 포함된 경우에만 검증 (Phase 1 업데이트 후)
+        if "index_stats" in body:
+            stats = body["index_stats"]
+            assert "base_dir" in stats
+            assert "embedding_dim" in stats
+            assert "indexes" in stats
+            assert isinstance(stats["indexes"], dict)
+
+            # case 인덱스가 로드된 상태
+            if "case" in stats["indexes"]:
+                case_info = stats["indexes"]["case"]
+                assert case_info["loaded"] is True
+                assert case_info["doc_count"] == 20
+
+    def test_health_response_time(self, client):
+        """헬스체크 응답 시간이 500ms 이내이다."""
+        start = time.monotonic()
+        resp = client.get("/health")
+        elapsed_ms = (time.monotonic() - start) * 1000
+
+        assert resp.status_code == 200
+        assert elapsed_ms < 500, f"헬스체크 응답 시간 {elapsed_ms:.1f}ms가 500ms를 초과"

--- a/tests/test_inference/test_embedding.py
+++ b/tests/test_inference/test_embedding.py
@@ -1,0 +1,269 @@
+"""
+EmbeddingPipeline 단위 테스트.
+
+SentenceTransformer 모델은 mock으로 대체하여 실제 모델 로딩 없이 테스트한다.
+"""
+
+import json
+import sys
+import types
+import unittest.mock as mock
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+# src.data_collection_preprocessing 패키지의 __init__.py가 dotenv, seoul_api_collector 등
+# 테스트 환경에 없을 수 있는 모듈을 import하므로, 미리 mock 등록한다.
+for _mod_name in (
+    "dotenv",
+    "sentence_transformers",
+    "src.data_collection_preprocessing.seoul_api_collector",
+):
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# Mock 헬퍼
+# ---------------------------------------------------------------------------
+
+
+def _mock_encode(texts, batch_size=64, show_progress_bar=True, normalize_embeddings=True):
+    """SentenceTransformer.encode() mock 구현."""
+    n = len(texts)
+    rng = np.random.default_rng(12345)
+    vecs = rng.standard_normal((n, 1024)).astype(np.float32)
+    if normalize_embeddings:
+        norms = np.linalg.norm(vecs, axis=1, keepdims=True)
+        norms[norms == 0] = 1
+        vecs = vecs / norms
+    return vecs
+
+
+@pytest.fixture
+def pipeline():
+    """SentenceTransformer를 mock한 EmbeddingPipeline 인스턴스."""
+    with mock.patch("src.data_collection_preprocessing.embedding.SentenceTransformer") as MockST:
+        mock_model = MockST.return_value
+        mock_model.encode = _mock_encode
+        mock_model.get_sentence_embedding_dimension.return_value = 1024
+        mock_model.device = "cpu"
+
+        from src.data_collection_preprocessing.embedding import EmbeddingPipeline
+        p = EmbeddingPipeline()
+        yield p
+
+
+# ---------------------------------------------------------------------------
+# 테스트용 JSONL 데이터
+# ---------------------------------------------------------------------------
+
+SAMPLE_TEXT = (
+    "[|system|]당신은 민원 상담 AI입니다.[|endofturn|]\n"
+    "[|user|][카테고리: 세금]\n"
+    "민원 내용: 재산세 납부 기한이 언제인가요?[|endofturn|]\n"
+    "[|assistant|]재산세 납부 기한은 매년 7월과 9월입니다.[|endofturn|]"
+)
+
+SAMPLE_TEXT_NO_COMPLAINT = (
+    "[|system|]당신은 민원 상담 AI입니다.[|endofturn|]\n"
+    "[|user|]안녕하세요[|endofturn|]\n"
+    "[|assistant|]안녕하세요, 무엇을 도와드릴까요?[|endofturn|]"
+)
+
+SAMPLE_TEXT_NO_ASSISTANT = (
+    "[|system|]시스템[|endofturn|]\n"
+    "[|user|][카테고리: 교통]\n"
+    "민원 내용: 도로 파손 신고[|endofturn|]"
+)
+
+
+def _make_jsonl_file(records, tmp_path):
+    """tmp_path에 JSONL 파일을 생성하고 경로를 반환한다."""
+    jsonl_path = tmp_path / "test_data.jsonl"
+    with open(jsonl_path, "w", encoding="utf-8") as f:
+        for record in records:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    return str(jsonl_path)
+
+
+# ---------------------------------------------------------------------------
+# 1. _parse_complaint_text 테스트
+# ---------------------------------------------------------------------------
+
+
+from src.data_collection_preprocessing.embedding import EmbeddingPipeline as _EP
+
+
+class TestParseComplaintText:
+    def test_normal_parse(self):
+        result = _EP._parse_complaint_text(SAMPLE_TEXT)
+        assert result is not None
+        assert "재산세 납부 기한" in result
+
+    def test_no_complaint_keyword(self):
+        result = _EP._parse_complaint_text(SAMPLE_TEXT_NO_COMPLAINT)
+        assert result is None
+
+    def test_empty_string(self):
+        result = _EP._parse_complaint_text("")
+        assert result is None
+
+    def test_no_user_block(self):
+        result = _EP._parse_complaint_text("민원 내용: 테스트")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# 2. _parse_answer_text 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestParseAnswerText:
+    def test_normal_parse(self):
+        result = _EP._parse_answer_text(SAMPLE_TEXT)
+        assert result is not None
+        assert "재산세 납부 기한" in result
+        assert "7월" in result
+
+    def test_no_assistant_block(self):
+        result = _EP._parse_answer_text(SAMPLE_TEXT_NO_ASSISTANT)
+        assert result is None
+
+    def test_empty_string(self):
+        result = _EP._parse_answer_text("")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# 3. _parse_category_from_text 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestParseCategoryFromText:
+    def test_normal_parse(self):
+        result = _EP._parse_category_from_text(SAMPLE_TEXT)
+        assert result == "세금"
+
+    def test_no_category(self):
+        result = _EP._parse_category_from_text("카테고리 없는 텍스트")
+        assert result is None
+
+    def test_category_with_spaces(self):
+        text = "[카테고리:  도로/교통 ]"
+        result = _EP._parse_category_from_text(text)
+        assert result == "도로/교통"
+
+
+# ---------------------------------------------------------------------------
+# 4. load_jsonl 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestLoadJsonl:
+    def test_normal_load(self, pipeline, tmp_path):
+        records = [
+            {"text": SAMPLE_TEXT, "category": "세금", "id": "test-001"},
+            {"text": SAMPLE_TEXT, "category": "세금", "id": "test-002"},
+        ]
+        jsonl_path = _make_jsonl_file(records, tmp_path)
+        result = pipeline.load_jsonl(jsonl_path)
+        assert len(result) == 2
+        assert result[0]["id"] == "test-001"
+        assert result[0]["category"] == "세금"
+        assert "재산세" in result[0]["complaint_text"]
+        assert result[0]["answer_text"] != ""
+
+    def test_skip_unparseable(self, pipeline, tmp_path):
+        records = [
+            {"text": SAMPLE_TEXT, "category": "세금", "id": "good-001"},
+            {"text": SAMPLE_TEXT_NO_COMPLAINT, "category": "기타", "id": "bad-001"},
+        ]
+        jsonl_path = _make_jsonl_file(records, tmp_path)
+        result = pipeline.load_jsonl(jsonl_path)
+        assert len(result) == 1
+        assert result[0]["id"] == "good-001"
+
+    def test_empty_file(self, pipeline, tmp_path):
+        jsonl_path = tmp_path / "empty.jsonl"
+        jsonl_path.touch()
+        result = pipeline.load_jsonl(str(jsonl_path))
+        assert result == []
+
+    def test_category_fallback_to_text_parsing(self, pipeline, tmp_path):
+        """JSONL에 category 필드가 없으면 텍스트에서 파싱한다."""
+        records = [{"text": SAMPLE_TEXT, "id": "no-cat-001"}]
+        jsonl_path = _make_jsonl_file(records, tmp_path)
+        result = pipeline.load_jsonl(jsonl_path)
+        assert len(result) == 1
+        assert result[0]["category"] == "세금"
+
+
+# ---------------------------------------------------------------------------
+# 5. embed_documents 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedDocuments:
+    def test_output_shape(self, pipeline):
+        texts = ["테스트 문장 1", "테스트 문장 2", "테스트 문장 3"]
+        embeddings = pipeline.embed_documents(texts)
+        assert embeddings.shape == (3, 1024)
+
+    def test_output_dtype(self, pipeline):
+        embeddings = pipeline.embed_documents(["테스트"])
+        assert embeddings.dtype == np.float32
+
+    def test_normalization(self, pipeline):
+        embeddings = pipeline.embed_documents(["정규화 검증"])
+        norms = np.linalg.norm(embeddings, axis=1)
+        np.testing.assert_allclose(norms, 1.0, atol=1e-5)
+
+    def test_single_document(self, pipeline):
+        embeddings = pipeline.embed_documents(["단일 문서"])
+        assert embeddings.shape == (1, 1024)
+
+    def test_batch_consistency(self, pipeline):
+        """배치 크기에 관계없이 결과 shape이 일관된다."""
+        texts = [f"문장 {i}" for i in range(10)]
+        embeddings = pipeline.embed_documents(texts, batch_size=3)
+        assert embeddings.shape == (10, 1024)
+
+
+# ---------------------------------------------------------------------------
+# 6. process_jsonl 통합 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestProcessJsonl:
+    def test_full_pipeline(self, pipeline, tmp_path):
+        records = [
+            {"text": SAMPLE_TEXT, "category": "세금", "id": f"test-{i:03d}"}
+            for i in range(5)
+        ]
+        jsonl_path = _make_jsonl_file(records, tmp_path)
+        embeddings, metadata_list = pipeline.process_jsonl(jsonl_path)
+
+        # 벡터 shape 검증
+        assert embeddings.shape == (5, 1024)
+        assert embeddings.dtype == np.float32
+
+        # 메타데이터 수 일치
+        assert len(metadata_list) == 5
+
+        # 메타데이터 내용 검증
+        meta = metadata_list[0]
+        assert meta.doc_id == "test-000"
+        assert meta.doc_type == "case"
+        assert meta.category == "세금"
+        assert meta.source == "AI Hub"
+        assert meta.extras["complaint_text"] != ""
+        assert meta.extras["answer_text"] != ""
+
+    def test_empty_jsonl_raises(self, pipeline, tmp_path):
+        jsonl_path = tmp_path / "empty.jsonl"
+        jsonl_path.touch()
+        with pytest.raises(ValueError, match="유효한 레코드가 없습니다"):
+            pipeline.process_jsonl(str(jsonl_path))

--- a/tests/test_inference/test_search_api.py
+++ b/tests/test_inference/test_search_api.py
@@ -1,0 +1,347 @@
+"""
+/search 및 /health API 엔드포인트 테스트.
+
+vLLM, SentenceTransformer 등 무거운 의존성을 mock하고
+FastAPI TestClient로 API 동작을 검증한다.
+"""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# 무거운 외부 의존성 mock (api_server import 전에 등록해야 함)
+# ---------------------------------------------------------------------------
+
+# vllm 관련 모듈 mock
+sys.modules.setdefault("vllm", MagicMock())
+sys.modules.setdefault("vllm.engine", MagicMock())
+sys.modules.setdefault("vllm.engine.arg_utils", MagicMock())
+sys.modules.setdefault("vllm.engine.async_llm_engine", MagicMock())
+sys.modules.setdefault("vllm.sampling_params", MagicMock())
+
+# sentence_transformers mock
+sys.modules.setdefault("sentence_transformers", MagicMock())
+
+# vllm_stabilizer 패치 함수 mock
+_mock_stabilizer = MagicMock()
+_mock_stabilizer.apply_transformers_patch = MagicMock()
+sys.modules.setdefault("src.inference.vllm_stabilizer", _mock_stabilizer)
+
+# retriever mock
+_mock_retriever_module = MagicMock()
+sys.modules.setdefault("src.inference.retriever", _mock_retriever_module)
+
+from fastapi.testclient import TestClient
+
+from src.inference.api_server import app, manager
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _mock_manager():
+    """모든 테스트에서 manager를 초기화된 상태로 mock한다."""
+    original_engine = manager.engine
+    original_retriever = manager.retriever
+    original_generate = manager.generate
+
+    manager.engine = MagicMock()
+    manager.retriever = MagicMock()
+    manager.retriever.search.return_value = [
+        {"id": "case-001", "category": "세금", "complaint": "테스트 민원", "answer": "테스트 답변", "score": 0.95}
+    ]
+    yield
+
+    manager.engine = original_engine
+    manager.retriever = original_retriever
+    manager.generate = original_generate
+
+
+@pytest.fixture
+def client():
+    """FastAPI TestClient."""
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# /health 엔드포인트 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestHealthEndpoint:
+    def test_health_returns_200(self, client):
+        response = client.get("/health")
+        assert response.status_code == 200
+
+    def test_health_contains_status(self, client):
+        response = client.get("/health")
+        data = response.json()
+        assert "status" in data
+        assert data["status"] == "healthy"
+
+    def test_health_contains_indexes(self, client):
+        response = client.get("/health")
+        data = response.json()
+        assert "indexes" in data
+
+    def test_health_contains_rag_status(self, client):
+        response = client.get("/health")
+        data = response.json()
+        assert "rag_enabled" in data
+
+
+# ---------------------------------------------------------------------------
+# /v1/generate 엔드포인트 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateEndpoint:
+    def _setup_generate_mock(self):
+        """vLLM 엔진의 generate를 mock한다."""
+        mock_output = MagicMock()
+        mock_output.outputs = [MagicMock()]
+        mock_output.outputs[0].text = "테스트 응답입니다."
+        mock_output.outputs[0].token_ids = list(range(10))
+        mock_output.prompt_token_ids = list(range(20))
+
+        async def mock_generate(*args, **kwargs):
+            async def gen():
+                yield mock_output
+            return gen(), []
+
+        manager.generate = AsyncMock(side_effect=mock_generate)
+        return mock_output
+
+    def test_generate_returns_200(self, client):
+        mock_output = self._setup_generate_mock()
+
+        async def fake_generate(request, request_id):
+            async def gen():
+                yield mock_output
+            return gen(), []
+
+        manager.generate = AsyncMock(side_effect=fake_generate)
+
+        response = client.post("/v1/generate", json={
+            "prompt": "테스트 프롬프트",
+            "max_tokens": 100,
+            "stream": False,
+        })
+        assert response.status_code == 200
+
+    def test_generate_response_structure(self, client):
+        mock_output = MagicMock()
+        mock_output.outputs = [MagicMock()]
+        mock_output.outputs[0].text = "생성된 답변"
+        mock_output.outputs[0].token_ids = list(range(5))
+        mock_output.prompt_token_ids = list(range(15))
+
+        async def fake_generate(request, request_id):
+            async def gen():
+                yield mock_output
+            return gen(), []
+
+        manager.generate = AsyncMock(side_effect=fake_generate)
+
+        response = client.post("/v1/generate", json={
+            "prompt": "구조 테스트",
+            "stream": False,
+        })
+        data = response.json()
+        assert "request_id" in data
+        assert "text" in data
+        assert "prompt_tokens" in data
+        assert "completion_tokens" in data
+
+    def test_generate_stream_flag_rejected(self, client):
+        """stream=True로 /v1/generate를 호출하면 400 에러."""
+        response = client.post("/v1/generate", json={
+            "prompt": "스트림 테스트",
+            "stream": True,
+        })
+        assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# /search 엔드포인트 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestSearchEndpoint:
+    """POST /search 엔드포인트 테스트."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_search(self):
+        """검색에 필요한 index_manager와 embed_model을 mock."""
+        # index_manager mock
+        mock_mgr = MagicMock()
+        mock_search_results = [
+            {
+                "doc_id": f"case-{i:04d}",
+                "doc_type": "case",
+                "source": "AI Hub",
+                "title": f"테스트 민원 {i}",
+                "category": "도로/교통",
+                "reliability_score": 0.6,
+                "score": round(0.95 - i * 0.03, 4),
+                "extras": {"complaint_text": f"민원 {i}", "answer_text": f"답변 {i}"},
+            }
+            for i in range(5)
+        ]
+        mock_mgr.search.return_value = mock_search_results
+        mock_mgr.get_index_stats.return_value = {
+            "base_dir": "/tmp", "embedding_dim": 1024,
+            "indexes": {"case": {"loaded": True, "doc_count": 5}}
+        }
+        manager.index_manager = mock_mgr
+
+        # embed_model mock
+        mock_model = MagicMock()
+        mock_model.encode.return_value = np.random.randn(1, 1024).astype(np.float32)
+        manager.embed_model = mock_model
+
+        yield
+
+        manager.index_manager = None
+        manager.embed_model = None
+
+    def test_search_returns_200(self, client):
+        """기본 검색 요청이 200을 반환한다."""
+        response = client.post("/search", json={
+            "query": "도로 보수 요청",
+            "top_k": 5,
+            "doc_type": "case",
+        })
+        assert response.status_code == 200
+
+    def test_search_response_structure(self, client):
+        """응답에 query, doc_type, results, total이 포함된다."""
+        response = client.post("/search", json={
+            "query": "도로 보수 요청",
+            "top_k": 5,
+            "doc_type": "case",
+        })
+        data = response.json()
+        assert "query" in data
+        assert "doc_type" in data
+        assert "results" in data
+        assert "total" in data
+        assert data["query"] == "도로 보수 요청"
+        assert data["doc_type"] == "case"
+        assert isinstance(data["results"], list)
+        assert data["total"] == len(data["results"])
+
+    def test_search_results_have_required_fields(self, client):
+        """각 결과에 doc_id, title, score, source_type이 포함된다."""
+        response = client.post("/search", json={
+            "query": "민원 테스트",
+            "top_k": 3,
+            "doc_type": "case",
+        })
+        data = response.json()
+        for result in data["results"]:
+            assert "doc_id" in result
+            assert "title" in result
+            assert "score" in result
+            assert "source_type" in result
+
+    def test_search_empty_query_returns_422(self, client):
+        """빈 쿼리 시 422 Validation Error를 반환한다."""
+        response = client.post("/search", json={
+            "query": "",
+            "top_k": 5,
+            "doc_type": "case",
+        })
+        assert response.status_code == 422
+
+    def test_search_invalid_doc_type_returns_400_or_422(self, client):
+        """잘못된 doc_type 시 400 또는 422를 반환한다."""
+        response = client.post("/search", json={
+            "query": "테스트 쿼리",
+            "top_k": 5,
+            "doc_type": "invalid_type",
+        })
+        assert response.status_code in (400, 422)
+
+    def test_search_top_k_validation(self, client):
+        """top_k=0 또는 51 시 422를 반환한다."""
+        # top_k=0
+        response = client.post("/search", json={
+            "query": "테스트 쿼리",
+            "top_k": 0,
+            "doc_type": "case",
+        })
+        assert response.status_code == 422
+
+        # top_k=51
+        response = client.post("/search", json={
+            "query": "테스트 쿼리",
+            "top_k": 51,
+            "doc_type": "case",
+        })
+        assert response.status_code == 422
+
+    def test_search_not_initialized_returns_503(self, client):
+        """index_manager=None 시 503을 반환한다."""
+        manager.index_manager = None
+
+        response = client.post("/search", json={
+            "query": "테스트 쿼리",
+            "top_k": 5,
+            "doc_type": "case",
+        })
+        assert response.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# 에러 케이스 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestErrorCases:
+    def test_missing_prompt(self, client):
+        """prompt 필드가 없으면 422 Validation Error."""
+        response = client.post("/v1/generate", json={
+            "max_tokens": 100,
+        })
+        assert response.status_code == 422
+
+    def test_invalid_temperature(self, client):
+        """temperature 범위 초과 시 422 Validation Error."""
+        response = client.post("/v1/generate", json={
+            "prompt": "테스트",
+            "temperature": 5.0,
+        })
+        assert response.status_code == 422
+
+    def test_invalid_top_p(self, client):
+        """top_p 범위 초과 시 422 Validation Error."""
+        response = client.post("/v1/generate", json={
+            "prompt": "테스트",
+            "top_p": 2.0,
+        })
+        assert response.status_code == 422
+
+    def test_negative_max_tokens(self, client):
+        """max_tokens가 0 이하이면 422 Validation Error."""
+        response = client.post("/v1/generate", json={
+            "prompt": "테스트",
+            "max_tokens": 0,
+        })
+        assert response.status_code == 422
+
+    def test_nonexistent_endpoint(self, client):
+        """존재하지 않는 경로에 대해 404."""
+        response = client.get("/v1/nonexistent")
+        assert response.status_code == 404
+
+    def test_wrong_method(self, client):
+        """GET으로 /v1/generate 호출 시 405."""
+        response = client.get("/v1/generate")
+        assert response.status_code == 405


### PR DESCRIPTION
## Summary

Closes #53

FAISS 벡터 검색 시스템을 구축하고 기존 API 서버에 통합합니다.

### 주요 변경사항

**임베딩 파이프라인 (`src/data_collection_preprocessing/embedding.py`)**
- `EmbeddingPipeline`: JSONL 파싱 → E5 임베딩(1024차원) → DocumentMetadata 생성
- `_parse_complaint_text()`, `_parse_answer_text()`, `_parse_category_from_text()` 정규식 파싱
- `embed_documents()`: "passage: " prefix 적용, 배치 처리, L2 정규화
- `embed_query()`: "query: " prefix 적용 쿼리 임베딩

**API 서버 확장 (`src/inference/api_server.py`, `src/inference/schemas.py`)**
- `POST /search`: MultiIndexManager 기반 문서 검색 엔드포인트
- `POST /v1/generate` RAG 통합: 유사 민원 검색 → 프롬프트 보강 → 텍스트 생성
- `SearchRequest`/`SearchResponse`/`SearchResult` Pydantic 스키마 추가
- `doc_type`을 `IndexType` enum으로 타입 안전성 확보

**보안 강화**
- API Key 인증 (`X-API-Key` 헤더, `API_KEY` 환경변수)
- Rate Limiting (generate 30/min, search 60/min, slowapi optional)
- CORS 미들웨어 (`CORS_ORIGINS` 환경변수)
- `/health` 민감 정보 노출 최소화 (model path, base_dir 제거)
- 프롬프트 인젝션 방어 (`_escape_special_tokens`)
- 입력 길이 제한 (prompt 10000자, query 2000자, max_tokens 4096)
- 내부 예외 정보 노출 차단

**운영 스크립트**
- `scripts/build_faiss_index.py`: JSONL → FAISS 인덱스 구축 CLI (DB 연동 옵션 포함)
- `scripts/evaluate_search.py`: Recall@5, Recall@10, MRR, 레이턴시(p50/p95/p99) 평가

## Test plan

- [x] `test_embedding.py` — 21 tests (파싱, JSONL 로드, 임베딩, 통합 파이프라인)
- [x] `test_search_api.py` — 20 tests (/health, /v1/generate, /search, 에러 케이스)
- [x] `test_api_integration.py` — 28 tests (검색, 보안, 성능, RAG 생성, 헬스체크)
- [x] **총 69개 테스트 전체 통과**