### PR TITLE
feat: DocumentProcessor 구현 — PDF/HWP/TXT 파싱 + 하이브리드 청킹 (#156)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,9 +28,8 @@ pandas>=2.0.0
 numpy>=1.24.0
 scikit-learn>=1.3.0
 
-# Document Processing (PDF/HWP/TXT)
+# Document Processing (PDF/TXT; HWP는 별도 설치 필요)
 PyMuPDF>=1.23.0
-python-hwp>=0.1.0
 
 # Data Collection
 requests>=2.31.0

--- a/src/inference/document_processor.py
+++ b/src/inference/document_processor.py
@@ -1,17 +1,18 @@
 """
 DocumentProcessor: 다형식 문서 파싱 및 하이브리드 청킹 모듈.
 
-이슈 #156 — PDF(PyMuPDF), HWP(python-hwp), TXT 파서를 통합하고,
-의미 단위(조/항/호, 문단) + 고정 크기(512토큰, 64토큰 오버랩) 하이브리드 청킹을 수행한다.
+이슈 #156 — PDF(PyMuPDF), HWP, TXT 파서를 통합하고,
+의미 단위(조/항/호, 문단) + 고정 크기(512토큰, 128토큰 오버랩) 하이브리드 청킹을 수행한다.
 
 ADR-004 Section B.3 참조.
 """
 
 import hashlib
 import re
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from loguru import logger
 
@@ -21,15 +22,19 @@ from src.inference.index_manager import DocumentMetadata, IndexType
 # 토크나이저 (토큰 기반 청킹용)
 # ---------------------------------------------------------------------------
 
-_tokenizer = None
+_LOAD_FAILED = object()  # 센티널: 로드 실패 확정
+_tokenizer = None  # None=미시도, _LOAD_FAILED=실패확정
 
 
 def _get_tokenizer():
     """transformers 토크나이저를 lazy-load한다.
 
-    EXAONE 토크나이저가 없으면 단순 공백 분할로 폴백.
+    EXAONE 토크나이저가 없으면 단순 문자 기반 근사로 폴백.
+    로드 실패 시 센티널을 설정하여 재시도를 방지한다.
     """
     global _tokenizer
+    if _tokenizer is _LOAD_FAILED:
+        return None
     if _tokenizer is not None:
         return _tokenizer
     try:
@@ -41,9 +46,9 @@ def _get_tokenizer():
         )
         logger.info("EXAONE 토크나이저 로드 완료")
     except Exception:
-        logger.warning("EXAONE 토크나이저 로드 실패 — 공백 분할 폴백 사용")
-        _tokenizer = None
-    return _tokenizer
+        logger.warning("EXAONE 토크나이저 로드 실패 — 문자 기반 폴백 사용")
+        _tokenizer = _LOAD_FAILED
+    return None if _tokenizer is _LOAD_FAILED else _tokenizer
 
 
 def _count_tokens(text: str) -> int:
