### PR TITLE
fix: dependabot 자동 승인을 CODEOWNER PAT로 변경

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,14 +21,15 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Approve PR
+      - name: Approve PR (CODEOWNER)
         if: steps.metadata.outputs.package-ecosystem == 'github_actions' || steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: |
           gh pr review "${{ github.event.pull_request.number }}" \
             --approve \
+            --body "Dependabot 자동 승인 (CODEOWNER)" \
             --repo "${{ github.repository }}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.REVIEWER_TOKEN }}
 
       - name: Auto-merge (GitHub Actions — all versions)
         if: steps.metadata.outputs.package-ecosystem == 'github_actions'


### PR DESCRIPTION
## Summary
- dependabot auto-merge 워크플로우의 approve 토큰을 `GITHUB_TOKEN` → `REVIEWER_TOKEN`(umyunsang PAT)으로 변경
- CODEOWNERS에 `* @umyunsang`이 설정되어 있어 dependabot PR에 자동 리뷰 요청 생성됨
- `GITHUB_TOKEN`(github-actions[bot])의 approve로는 CODEOWNER 리뷰 요청을 충족할 수 없음
- umyunsang PAT로 approve하여 CODEOWNER 리뷰 조건 충족 → auto-merge 정상 동작

## Test plan
- [ ] dependabot PR 생성 시 umyunsang으로 자동 approve 되는지 확인
- [ ] approve 후 auto-merge가 정상 동작하는지 확인