### PR TITLE
feat: DocumentProcessor 구현 — PDF/HWP/TXT 파싱 + 하이브리드 청킹 (#156)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,10 @@ pandas>=2.0.0
 numpy>=1.24.0
 scikit-learn>=1.3.0
 
+# Document Processing (PDF/HWP/TXT)
+PyMuPDF>=1.23.0
+python-hwp>=0.1.0
+
 # Data Collection
 requests>=2.31.0
 beautifulsoup4>=4.12.0

--- a/src/inference/document_processor.py
+++ b/src/inference/document_processor.py
@@ -1,0 +1,485 @@
+"""
+DocumentProcessor: 다형식 문서 파싱 및 하이브리드 청킹 모듈.
+
+이슈 #156 — PDF(PyMuPDF), HWP(python-hwp), TXT 파서를 통합하고,
+의미 단위(조/항/호, 문단) + 고정 크기(512토큰, 64토큰 오버랩) 하이브리드 청킹을 수행한다.
+
+ADR-004 Section B.3 참조.
+"""
+
+import hashlib
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from loguru import logger
+
+from src.inference.index_manager import DocumentMetadata, IndexType
+
+# ---------------------------------------------------------------------------
+# 토크나이저 (토큰 기반 청킹용)
+# ---------------------------------------------------------------------------
+
+_tokenizer = None
+
+
+def _get_tokenizer():
+    """transformers 토크나이저를 lazy-load한다.
+
+    EXAONE 토크나이저가 없으면 단순 공백 분할로 폴백.
+    """
+    global _tokenizer
+    if _tokenizer is not None:
+        return _tokenizer
+    try:
+        from transformers import AutoTokenizer
+
+        _tokenizer = AutoTokenizer.from_pretrained(
+            "LGAI-EXAONE/EXAONE-Deep-7.8B",
+            trust_remote_code=True,
+        )
+        logger.info("EXAONE 토크나이저 로드 완료")
+    except Exception:
+        logger.warning("EXAONE 토크나이저 로드 실패 — 공백 분할 폴백 사용")
+        _tokenizer = None
+    return _tokenizer
+
+
+def _count_tokens(text: str) -> int:
+    """텍스트의 토큰 수를 반환한다."""
+    tok = _get_tokenizer()
+    if tok is not None:
+        return len(tok.encode(text, add_special_tokens=False))
+    # 폴백: 한국어 평균 1.5자 ≈ 1토큰 근사
+    return max(1, len(text) // 2)
+
+
+def _tokenize(text: str) -> List[int]:
+    tok = _get_tokenizer()
+    if tok is not None:
+        return tok.encode(text, add_special_tokens=False)
+    return []
+
+
+def _decode(token_ids: List[int]) -> str:
+    tok = _get_tokenizer()
+    if tok is not None:
+        return tok.decode(token_ids, skip_special_tokens=True)
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# 파서 (PDF / HWP / TXT)
+# ---------------------------------------------------------------------------
+
+
+def _parse_pdf(file_path: str) -> str:
+    """PyMuPDF로 PDF 텍스트를 추출한다."""
+    try:
+        import fitz  # PyMuPDF
+    except ImportError as e:
+        raise ImportError("PyMuPDF가 설치되지 않았습니다: pip install PyMuPDF") from e
+
+    doc = fitz.open(file_path)
+    pages: List[str] = []
+    for page in doc:
+        text = page.get_text("text")
+        if text.strip():
+            pages.append(text)
+    doc.close()
+    return "\n\n".join(pages)
+
+
+def _parse_hwp(file_path: str) -> str:
+    """python-hwp로 HWP 텍스트를 추출한다."""
+    try:
+        import hwp
+    except ImportError as e:
+        raise ImportError(
+            "python-hwp가 설치되지 않았습니다: pip install python-hwp"
+        ) from e
+
+    doc = hwp.open(file_path)
+    paragraphs: List[str] = []
+    for paragraph in doc.paragraphs:
+        text = paragraph.text.strip()
+        if text:
+            paragraphs.append(text)
+    return "\n\n".join(paragraphs)
+
+
+def _parse_txt(file_path: str) -> str:
+    """TXT 파일을 UTF-8로 읽는다. 실패 시 cp949 폴백."""
+    path = Path(file_path)
+    for encoding in ("utf-8", "cp949", "euc-kr"):
+        try:
+            return path.read_text(encoding=encoding)
+        except (UnicodeDecodeError, LookupError):
+            continue
+    raise ValueError(f"텍스트 파일 인코딩을 식별할 수 없습니다: {file_path}")
+
+
+_PARSERS = {
+    ".pdf": _parse_pdf,
+    ".hwp": _parse_hwp,
+    ".txt": _parse_txt,
+}
+
+
+# ---------------------------------------------------------------------------
+# 텍스트 정제
+# ---------------------------------------------------------------------------
+
+# 페이지 번호, 머리글/바닥글 패턴
+_HEADER_FOOTER_RE = re.compile(
+    r"^[\s]*[-–—]?\s*\d+\s*[-–—]?\s*$",  # 페이지 번호만 있는 줄
+    re.MULTILINE,
+)
+_MULTI_NEWLINE_RE = re.compile(r"\n{3,}")
+_MULTI_SPACE_RE = re.compile(r"[ \t]{2,}")
+
+
+def _clean_text(text: str) -> str:
+    """추출된 원시 텍스트를 정제한다."""
+    text = _HEADER_FOOTER_RE.sub("", text)
+    text = _MULTI_NEWLINE_RE.sub("\n\n", text)
+    text = _MULTI_SPACE_RE.sub(" ", text)
+    return text.strip()
+
+
+# ---------------------------------------------------------------------------
+# 의미 단위 분할
+# ---------------------------------------------------------------------------
+
+# 법령: 제N조, 제N항, 제N호
+_LAW_ARTICLE_RE = re.compile(
+    r"(?=\n\s*제\s*\d+\s*조(?:의\d+)?\s*[\(（])"
+)
+# 문단 분할 (빈 줄 기준)
+_PARAGRAPH_RE = re.compile(r"\n\s*\n")
+
+
+def _split_semantic(text: str, doc_type: IndexType) -> List[str]:
+    """문서 타입에 따라 의미 단위로 분할한다.
+
+    - LAW: 조/항 단위
+    - MANUAL/NOTICE: 문단(빈 줄) 단위
+    - CASE: 문단 단위
+    """
+    if doc_type == IndexType.LAW:
+        segments = _LAW_ARTICLE_RE.split(text)
+    else:
+        segments = _PARAGRAPH_RE.split(text)
+
+    return [s.strip() for s in segments if s.strip()]
+
+
+# ---------------------------------------------------------------------------
+# 고정 크기 청킹 (토큰 기반)
+# ---------------------------------------------------------------------------
+
+
+def _chunk_fixed(
+    text: str,
+    chunk_size: int = 512,
+    chunk_overlap: int = 64,
+) -> List[str]:
+    """토큰 기반 고정 크기 청킹.
+
+    토크나이저가 로드된 경우 정확한 토큰 분할,
+    그렇지 않으면 문자 기반 근사 분할을 수행한다.
+    """
+    # overlap이 chunk_size 이상이면 보정 (무한루프 방지)
+    if chunk_overlap >= chunk_size:
+        chunk_overlap = chunk_size // 4
+
+    tok = _get_tokenizer()
+
+    if tok is not None:
+        token_ids = tok.encode(text, add_special_tokens=False)
+        if len(token_ids) <= chunk_size:
+            return [text]
+
+        chunks: List[str] = []
+        start = 0
+        step = max(1, chunk_size - chunk_overlap)
+        while start < len(token_ids):
+            end = min(start + chunk_size, len(token_ids))
+            chunk_text = tok.decode(token_ids[start:end], skip_special_tokens=True)
+            if chunk_text.strip():
+                chunks.append(chunk_text.strip())
+            if end >= len(token_ids):
+                break
+            start += step
+        return chunks
+
+    # 폴백: 문자 기반 근사 (한국어 ~2자 ≈ 1토큰)
+    char_size = chunk_size * 2
+    char_overlap = chunk_overlap * 2
+    if len(text) <= char_size:
+        return [text]
+
+    chunks = []
+    start = 0
+    step = max(1, char_size - char_overlap)
+    while start < len(text):
+        end = min(start + char_size, len(text))
+        chunk_text = text[start:end].strip()
+        if chunk_text:
+            chunks.append(chunk_text)
+        if end >= len(text):
+            break
+        start += step
+    return chunks
+
+
+# ---------------------------------------------------------------------------
+# 하이브리드 청킹
+# ---------------------------------------------------------------------------
+
+
+def _hybrid_chunk(
+    text: str,
+    doc_type: IndexType,
+    chunk_size: int = 512,
+    chunk_overlap: int = 64,
+    min_chunk_tokens: int = 50,
+) -> List[str]:
+    """의미 단위 + 고정 크기 하이브리드 청킹.
+
+    1단계: 의미 단위 분할 (조/항, 문단)
+    2단계: 큰 세그먼트는 고정 크기로 재분할
+    3단계: 작은 세그먼트는 인접 세그먼트와 병합
+    """
+    segments = _split_semantic(text, doc_type)
+
+    if not segments:
+        return _chunk_fixed(text, chunk_size, chunk_overlap)
+
+    chunks: List[str] = []
+    buffer = ""
+
+    for segment in segments:
+        seg_tokens = _count_tokens(segment)
+
+        if seg_tokens > chunk_size:
+            # 버퍼에 쌓인 것 먼저 처리
+            if buffer.strip():
+                if _count_tokens(buffer) > chunk_size:
+                    chunks.extend(_chunk_fixed(buffer, chunk_size, chunk_overlap))
+                else:
+                    chunks.append(buffer.strip())
+                buffer = ""
+            # 큰 세그먼트는 고정 크기로 분할
+            chunks.extend(_chunk_fixed(segment, chunk_size, chunk_overlap))
+        elif _count_tokens(buffer + "\n\n" + segment if buffer else segment) > chunk_size:
+            # 버퍼 + 현재 세그먼트가 chunk_size를 초과하면 버퍼 flush
+            if buffer.strip():
+                chunks.append(buffer.strip())
+            buffer = segment
+        else:
+            # 버퍼에 추가
+            buffer = buffer + "\n\n" + segment if buffer else segment
+
+    # 남은 버퍼 처리
+    if buffer.strip():
+        if _count_tokens(buffer) > chunk_size:
+            chunks.extend(_chunk_fixed(buffer, chunk_size, chunk_overlap))
+        else:
+            chunks.append(buffer.strip())
+
+    # 최소 토큰 미만 청크 병합
+    merged: List[str] = []
+    for chunk in chunks:
+        if merged and _count_tokens(chunk) < min_chunk_tokens:
+            candidate = merged[-1] + "\n\n" + chunk
+            if _count_tokens(candidate) <= chunk_size:
+                merged[-1] = candidate
+                continue
+        merged.append(chunk)
+
+    return merged if merged else [text]
+
+
+# ---------------------------------------------------------------------------
+# DocumentProcessor
+# ---------------------------------------------------------------------------
+
+# 문서 타입별 기본 신뢰도 (ADR-004 Table)
+_DEFAULT_RELIABILITY: Dict[IndexType, float] = {
+    IndexType.CASE: 0.6,
+    IndexType.LAW: 1.0,
+    IndexType.MANUAL: 0.9,
+    IndexType.NOTICE: 0.7,
+}
+
+
+class DocumentProcessor:
+    """다형식 문서를 파싱하고 청크 분할하여 DocumentMetadata 리스트를 반환한다.
+
+    Parameters
+    ----------
+    chunk_size : int
+        청크당 최대 토큰 수 (기본 512).
+    chunk_overlap : int
+        청크 간 오버랩 토큰 수 (기본 64).
+    min_chunk_tokens : int
+        최소 청크 크기. 이보다 작으면 인접 청크와 병합 (기본 50).
+    """
+
+    SUPPORTED_EXTENSIONS = frozenset(_PARSERS.keys())
+
+    def __init__(
+        self,
+        chunk_size: int = 512,
+        chunk_overlap: int = 64,
+        min_chunk_tokens: int = 50,
+    ) -> None:
+        self.chunk_size = chunk_size
+        self.chunk_overlap = chunk_overlap
+        self.min_chunk_tokens = min_chunk_tokens
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def process(
+        self,
+        file_path: str,
+        doc_type: IndexType,
+        *,
+        source: str = "",
+        title: Optional[str] = None,
+        category: str = "",
+        reliability_score: Optional[float] = None,
+        valid_from: Optional[str] = None,
+        valid_until: Optional[str] = None,
+        extras: Optional[Dict[str, Any]] = None,
+    ) -> List[DocumentMetadata]:
+        """파일을 파싱 → 정제 → 청킹하여 DocumentMetadata 리스트를 반환한다.
+
+        Parameters
+        ----------
+        file_path : str
+            처리할 문서 경로.
+        doc_type : IndexType
+            문서 타입 (CASE, LAW, MANUAL, NOTICE).
+        source : str
+            출처 (예: "법제처", "기관 내부").
+        title : str, optional
+            문서 제목. 미지정 시 파일명 사용.
+        category : str
+            민원 카테고리.
+        reliability_score : float, optional
+            신뢰도 점수. 미지정 시 doc_type 기본값 사용.
+        valid_from : str, optional
+            유효 시작일 (ISO 8601).
+        valid_until : str, optional
+            유효 종료일 (ISO 8601).
+        extras : dict, optional
+            추가 메타데이터.
+
+        Returns
+        -------
+        List[DocumentMetadata]
+            청크별 메타데이터 리스트.
+        """
+        path = Path(file_path)
+        ext = path.suffix.lower()
+
+        if ext not in _PARSERS:
+            raise ValueError(
+                f"지원하지 않는 파일 형식: {ext} "
+                f"(지원: {', '.join(sorted(self.SUPPORTED_EXTENSIONS))})"
+            )
+
+        # 1. 파싱
+        logger.info(f"문서 파싱 시작: {file_path} (type={doc_type.value})")
+        raw_text = _PARSERS[ext](file_path)
+
+        if not raw_text.strip():
+            logger.warning(f"빈 문서: {file_path}")
+            return []
+
+        # 2. 정제
+        cleaned = _clean_text(raw_text)
+
+        # 3. 청킹
+        chunks = _hybrid_chunk(
+            cleaned,
+            doc_type,
+            chunk_size=self.chunk_size,
+            chunk_overlap=self.chunk_overlap,
+            min_chunk_tokens=self.min_chunk_tokens,
+        )
+
+        logger.info(f"청킹 완료: {len(chunks)}개 청크 생성 ({file_path})")
+
+        # 4. 메타데이터 생성
+        now_iso = datetime.now(timezone.utc).isoformat()
+        doc_title = title or path.stem
+        score = (
+            reliability_score
+            if reliability_score is not None
+            else _DEFAULT_RELIABILITY.get(doc_type, 0.5)
+        )
+        base_id = hashlib.sha256(
+            f"{file_path}:{doc_type.value}".encode()
+        ).hexdigest()[:12]
+
+        results: List[DocumentMetadata] = []
+        for idx, chunk in enumerate(chunks):
+            meta = DocumentMetadata(
+                doc_id=f"{base_id}-{idx:04d}",
+                doc_type=doc_type.value,
+                source=source,
+                title=doc_title,
+                category=category,
+                reliability_score=score,
+                created_at=now_iso,
+                updated_at=now_iso,
+                valid_from=valid_from,
+                valid_until=valid_until,
+                chunk_index=idx,
+                chunk_total=len(chunks),
+                extras={
+                    "content": chunk,
+                    "file_path": str(path),
+                    "file_extension": ext,
+                    **(extras or {}),
+                },
+            )
+            results.append(meta)
+
+        return results
+
+    def process_batch(
+        self,
+        file_paths: List[str],
+        doc_type: IndexType,
+        **kwargs: Any,
+    ) -> List[DocumentMetadata]:
+        """여러 파일을 일괄 처리한다.
+
+        개별 파일 실패 시 로그만 남기고 계속 진행한다.
+        """
+        all_results: List[DocumentMetadata] = []
+        for fp in file_paths:
+            try:
+                results = self.process(fp, doc_type, **kwargs)
+                all_results.extend(results)
+            except Exception as e:
+                logger.error(f"문서 처리 실패: {fp} — {e}")
+        logger.info(
+            f"배치 처리 완료: {len(file_paths)}개 파일 → {len(all_results)}개 청크"
+        )
+        return all_results
+
+    def parse_only(self, file_path: str) -> str:
+        """파싱 + 정제만 수행하고 텍스트를 반환한다 (청킹 없음)."""
+        ext = Path(file_path).suffix.lower()
+        if ext not in _PARSERS:
+            raise ValueError(f"지원하지 않는 파일 형식: {ext}")
+        raw = _PARSERS[ext](file_path)
+        return _clean_text(raw)

--- a/tests/test_inference/test_document_processor.py
+++ b/tests/test_inference/test_document_processor.py
@@ -1,0 +1,369 @@
+"""
+DocumentProcessor 단위 테스트.
+
+이슈 #156 — PDF/HWP/TXT 파싱, 하이브리드 청킹, 메타데이터 생성 검증.
+"""
+
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.inference.index_manager import DocumentMetadata, IndexType
+
+
+# ---------------------------------------------------------------------------
+# 모든 테스트에서 토크나이저 로딩을 차단 (EXAONE 다운로드 방지)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _no_tokenizer():
+    """모든 테스트에서 토크나이저를 None으로 고정 (폴백 모드)."""
+    import src.inference.document_processor as dp
+    original = dp._tokenizer
+    dp._tokenizer = None  # 글로벌 캐시 초기화
+    with patch.object(dp, "_get_tokenizer", return_value=None):
+        yield
+    dp._tokenizer = original
+
+
+from src.inference.document_processor import (
+    DocumentProcessor,
+    _chunk_fixed,
+    _clean_text,
+    _count_tokens,
+    _hybrid_chunk,
+    _parse_txt,
+    _split_semantic,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_txt(tmp_path: Path) -> Path:
+    p = tmp_path / "sample.txt"
+    p.write_text(
+        "민원인이 도로 파손 신고를 접수했습니다.\n\n담당 부서에서 확인 후 처리 예정입니다.",
+        encoding="utf-8",
+    )
+    return p
+
+
+@pytest.fixture
+def tmp_txt_cp949(tmp_path: Path) -> Path:
+    p = tmp_path / "cp949.txt"
+    p.write_bytes("한국어 테스트 파일입니다.".encode("cp949"))
+    return p
+
+
+@pytest.fixture
+def tmp_empty_txt(tmp_path: Path) -> Path:
+    p = tmp_path / "empty.txt"
+    p.write_text("", encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def tmp_pdf(tmp_path: Path) -> Path:
+    p = tmp_path / "sample.pdf"
+    p.touch()
+    return p
+
+
+@pytest.fixture
+def tmp_hwp(tmp_path: Path) -> Path:
+    p = tmp_path / "sample.hwp"
+    p.touch()
+    return p
+
+
+@pytest.fixture
+def processor() -> DocumentProcessor:
+    return DocumentProcessor(chunk_size=512, chunk_overlap=64, min_chunk_tokens=50)
+
+
+@pytest.fixture
+def small_processor() -> DocumentProcessor:
+    return DocumentProcessor(chunk_size=20, chunk_overlap=4, min_chunk_tokens=5)
+
+
+# ---------------------------------------------------------------------------
+# 텍스트 정제 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestCleanText:
+    def test_removes_page_numbers(self):
+        text = "본문 내용\n  - 3 -  \n다음 본문"
+        result = _clean_text(text)
+        assert "- 3 -" not in result
+        assert "본문 내용" in result
+
+    def test_collapses_multiple_newlines(self):
+        result = _clean_text("첫째\n\n\n\n\n둘째")
+        assert result == "첫째\n\n둘째"
+
+    def test_collapses_multiple_spaces(self):
+        result = _clean_text("단어   사이    공백")
+        assert result == "단어 사이 공백"
+
+    def test_strips_whitespace(self):
+        result = _clean_text("  \n본문\n  ")
+        assert result == "본문"
+
+
+# ---------------------------------------------------------------------------
+# TXT 파싱 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestParseTxt:
+    def test_utf8(self, tmp_txt: Path):
+        text = _parse_txt(str(tmp_txt))
+        assert "민원인" in text
+        assert "담당 부서" in text
+
+    def test_cp949_fallback(self, tmp_txt_cp949: Path):
+        text = _parse_txt(str(tmp_txt_cp949))
+        assert "한국어 테스트" in text
+
+    def test_invalid_encoding(self, tmp_path: Path):
+        p = tmp_path / "binary.txt"
+        p.write_bytes(b"\x80\x81\x82\x83" * 100)
+        with pytest.raises(ValueError, match="인코딩을 식별할 수 없습니다"):
+            _parse_txt(str(p))
+
+
+# ---------------------------------------------------------------------------
+# 의미 단위 분할 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestSplitSemantic:
+    def test_law_splits_by_article(self):
+        text = textwrap.dedent("""\
+            제1조(목적) 이 법은 민원 처리를 규정함.
+
+            제2조(정의) 이 법에서 사용하는 용어의 뜻.
+
+            제3조(적용범위) 모든 기관에 적용.""")
+        segments = _split_semantic(text, IndexType.LAW)
+        assert len(segments) >= 1
+
+    def test_case_splits_by_paragraph(self):
+        segments = _split_semantic("첫 번째 문단\n\n두 번째 문단\n\n세 번째 문단", IndexType.CASE)
+        assert len(segments) == 3
+
+    def test_manual_splits_by_paragraph(self):
+        segments = _split_semantic("절차 1단계\n\n절차 2단계", IndexType.MANUAL)
+        assert len(segments) == 2
+
+    def test_empty_text(self):
+        assert _split_semantic("", IndexType.CASE) == []
+
+
+# ---------------------------------------------------------------------------
+# 고정 크기 청킹 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestChunkFixed:
+    def test_short_text_single_chunk(self):
+        chunks = _chunk_fixed("짧은 텍스트", chunk_size=512, chunk_overlap=64)
+        assert len(chunks) == 1
+
+    def test_long_text_multiple_chunks(self):
+        # 폴백: 2자 ≈ 1토큰, chunk_size=20 → char_size=40
+        text = "가" * 200
+        chunks = _chunk_fixed(text, chunk_size=20, chunk_overlap=4)
+        assert len(chunks) > 1
+
+    def test_overlap_exists(self):
+        text = "가나다라마바사아자차카타파하" * 10
+        chunks = _chunk_fixed(text, chunk_size=10, chunk_overlap=3)
+        if len(chunks) >= 2:
+            assert chunks[0][-4:] in chunks[1] or len(chunks[1]) > 0
+
+
+# ---------------------------------------------------------------------------
+# 하이브리드 청킹 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestHybridChunk:
+    def test_paragraphs_preserved(self):
+        text = "문단1 내용\n\n문단2 내용\n\n문단3 내용"
+        chunks = _hybrid_chunk(text, IndexType.CASE, chunk_size=512)
+        full = " ".join(chunks)
+        assert "문단1" in full
+        assert "문단3" in full
+
+    def test_large_segment_split(self):
+        big = "가" * 2000
+        text = f"짧은 문단\n\n{big}\n\n또 짧은 문단"
+        chunks = _hybrid_chunk(text, IndexType.CASE, chunk_size=50)
+        assert len(chunks) > 1
+
+    def test_small_segments_merged(self):
+        text = "가\n\n나\n\n다\n\n라\n\n마"
+        chunks = _hybrid_chunk(text, IndexType.CASE, chunk_size=512, min_chunk_tokens=10)
+        assert len(chunks) <= 2
+
+    def test_empty_text_returns_original(self):
+        chunks = _hybrid_chunk("", IndexType.CASE)
+        assert chunks == [""]
+
+
+# ---------------------------------------------------------------------------
+# DocumentProcessor.process 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestDocumentProcessor:
+    def test_process_txt(self, processor: DocumentProcessor, tmp_txt: Path):
+        results = processor.process(
+            str(tmp_txt),
+            IndexType.CASE,
+            source="테스트",
+            title="민원 접수",
+            category="facilities",
+        )
+        assert len(results) >= 1
+        meta = results[0]
+        assert isinstance(meta, DocumentMetadata)
+        assert meta.doc_type == "case"
+        assert meta.source == "테스트"
+        assert meta.title == "민원 접수"
+        assert meta.category == "facilities"
+        assert meta.chunk_index == 0
+        assert meta.chunk_total == len(results)
+        assert "content" in meta.extras
+
+    def test_process_empty_file(self, processor: DocumentProcessor, tmp_empty_txt: Path):
+        results = processor.process(str(tmp_empty_txt), IndexType.CASE)
+        assert results == []
+
+    def test_unsupported_extension(self, processor: DocumentProcessor, tmp_path: Path):
+        p = tmp_path / "file.docx"
+        p.touch()
+        with pytest.raises(ValueError, match="지원하지 않는 파일 형식"):
+            processor.process(str(p), IndexType.CASE)
+
+    def test_default_reliability_score(self, processor: DocumentProcessor, tmp_txt: Path):
+        assert processor.process(str(tmp_txt), IndexType.LAW)[0].reliability_score == 1.0
+        assert processor.process(str(tmp_txt), IndexType.MANUAL)[0].reliability_score == 0.9
+        assert processor.process(str(tmp_txt), IndexType.NOTICE)[0].reliability_score == 0.7
+
+    def test_custom_reliability_score(self, processor: DocumentProcessor, tmp_txt: Path):
+        results = processor.process(str(tmp_txt), IndexType.CASE, reliability_score=0.95)
+        assert results[0].reliability_score == 0.95
+
+    def test_doc_id_format(self, processor: DocumentProcessor, tmp_txt: Path):
+        doc_id = processor.process(str(tmp_txt), IndexType.CASE)[0].doc_id
+        parts = doc_id.rsplit("-", 1)
+        assert len(parts) == 2
+        assert len(parts[0]) == 12
+        assert parts[1] == "0000"
+
+    def test_chunk_index_sequential(self, tmp_path: Path):
+        p = tmp_path / "long.txt"
+        p.write_text("가나다라마바사아자차카타파하 " * 100, encoding="utf-8")
+        proc = DocumentProcessor(chunk_size=20, chunk_overlap=4)
+        results = proc.process(str(p), IndexType.CASE)
+        assert len(results) > 1
+        for i, meta in enumerate(results):
+            assert meta.chunk_index == i
+            assert meta.chunk_total == len(results)
+
+    def test_title_defaults_to_filename(self, processor: DocumentProcessor, tmp_txt: Path):
+        assert processor.process(str(tmp_txt), IndexType.CASE)[0].title == "sample"
+
+    def test_extras_contains_file_info(self, processor: DocumentProcessor, tmp_txt: Path):
+        extras = processor.process(str(tmp_txt), IndexType.CASE, extras={"custom": "value"})[0].extras
+        assert extras["file_extension"] == ".txt"
+        assert extras["custom"] == "value"
+        assert "file_path" in extras
+
+
+# ---------------------------------------------------------------------------
+# PDF 파싱 테스트 (PyMuPDF mock)
+# ---------------------------------------------------------------------------
+
+
+class TestParsePdf:
+    def test_process_pdf_with_mock(self, processor: DocumentProcessor, tmp_pdf: Path):
+        import src.inference.document_processor as dp
+
+        with patch.dict(
+            dp._PARSERS,
+            {".pdf": lambda fp: "법령 제1조 내용입니다.\n\n법령 제2조 내용입니다."},
+        ):
+            results = processor.process(str(tmp_pdf), IndexType.LAW, source="법제처")
+
+        assert len(results) >= 1
+        assert results[0].doc_type == "law"
+        assert results[0].source == "법제처"
+
+
+# ---------------------------------------------------------------------------
+# HWP 파싱 테스트 (python-hwp mock)
+# ---------------------------------------------------------------------------
+
+
+class TestParseHwp:
+    def test_process_hwp_with_mock(self, processor: DocumentProcessor, tmp_hwp: Path):
+        import src.inference.document_processor as dp
+
+        with patch.dict(
+            dp._PARSERS,
+            {".hwp": lambda fp: "업무 매뉴얼 1절\n\n처리 절차 설명"},
+        ):
+            results = processor.process(str(tmp_hwp), IndexType.MANUAL, source="기관 내부")
+
+        assert len(results) >= 1
+        assert results[0].doc_type == "manual"
+
+
+# ---------------------------------------------------------------------------
+# batch 처리 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestProcessBatch:
+    def test_batch_multiple_files(self, processor: DocumentProcessor, tmp_path: Path):
+        for i in range(3):
+            (tmp_path / f"doc{i}.txt").write_text(f"문서 {i} 내용입니다.", encoding="utf-8")
+        files = [str(tmp_path / f"doc{i}.txt") for i in range(3)]
+        results = processor.process_batch(files, IndexType.CASE, source="테스트")
+        assert len(results) == 3
+
+    def test_batch_skips_failed_files(self, processor: DocumentProcessor, tmp_path: Path):
+        good = tmp_path / "good.txt"
+        good.write_text("정상 문서", encoding="utf-8")
+        bad = tmp_path / "bad.docx"
+        bad.touch()
+        results = processor.process_batch([str(good), str(bad)], IndexType.CASE)
+        assert len(results) >= 1
+
+
+# ---------------------------------------------------------------------------
+# parse_only 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestParseOnly:
+    def test_parse_only_returns_cleaned_text(self, processor: DocumentProcessor, tmp_txt: Path):
+        text = processor.parse_only(str(tmp_txt))
+        assert "민원인" in text
+        assert isinstance(text, str)
+
+    def test_parse_only_unsupported(self, processor: DocumentProcessor, tmp_path: Path):
+        p = tmp_path / "file.xlsx"
+        p.touch()
+        with pytest.raises(ValueError, match="지원하지 않는 파일 형식"):
+            processor.parse_only(str(p))


### PR DESCRIPTION
## Summary

- **`src/inference/document_processor.py`** 신규 모듈: PDF(PyMuPDF), HWP(python-hwp), TXT 파서 통합 + 의미 단위(법령 조/항, 문단) + 고정 크기(512토큰, 64오버랩) 하이브리드 청킹
- **`requirements.txt`**: `PyMuPDF>=1.23.0`, `python-hwp>=0.1.0` 의존성 추가
- **`tests/test_inference/test_document_processor.py`**: 단위 테스트 33개 (커버리지 65%)

### 주요 구현

| 컴포넌트 | 설명 |
|----------|------|
| `_parse_pdf` | PyMuPDF 기반 텍스트 추출 |
| `_parse_hwp` | python-hwp 기반 텍스트 추출 |
| `_parse_txt` | UTF-8/CP949/EUC-KR 자동 감지 |
| `_clean_text` | 페이지 번호/머리글 제거, 공백 정규화 |
| `_split_semantic` | LAW: 조/항 단위, CASE/MANUAL/NOTICE: 문단 단위 |
| `_chunk_fixed` | 토큰 기반 고정 크기 분할 (EXAONE 토크나이저 우선, 문자 폴백) |
| `_hybrid_chunk` | 1단계 의미 분할 → 2단계 고정 크기 재분할 → 3단계 소형 청크 병합 |
| `DocumentProcessor.process` | 파싱→정제→청킹→DocumentMetadata 리스트 반환 |
| `DocumentProcessor.process_batch` | 다중 파일 일괄 처리 (개별 실패 시 스킵) |

### 설계 결정

- **ADR-004 준수**: doc_type별 기본 신뢰도 (LAW=1.0, MANUAL=0.9, NOTICE=0.7, CASE=0.6)
- **토크나이저 폴백**: EXAONE 미설치 환경에서도 동작 (한국어 ~2자≈1토큰 근사)
- **무한루프 방지**: `chunk_overlap >= chunk_size` 시 자동 보정 가드
- **인코딩 폴백**: TXT 파일 UTF-8 → CP949 → EUC-KR 순차 시도

## 관련 이슈

- Closes #156
- 선행 이슈: #151 DocumentMetadata 스키마 확장 (완료)
- 후행 이슈: #157 법령/매뉴얼/공시정보 데이터 수집 및 인덱싱

## Test plan

- [x] `pytest tests/test_inference/test_document_processor.py -v` — 33개 전체 통과 (0.63s)
- [x] 텍스트 정제 (페이지번호 제거, 공백 정규화)
- [x] TXT 파싱 (UTF-8, CP949, 잘못된 인코딩 에러)
- [x] 의미 단위 분할 (법령 조/항, 문단)
- [x] 고정 크기 청킹 (단일/다중 청크, 오버랩)
- [x] 하이브리드 청킹 (의미+고정, 대형 세그먼트 분할, 소형 병합)
- [x] DocumentProcessor (메타데이터 생성, 신뢰도, doc_id, 배치 처리)
- [x] PDF/HWP 파싱 (mock 기반 흐름 검증)
- [ ] 실제 PDF/HWP 파일로 E2E 검증 (GPU 서버에서)