### PR TITLE
fix: 발표자료 페이지 한글 인코딩 깨짐 수정

### DIFF
--- a/site/docs/presentation.md
+++ b/site/docs/presentation.md
@@ -14,4 +14,4 @@ hide:
 <iframe src="https://docs.google.com/gview?url=https://govon-org.github.io/GovOn/assets/GovOn_Secure_On-Premise_AI.pdf&embedded=true" style="width:100%; height:80vh; border:none;" allowfullscreen></iframe>
 
 !!! tip "PDF가 표시되지 않는 경우"
-    Google Docs Viewer 로딩에 시��이 걸릴 수 있습니다. 표시되지 않으면 위의 **PDF 다운로드** 버튼을 클릭하세요.
+    Google Docs Viewer 로딩에 시간이 걸릴 수 있습니다. 표시되지 않으면 위의 **PDF 다운로드** 버튼을 클릭하세요.


### PR DESCRIPTION
발표자료 페이지의 한글 텍스트가 깨져서 렌더링되는 문제 수정 (UTF-8 재작성)