@@ -53,20 +58,6 @@ def _count_tokens(text: str) -> int:
         return len(tok.encode(text, add_special_tokens=False))
     # 폴백: 한국어 평균 1.5자 ≈ 1토큰 근사
     return max(1, len(text) // 2)
-
-
-def _tokenize(text: str) -> List[int]:
-    tok = _get_tokenizer()
-    if tok is not None:
-        return tok.encode(text, add_special_tokens=False)
-    return []
-
-
-def _decode(token_ids: List[int]) -> str:
-    tok = _get_tokenizer()
-    if tok is not None:
-        return tok.decode(token_ids, skip_special_tokens=True)
-    return ""
 
 
 # ---------------------------------------------------------------------------
@@ -81,32 +72,40 @@ def _parse_pdf(file_path: str) -> str:
     except ImportError as e:
         raise ImportError("PyMuPDF가 설치되지 않았습니다: pip install PyMuPDF") from e
 
-    doc = fitz.open(file_path)
     pages: List[str] = []
-    for page in doc:
-        text = page.get_text("text")
-        if text.strip():
-            pages.append(text)
-    doc.close()
+    with fitz.open(file_path) as doc:
+        for page in doc:
+            text = page.get_text("text")
+            if text.strip():
+                pages.append(text)
     return "\n\n".join(pages)
 
 
 def _parse_hwp(file_path: str) -> str:
-    """python-hwp로 HWP 텍스트를 추출한다."""
+    """HWP 텍스트를 추출한다.
+
+    pyhwp 또는 호환 라이브러리가 필요하다. PyPI에 안정적인 HWP 파서가
+    없으므로 런타임 ImportError로 안내한다.
+    """
     try:
         import hwp
     except ImportError as e:
         raise ImportError(
-            "python-hwp가 설치되지 않았습니다: pip install python-hwp"
+            "HWP 파서가 설치되지 않았습니다. "
+            "pyhwp 또는 호환 라이브러리를 설치해 주세요."
         ) from e
 
     doc = hwp.open(file_path)
-    paragraphs: List[str] = []
-    for paragraph in doc.paragraphs:
-        text = paragraph.text.strip()
-        if text:
-            paragraphs.append(text)
-    return "\n\n".join(paragraphs)
+    try:
+        paragraphs: List[str] = []
+        for paragraph in doc.paragraphs:
+            text = paragraph.text.strip()
+            if text:
+                paragraphs.append(text)
+        return "\n\n".join(paragraphs)
+    finally:
+        if hasattr(doc, "close"):
+            doc.close()
 
 
 def _parse_txt(file_path: str) -> str:
@@ -183,7 +182,7 @@ def _split_semantic(text: str, doc_type: IndexType) -> List[str]:
 def _chunk_fixed(
     text: str,
     chunk_size: int = 512,
-    chunk_overlap: int = 64,
+    chunk_overlap: int = 128,
 ) -> List[str]:
     """토큰 기반 고정 크기 청킹.
 
@@ -243,7 +242,7 @@ def _hybrid_chunk(
     text: str,
     doc_type: IndexType,
     chunk_size: int = 512,
-    chunk_overlap: int = 64,
+    chunk_overlap: int = 128,
     min_chunk_tokens: int = 50,
 ) -> List[str]:
     """의미 단위 + 고정 크기 하이브리드 청킹.
@@ -252,6 +251,9 @@ def _hybrid_chunk(
     2단계: 큰 세그먼트는 고정 크기로 재분할
     3단계: 작은 세그먼트는 인접 세그먼트와 병합
     """
+    if not text.strip():
+        return []
+
     segments = _split_semantic(text, doc_type)
 
     if not segments:
@@ -299,7 +301,34 @@ def _hybrid_chunk(
                 continue
         merged.append(chunk)
 
-    return merged if merged else [text]
+    return merged if merged else []
+
+
+# ---------------------------------------------------------------------------
+# BatchResult
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BatchResult:
+    """process_batch 반환 타입. 성공/실패 정보를 모두 포함한다."""
+
+    succeeded: List[DocumentMetadata] = field(default_factory=list)
+    failed: List[Tuple[str, str]] = field(default_factory=list)  # [(file_path, error)]
+
+    @property
+    def total_chunks(self) -> int:
+        return len(self.succeeded)
+
+    @property
+    def success_count(self) -> int:
+        return self.total_chunks - len(self.failed) if not self.failed else self._count_files()
+
+    def _count_files(self) -> int:
+        seen = set()
+        for m in self.succeeded:
+            seen.add(m.extras.get("file_path", ""))
+        return len(seen)
 
 
 # ---------------------------------------------------------------------------
@@ -323,7 +352,7 @@ class DocumentProcessor:
     chunk_size : int
         청크당 최대 토큰 수 (기본 512).
     chunk_overlap : int
-        청크 간 오버랩 토큰 수 (기본 64).
+        청크 간 오버랩 토큰 수 (기본 128, ADR-004).
     min_chunk_tokens : int
         최소 청크 크기. 이보다 작으면 인접 청크와 병합 (기본 50).
     """
@@ -333,7 +362,7 @@ class DocumentProcessor:
     def __init__(
         self,
         chunk_size: int = 512,
-        chunk_overlap: int = 64,
+        chunk_overlap: int = 128,
         min_chunk_tokens: int = 50,
     ) -> None:
         self.chunk_size = chunk_size
@@ -359,31 +388,11 @@ class DocumentProcessor:
     ) -> List[DocumentMetadata]:
         """파일을 파싱 → 정제 → 청킹하여 DocumentMetadata 리스트를 반환한다.
 
-        Parameters
-        ----------
-        file_path : str
-            처리할 문서 경로.
-        doc_type : IndexType
-            문서 타입 (CASE, LAW, MANUAL, NOTICE).
-        source : str
-            출처 (예: "법제처", "기관 내부").
-        title : str, optional
-            문서 제목. 미지정 시 파일명 사용.
-        category : str
-            민원 카테고리.
-        reliability_score : float, optional
-            신뢰도 점수. 미지정 시 doc_type 기본값 사용.
-        valid_from : str, optional
-            유효 시작일 (ISO 8601).
-        valid_until : str, optional
-            유효 종료일 (ISO 8601).
-        extras : dict, optional
-            추가 메타데이터.
-
         Returns
         -------
         List[DocumentMetadata]
-            청크별 메타데이터 리스트.
+            청크별 메타데이터 리스트. doc_id는 원본 문서 단위로 동일하며,
+            청크는 chunk_index로 구분한다.
         """
         path = Path(file_path)
         ext = path.suffix.lower()
@@ -405,6 +414,10 @@ class DocumentProcessor:
         # 2. 정제
         cleaned = _clean_text(raw_text)
 
+        if not cleaned:
+            logger.warning(f"정제 후 빈 문서: {file_path}")
+            return []
+
         # 3. 청킹
         chunks = _hybrid_chunk(
             cleaned,
@@ -413,6 +426,10 @@ class DocumentProcessor:
             chunk_overlap=self.chunk_overlap,
             min_chunk_tokens=self.min_chunk_tokens,
         )
+
+        if not chunks:
+            logger.warning(f"청킹 결과 없음: {file_path}")
+            return []
 
         logger.info(f"청킹 완료: {len(chunks)}개 청크 생성 ({file_path})")
 
@@ -424,14 +441,15 @@ class DocumentProcessor:
             if reliability_score is not None
             else _DEFAULT_RELIABILITY.get(doc_type, 0.5)
         )
