### PR TITLE
fix: Cloud Run 워크플로우 GCP 인증 시크릿 미설정 오류 수정

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -50,6 +50,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Check GCP credentials
+        id: check-creds
+        run: |
+          if [ -z "$GCP_SA_KEY" ]; then
+            echo "::error::GCP_SA_KEY 시크릿이 설정되지 않았습니다. 배포를 중단합니다."
+            exit 1
+          fi
+        env:
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+
       - name: Determine image tag
         id: image
         run: |

--- a/.github/workflows/monitor-cloud-run.yml
+++ b/.github/workflows/monitor-cloud-run.yml
@@ -17,16 +17,31 @@ jobs:
   monitor:
     runs-on: ubuntu-latest
     steps:
+      - name: Check GCP credentials
+        id: check-creds
+        run: |
+          if [ -z "$GCP_SA_KEY" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::GCP_SA_KEY 시크릿이 설정되지 않았습니다. 모니터링을 건너뜁니다."
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+
       - name: Authenticate to Google Cloud
+        if: steps.check-creds.outputs.available == 'true'
         uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up Cloud SDK
+        if: steps.check-creds.outputs.available == 'true'
         uses: google-github-actions/setup-gcloud@v3
 
       - name: Get service URL
         id: service
+        if: steps.check-creds.outputs.available == 'true'
         continue-on-error: true
         run: |
           URL=$(gcloud run services describe ${{ env.SERVICE_NAME }} \
@@ -36,6 +51,7 @@ jobs:
 
       - name: Health check
         id: health
+        if: steps.check-creds.outputs.available == 'true'
         continue-on-error: true
         run: |
           URL="${{ steps.service.outputs.url }}"
@@ -59,6 +75,7 @@ jobs:
 
       - name: Check metrics
         id: metrics
+        if: steps.check-creds.outputs.available == 'true'
         continue-on-error: true
         run: |
           # Get instance count
@@ -142,11 +159,15 @@ jobs:
         run: |
           echo "### Cloud Run Monitoring" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Metric | Value |" >> $GITHUB_STEP_SUMMARY
-          echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Service | ${{ env.SERVICE_NAME }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Status | ${{ steps.health.outputs.status }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| HTTP Code | ${{ steps.health.outputs.http_code }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Latency | ${{ steps.health.outputs.latency }}s |" >> $GITHUB_STEP_SUMMARY
-          echo "| Revision | ${{ steps.metrics.outputs.revision }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Timestamp | $(date -u +%Y-%m-%dT%H:%M:%SZ) |" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.check-creds.outputs.available }}" != "true" ]; then
+            echo "> **GCP_SA_KEY 시크릿 미설정으로 모니터링을 건너뛰었습니다.**" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| Metric | Value |" >> $GITHUB_STEP_SUMMARY
+            echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
+            echo "| Service | ${{ env.SERVICE_NAME }} |" >> $GITHUB_STEP_SUMMARY
+            echo "| Status | ${{ steps.health.outputs.status }} |" >> $GITHUB_STEP_SUMMARY
+            echo "| HTTP Code | ${{ steps.health.outputs.http_code }} |" >> $GITHUB_STEP_SUMMARY
+            echo "| Latency | ${{ steps.health.outputs.latency }}s |" >> $GITHUB_STEP_SUMMARY
+            echo "| Revision | ${{ steps.metrics.outputs.revision }} |" >> $GITHUB_STEP_SUMMARY
+            echo "| Timestamp | $(date -u +%Y-%m-%dT%H:%M:%SZ) |" >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
## 문제

Cloud Run Monitoring 워크플로우가 2026-03-27~28 기간 동안 연속 10회 이상 실패.

**오류 메시지:**
```
google-github-actions/auth failed with: the GitHub Action workflow must specify exactly one of
"workload_identity_provider" or "credentials_json"!
```

## 원인

`monitor-cloud-run.yml`에서 `${{ secrets.GCP_SA_KEY }}`를 참조하지만, 해당 시크릿이 레포지토리에 설정되어 있지 않음. 시크릿이 빈 문자열로 평가되어 `google-github-actions/auth@v3`가 `credentials_json`도 `workload_identity_provider`도 제공되지 않았다고 판단하여 실패.

## 수정 내용

### `monitor-cloud-run.yml`
- GCP 인증 전에 `GCP_SA_KEY` 시크릿 존재 여부를 확인하는 step 추가
- 시크릿 미설정 시 모든 GCP 관련 step을 조건부로 건너뜀 (graceful skip)
- Monitoring Summary에서 시크릿 미설정 상태를 명시적으로 표시

### `deploy-cloud-run.yml`
- 배포 시작 전 `GCP_SA_KEY` 시크릿 존재 여부를 확인하는 step 추가
- 시크릿 미설정 시 명확한 에러 메시지와 함께 조기 종료 (배포는 반드시 인증이 필요하므로 skip이 아닌 fail)

## 테스트 계획

- [ ] `GCP_SA_KEY` 시크릿 미설정 상태에서 monitor-cloud-run 워크플로우가 성공(skip)하는지 확인
- [ ] `GCP_SA_KEY` 시크릿 설정 후 정상적으로 GCP 인증 및 모니터링이 동작하는지 확인
- [ ] deploy-cloud-run 워크플로우에서 시크릿 미설정 시 명확한 에러 메시지가 출력되는지 확인