### PR TITLE
fix: 발표자료 PDF 임베드 렌더링 수정

### DIFF
--- a/site/docs/presentation.md
+++ b/site/docs/presentation.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 # 프로젝트 발표자료
 
 **GovOn — 폐쇄망 온프레미스 AI 민원 처리 인프라**
@@ -6,11 +11,7 @@
 
 [:material-download: PDF 다운로드](assets/GovOn_Secure_On-Premise_AI.pdf){ .md-button .md-button--primary }
 
----
-
-<div style="width: 100%; height: 80vh;">
-  <embed src="assets/GovOn_Secure_On-Premise_AI.pdf" type="application/pdf" width="100%" height="100%" />
-</div>
+<iframe src="https://docs.google.com/gview?url=https://govon-org.github.io/GovOn/assets/GovOn_Secure_On-Premise_AI.pdf&embedded=true" style="width:100%; height:80vh; border:none;" allowfullscreen></iframe>
 
 !!! tip "PDF가 표시되지 않는 경우"
-    브라우저에서 PDF 뷰어를 지원하지 않을 경우, 위의 **PDF 다운로드** 버튼을 클릭하여 직접 확인하세요.
+    Google Docs Viewer 로딩에 시��이 걸릴 수 있습니다. 표시되지 않으면 위의 **PDF 다운로드** 버튼을 클릭하세요.


### PR DESCRIPTION
## Summary
- `<embed>` 태그가 MkDocs Material에서 렌더링되지 않는 문제 수정
- Google Docs Viewer `<iframe>`으로 변경하여 브라우저 내 PDF 열람 지원

## Test plan
- [ ] 발표자료 페이지에서 PDF가 iframe 내에 렌더링되는지 확인
- [ ] PDF 다운로드 버튼 동작 확인