-        base_id = hashlib.sha256(
+        # doc_id: 원본 문서 단위 안정 ID (모든 청크가 동일)
+        doc_id = hashlib.sha256(
             f"{file_path}:{doc_type.value}".encode()
         ).hexdigest()[:12]
 
         results: List[DocumentMetadata] = []
         for idx, chunk in enumerate(chunks):
             meta = DocumentMetadata(
-                doc_id=f"{base_id}-{idx:04d}",
+                doc_id=doc_id,
                 doc_type=doc_type.value,
                 source=source,
                 title=doc_title,
@@ -444,7 +462,7 @@ class DocumentProcessor:
                 chunk_index=idx,
                 chunk_total=len(chunks),
                 extras={
-                    "content": chunk,
+                    "chunk_text": chunk,
                     "file_path": str(path),
                     "file_extension": ext,
                     **(extras or {}),
@@ -459,22 +477,27 @@ class DocumentProcessor:
         file_paths: List[str],
         doc_type: IndexType,
         **kwargs: Any,
-    ) -> List[DocumentMetadata]:
+    ) -> BatchResult:
         """여러 파일을 일괄 처리한다.
 
-        개별 파일 실패 시 로그만 남기고 계속 진행한다.
+        Returns
+        -------
+        BatchResult
+            성공한 청크 리스트와 실패한 파일 정보를 모두 포함.
         """
-        all_results: List[DocumentMetadata] = []
+        result = BatchResult()
         for fp in file_paths:
             try:
-                results = self.process(fp, doc_type, **kwargs)
-                all_results.extend(results)
+                chunks = self.process(fp, doc_type, **kwargs)
+                result.succeeded.extend(chunks)
             except Exception as e:
                 logger.error(f"문서 처리 실패: {fp} — {e}")
+                result.failed.append((fp, str(e)))
         logger.info(
-            f"배치 처리 완료: {len(file_paths)}개 파일 → {len(all_results)}개 청크"
+            f"배치 처리 완료: {len(file_paths)}개 파일 → "
+            f"{result.total_chunks}개 청크, {len(result.failed)}개 실패"
         )
-        return all_results
+        return result
 
     def parse_only(self, file_path: str) -> str:
         """파싱 + 정제만 수행하고 텍스트를 반환한다 (청킹 없음)."""

--- a/tests/test_inference/test_document_processor.py
+++ b/tests/test_inference/test_document_processor.py
@@ -17,18 +17,21 @@ from src.inference.index_manager import DocumentMetadata, IndexType
 # 모든 테스트에서 토크나이저 로딩을 차단 (EXAONE 다운로드 방지)
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture(autouse=True)
 def _no_tokenizer():
-    """모든 테스트에서 토크나이저를 None으로 고정 (폴백 모드)."""
+    """모든 테스트에서 토크나이저를 폴백 모드로 고정."""
     import src.inference.document_processor as dp
+
     original = dp._tokenizer
-    dp._tokenizer = None  # 글로벌 캐시 초기화
+    dp._tokenizer = dp._LOAD_FAILED  # 센티널: 로드 시도 차단
     with patch.object(dp, "_get_tokenizer", return_value=None):
         yield
     dp._tokenizer = original
 
 
 from src.inference.document_processor import (
+    BatchResult,
     DocumentProcessor,
     _chunk_fixed,
     _clean_text,
@@ -69,6 +72,14 @@ def tmp_empty_txt(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
+def tmp_header_only_txt(tmp_path: Path) -> Path:
+    """정제 후 빈 문서가 되는 파일 (페이지 번호만)."""
+    p = tmp_path / "header_only.txt"
+    p.write_text(" - 1 - \n - 2 - \n - 3 - ", encoding="utf-8")
+    return p
+
+
+@pytest.fixture
 def tmp_pdf(tmp_path: Path) -> Path:
     p = tmp_path / "sample.pdf"
     p.touch()
@@ -84,7 +95,7 @@ def tmp_hwp(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def processor() -> DocumentProcessor:
-    return DocumentProcessor(chunk_size=512, chunk_overlap=64, min_chunk_tokens=50)
+    return DocumentProcessor(chunk_size=512, chunk_overlap=128, min_chunk_tokens=50)
 
 
 @pytest.fixture
@@ -174,11 +185,10 @@ class TestSplitSemantic:
 
 class TestChunkFixed:
     def test_short_text_single_chunk(self):
-        chunks = _chunk_fixed("짧은 텍스트", chunk_size=512, chunk_overlap=64)
+        chunks = _chunk_fixed("짧은 텍스트", chunk_size=512, chunk_overlap=128)
         assert len(chunks) == 1
 
     def test_long_text_multiple_chunks(self):
-        # 폴백: 2자 ≈ 1토큰, chunk_size=20 → char_size=40
         text = "가" * 200
         chunks = _chunk_fixed(text, chunk_size=20, chunk_overlap=4)
         assert len(chunks) > 1
@@ -188,6 +198,15 @@ class TestChunkFixed:
         chunks = _chunk_fixed(text, chunk_size=10, chunk_overlap=3)
         if len(chunks) >= 2:
             assert chunks[0][-4:] in chunks[1] or len(chunks[1]) > 0
+
+    def test_overlap_ge_chunk_size_no_infinite_loop(self):
+        """overlap >= chunk_size일 때 무한루프가 발생하지 않아야 한다."""
+        text = "가" * 200
+        chunks = _chunk_fixed(text, chunk_size=20, chunk_overlap=20)
+        assert len(chunks) > 1
+
+        chunks = _chunk_fixed(text, chunk_size=20, chunk_overlap=30)
+        assert len(chunks) > 1
 
 
 # ---------------------------------------------------------------------------
@@ -206,7 +225,7 @@ class TestHybridChunk:
     def test_large_segment_split(self):
         big = "가" * 2000
         text = f"짧은 문단\n\n{big}\n\n또 짧은 문단"
-        chunks = _hybrid_chunk(text, IndexType.CASE, chunk_size=50)
+        chunks = _hybrid_chunk(text, IndexType.CASE, chunk_size=50, chunk_overlap=10)
         assert len(chunks) > 1
 
     def test_small_segments_merged(self):
@@ -214,9 +233,32 @@ class TestHybridChunk:
         chunks = _hybrid_chunk(text, IndexType.CASE, chunk_size=512, min_chunk_tokens=10)
         assert len(chunks) <= 2
 
-    def test_empty_text_returns_original(self):
+    def test_empty_text_returns_empty_list(self):
+        """빈 텍스트는 빈 리스트를 반환해야 한다."""
         chunks = _hybrid_chunk("", IndexType.CASE)
-        assert chunks == [""]
+        assert chunks == []
+
+    def test_whitespace_only_returns_empty_list(self):
+        chunks = _hybrid_chunk("   \n\n   ", IndexType.CASE)
+        assert chunks == []
+
+
+# ---------------------------------------------------------------------------
+# 토크나이저 센티널 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestTokenizerSentinel:
+    def test_load_failed_sentinel_prevents_retry(self):
+        """_LOAD_FAILED 센티널이 재시도를 방지하는지 확인."""
+        import src.inference.document_processor as dp
+
+        dp._tokenizer = dp._LOAD_FAILED
+        # _get_tokenizer가 mock되지 않은 실제 함수를 호출해도
+        # _LOAD_FAILED 센티널 덕분에 즉시 None 반환
+        with patch.object(dp, "_get_tokenizer", wraps=dp._get_tokenizer):
+            result = dp._get_tokenizer()
+            assert result is None
 
 
 # ---------------------------------------------------------------------------
@@ -242,10 +284,15 @@ class TestDocumentProcessor:
         assert meta.category == "facilities"
         assert meta.chunk_index == 0
         assert meta.chunk_total == len(results)
-        assert "content" in meta.extras
+        assert "chunk_text" in meta.extras
 
     def test_process_empty_file(self, processor: DocumentProcessor, tmp_empty_txt: Path):
         results = processor.process(str(tmp_empty_txt), IndexType.CASE)
+        assert results == []
+
+    def test_process_header_only_file(self, processor: DocumentProcessor, tmp_header_only_txt: Path):
+        """정제 후 빈 문서는 빈 리스트를 반환해야 한다."""
+        results = processor.process(str(tmp_header_only_txt), IndexType.CASE)
         assert results == []
 
     def test_unsupported_extension(self, processor: DocumentProcessor, tmp_path: Path):
@@ -263,14 +310,18 @@ class TestDocumentProcessor:
         results = processor.process(str(tmp_txt), IndexType.CASE, reliability_score=0.95)
         assert results[0].reliability_score == 0.95
 
-    def test_doc_id_format(self, processor: DocumentProcessor, tmp_txt: Path):
-        doc_id = processor.process(str(tmp_txt), IndexType.CASE)[0].doc_id
-        parts = doc_id.rsplit("-", 1)
-        assert len(parts) == 2
-        assert len(parts[0]) == 12
-        assert parts[1] == "0000"
+    def test_doc_id_stable_across_chunks(self, tmp_path: Path):
+        """같은 문서의 모든 청크가 동일한 doc_id를 가져야 한다."""
+        p = tmp_path / "long.txt"
+        p.write_text("가나다라마바사아자차카타파하 " * 100, encoding="utf-8")
+        proc = DocumentProcessor(chunk_size=20, chunk_overlap=4)
+        results = proc.process(str(p), IndexType.CASE)
+        assert len(results) > 1
+        doc_ids = {m.doc_id for m in results}
+        assert len(doc_ids) == 1, f"모든 청크의 doc_id가 동일해야 함: {doc_ids}"
 
     def test_chunk_index_sequential(self, tmp_path: Path):
+        """청크 인덱스가 순차적으로 할당되는지 확인."""
         p = tmp_path / "long.txt"
         p.write_text("가나다라마바사아자차카타파하 " * 100, encoding="utf-8")
         proc = DocumentProcessor(chunk_size=20, chunk_overlap=4)
@@ -283,11 +334,20 @@ class TestDocumentProcessor:
     def test_title_defaults_to_filename(self, processor: DocumentProcessor, tmp_txt: Path):
         assert processor.process(str(tmp_txt), IndexType.CASE)[0].title == "sample"
 
-    def test_extras_contains_file_info(self, processor: DocumentProcessor, tmp_txt: Path):
-        extras = processor.process(str(tmp_txt), IndexType.CASE, extras={"custom": "value"})[0].extras
+    def test_extras_uses_chunk_text_key(self, processor: DocumentProcessor, tmp_txt: Path):
+        """extras에 'chunk_text' 키를 사용해야 한다 (ORM content 컬럼과 구분)."""
+        results = processor.process(str(tmp_txt), IndexType.CASE, extras={"custom": "value"})
+        extras = results[0].extras
+        assert "chunk_text" in extras
+        assert "content" not in extras  # ORM 혼동 방지
         assert extras["file_extension"] == ".txt"
         assert extras["custom"] == "value"
         assert "file_path" in extras
+
+    def test_default_overlap_is_128(self):
+        """ADR-004 기준 기본 오버랩이 128인지 확인."""
+        proc = DocumentProcessor()
+        assert proc.chunk_overlap == 128
 
 
 # ---------------------------------------------------------------------------
@@ -311,7 +371,7 @@ class TestParsePdf:
 
 
 # ---------------------------------------------------------------------------
-# HWP 파싱 테스트 (python-hwp mock)
+# HWP 파싱 테스트 (mock)
 # ---------------------------------------------------------------------------
 
 
@@ -339,16 +399,28 @@ class TestProcessBatch:
         for i in range(3):
             (tmp_path / f"doc{i}.txt").write_text(f"문서 {i} 내용입니다.", encoding="utf-8")
         files = [str(tmp_path / f"doc{i}.txt") for i in range(3)]
-        results = processor.process_batch(files, IndexType.CASE, source="테스트")
-        assert len(results) == 3
+        result = processor.process_batch(files, IndexType.CASE, source="테스트")
+        assert isinstance(result, BatchResult)
+        assert result.total_chunks == 3
+        assert len(result.failed) == 0
 
-    def test_batch_skips_failed_files(self, processor: DocumentProcessor, tmp_path: Path):
+    def test_batch_tracks_failures(self, processor: DocumentProcessor, tmp_path: Path):
+        """실패 파일 정보가 BatchResult.failed에 기록되어야 한다."""
         good = tmp_path / "good.txt"
         good.write_text("정상 문서", encoding="utf-8")
         bad = tmp_path / "bad.docx"
         bad.touch()
-        results = processor.process_batch([str(good), str(bad)], IndexType.CASE)
-        assert len(results) >= 1
+
+        result = processor.process_batch([str(good), str(bad)], IndexType.CASE)
+        assert result.total_chunks >= 1
+        assert len(result.failed) == 1
+        assert "bad.docx" in result.failed[0][0]
+        assert "지원하지 않는 파일 형식" in result.failed[0][1]
+
+    def test_batch_result_properties(self):
+        br = BatchResult()
+        assert br.total_chunks == 0
+        assert len(br.failed) == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **`src/inference/document_processor.py`** 신규 모듈: PDF(PyMuPDF), HWP, TXT 파서 통합 + 의미 단위(법령 조/항, 문단) + 고정 크기(512토큰, 128오버랩) 하이브리드 청킹
- **`requirements.txt`**: `PyMuPDF>=1.23.0` 추가 (HWP는 런타임 optional)
- **`tests/test_inference/test_document_processor.py`**: 단위 테스트 39개

### 주요 구현

| 컴포넌트 | 설명 |
|----------|------|
| `_parse_pdf` | PyMuPDF context manager 기반 텍스트 추출 |
| `_parse_hwp` | HWP 파서 (optional dependency, try/finally 안전 종료) |
| `_parse_txt` | UTF-8/CP949/EUC-KR 자동 감지 |
| `_clean_text` | 페이지 번호/머리글 제거, 공백 정규화, 정제 후 빈 문서 가드 |
| `_split_semantic` | LAW: 조/항 단위, CASE/MANUAL/NOTICE: 문단 단위 |
| `_chunk_fixed` | 토큰 기반 고정 크기 분할 (EXAONE 우선, 문자 폴백) |
| `_hybrid_chunk` | 1단계 의미 분할 → 2단계 고정 크기 재분할 → 3단계 소형 청크 병합 |
| `DocumentProcessor.process` | 파싱→정제→청킹→DocumentMetadata 반환 |
| `DocumentProcessor.process_batch` | 다중 파일 일괄 처리 → `BatchResult(succeeded, failed)` |

### 이전 리뷰 반영 사항

**Critical (umyunsang)**
- [x] C-1: `_LOAD_FAILED` 센티널로 토크나이저 무한 재시도 방지
- [x] C-2: `_parse_pdf` — `fitz.open()` context manager로 fd 누수 방지
- [x] C-3: `_parse_hwp` — `try/finally`로 fd 누수 방지
- [x] C-4: `process_batch()` — `BatchResult(succeeded, failed)` 구조화 반환

**Major (umyunsang)**
- [x] M-1: `extras["content"]` → `extras["chunk_text"]`로 변경 (ORM content 컬럼 혼동 방지)
- [x] M-2: `chunk_overlap` 기본값 64 → 128 (ADR-004 준수)

**Blocker (yuujjjj)**
- [x] B-1: `python-hwp` PyPI 미존재 → requirements.txt에서 제거, 런타임 ImportError 안내
- [x] B-2: `doc_id` 청크별 분리 → 원본 문서 단위 안정 ID로 통일 (ORM `source_id` 정합)

**Suggestion (yuujjjj)**
- [x] S-1: `_clean_text()` 이후 빈 문서 가드 추가, `_hybrid_chunk("")` → `[]` 반환

## 관련 이슈

- Closes #156
- 선행: #151 DocumentMetadata 스키마 확장 (완료)
- 후행: #157 법령/매뉴얼/공시정보 데이터 수집 및 인덱싱

## Test plan

- [x] `pytest tests/test_inference/test_document_processor.py -v` — 39개 전체 통과 (0.84s)
- [x] 텍스트 정제 (페이지번호 제거, 공백 정규화)
- [x] TXT 파싱 (UTF-8, CP949, 잘못된 인코딩 에러)
- [x] 의미 단위 분할 (법령 조/항, 문단)
- [x] 고정 크기 청킹 (단일/다중, 오버랩, overlap≥chunk_size 무한루프 방지)
- [x] 하이브리드 청킹 (의미+고정, 대형 분할, 소형 병합, 빈 텍스트)
- [x] 토크나이저 센티널 패턴 (재시도 방지)
- [x] doc_id 안정성 (동일 문서 전 청크 동일 ID)
- [x] BatchResult (성공/실패 구조화)
- [x] 정제 후 빈 문서 가드
- [ ] 실제 PDF/HWP 파일로 E2E 검증 (GPU 서버에서)