### PR TITLE
fix: LLM 응답에서 <thought> 블록 서버사이드 제거 (#56)

### DIFF
--- a/src/inference/api_server.py
+++ b/src/inference/api_server.py
@@ -115,6 +115,11 @@ class vLLMEngineManager:
             text = text.replace(token, token.replace("[", "\\[").replace("]", "\\]").replace("<", "\\<").replace(">", "\\>"))
         return text
 
+    @staticmethod
+    def _strip_thought_blocks(text: str) -> str:
+        """LLM 출력에서 내부 추론 블록(<thought>...</thought>)을 제거한다."""
+        return re.sub(r"<thought>.*?</thought>\s*", "", text, flags=re.DOTALL).strip()
+
     def _build_rag_context(self, retrieved_cases: List[dict]) -> str:
         """RAG 참고 사례 컨텍스트 문자열을 생성한다."""
         if not retrieved_cases:
@@ -319,7 +324,7 @@ async def generate(request: GenerateRequest, _: None = Depends(verify_api_key)):
 
     return GenerateResponse(
         request_id=request_id,
-        text=final_output.outputs[0].text,
+        text=manager._strip_thought_blocks(final_output.outputs[0].text),
         prompt_tokens=len(final_output.prompt_token_ids),
         completion_tokens=len(final_output.outputs[0].token_ids),
         retrieved_cases=[RetrievedCase(**c) for c in retrieved_cases]
@@ -342,6 +347,8 @@ async def stream_generate(request: GenerateRequest, _: None = Depends(verify_api
         async for request_output in results_generator:
             text = request_output.outputs[0].text
             finished = request_output.finished
+            if finished:
+                text = manager._strip_thought_blocks(text)
 
             response_obj = {
                 "request_id": request_id,


### PR DESCRIPTION
- _strip_thought_blocks() 정적 메서드 추가
- /v1/generate, /v1/stream 응답에서 내부 추론 블록 제거 후 반환
- 클라이언트에 generator의 사고 과정이 노출되지 않도록 방지

## 관련 이슈
<!-- 반드시 관련 이슈를 연결해 주세요. 이슈 연결 없는 PR은 리뷰가 진행되지 않습니다. -->
<!-- 예: Closes #123, Refs #456 -->
-

## 작업 배경
<!-- 이번 작업을 수행한 이유를 간단히 적어주세요. -->


## 주요 변경 사항
<!-- 새로 추가되거나 수정된 핵심 기능을 요약해 주세요. -->
-

## 테스트 결과
<!-- 기능이 정상 작동하는지 확인한 방법을 적어주세요. -->
- [ ] 로컬 테스트 완료
- [ ] 기존 기능 정상 동작 확인

## 기타 사항
<!-- 리뷰어가 참고해야 할 이슈나 질문을 적어주세요. -->

---

## 머지 조건 체크리스트
<!-- 아래 조건이 모두 충족되어야 머지할 수 있습니다. -->
- [ ] 2명 이상의 코드리뷰 승인 완료
- [ ] CODEOWNERS(팀장) 최종 승인 완료
- [ ] 모든 리뷰 코멘트 해결(resolved) 완료

## 리뷰어 가이드
<!-- 리뷰어는 아래 태그를 사용해 구조화된 피드백을 남겨주세요. -->

| 태그 | 의미 | 예시 |
|------|------|------|
| `[MUST]` | 반드시 수정 (보안·버그·성능 이슈) | `[MUST] API 키가 로그에 노출됩니다.` |
| `[SHOULD]` | 수정 강권 (코드 품질·유지보수성) | `[SHOULD] 이 로직은 별도 함수로 분리하는 것이 좋습니다.` |
| `[NITS]` | 사소한 개선 (스타일·네이밍) | `[NITS] 변수명을 \`result\`보다 \`parsed_output\`이 명확합니다.` |
| `[QUESTION]` | 이해를 위한 질문 | `[QUESTION] 이 조건이 항상 True일 수 있지 않나요?` |

