### PR TITLE
docs: 발표자료 탭을 GovOn 발표자료와 AI 기본계획으로 분리

### DIFF
--- a/site/docs/national-presentation.md
+++ b/site/docs/national-presentation.md
@@ -1,0 +1,17 @@
+---
+hide:
+  - toc
+---
+
+# AI 기본계획 (2026~2028)
+
+**대한민국 인공지능 기본계획 (2026~2028)**
+
+국가인공지능전략위원회가 발표한 대한민국 인공지능 기본계획으로, GovOn 프로젝트의 정책적 근거 문서입니다.
+
+[:material-download: PDF 다운로드](assets/대한민국_인공지능_기본계획_2026-2028.pdf){ .md-button .md-button--primary }
+
+<iframe src="https://docs.google.com/gview?url=https://govon-org.github.io/GovOn/assets/%EB%8C%80%ED%95%9C%EB%AF%BC%EA%B5%AD_%EC%9D%B8%EA%B3%B5%EC%A7%80%EB%8A%A5_%EA%B8%B0%EB%B3%B8%EA%B3%84%ED%9A%8D_2026-2028.pdf&embedded=true" style="width:100%; height:80vh; border:none;" allowfullscreen></iframe>
+
+!!! tip "PDF가 표시되지 않는 경우"
+    Google Docs Viewer 로딩에 시간이 걸릴 수 있습니다. 표시되지 않으면 위의 **PDF 다운로드** 버튼을 클릭하세요.

--- a/site/docs/presentation.md
+++ b/site/docs/presentation.md
@@ -3,9 +3,7 @@ hide:
   - toc
 ---
 
-# 발표자료
-
-## GovOn 프로젝트 발표자료
+# GovOn 프로젝트 발표자료
 
 **GovOn — 폐쇄망 온프레미스 AI 민원 처리 인프라**
 
@@ -14,21 +12,6 @@ hide:
 [:material-download: PDF 다운로드](assets/GovOn_Secure_On-Premise_AI.pdf){ .md-button .md-button--primary }
 
 <iframe src="https://docs.google.com/gview?url=https://govon-org.github.io/GovOn/assets/GovOn_Secure_On-Premise_AI.pdf&embedded=true" style="width:100%; height:80vh; border:none;" allowfullscreen></iframe>
-
-!!! tip "PDF가 표시되지 않는 경우"
-    Google Docs Viewer 로딩에 시간이 걸릴 수 있습니다. 표시되지 않으면 위의 **PDF 다운로드** 버튼을 클릭하세요.
-
----
-
-## 국가인공지능전략위원회 발표자료
-
-**대한민국 인공지능 기본계획 (2026~2028)**
-
-국가인공지능전략위원회가 발표한 대한민국 인공지능 기본계획으로, GovOn 프로젝트의 정책적 근거 문서입니다.
-
-[:material-download: PDF 다운로드](assets/대한민국_인공지능_기본계획_2026-2028.pdf){ .md-button }
-
-<iframe src="https://docs.google.com/gview?url=https://govon-org.github.io/GovOn/assets/%EB%8C%80%ED%95%9C%EB%AF%BC%EA%B5%AD_%EC%9D%B8%EA%B3%B5%EC%A7%80%EB%8A%A5_%EA%B8%B0%EB%B3%B8%EA%B3%84%ED%9A%8D_2026-2028.pdf&embedded=true" style="width:100%; height:80vh; border:none;" allowfullscreen></iframe>
 
 !!! tip "PDF가 표시되지 않는 경우"
     Google Docs Viewer 로딩에 시간이 걸릴 수 있습니다. 표시되지 않으면 위의 **PDF 다운로드** 버튼을 클릭하세요.

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -61,7 +61,9 @@ markdown_extensions:
 
 nav:
   - 홈: index.md
-  - 발표자료: presentation.md
+  - 발표자료:
+      - GovOn 프로젝트 발표자료: presentation.md
+      - AI 기본계획 (2026~2028): national-presentation.md
   - 아키텍처:
       - 시스템 구성도: architecture/overview.md
       - ADR: architecture/adr/index.md


### PR DESCRIPTION
발표자료 탭 하위에 GovOn 프로젝트 발표자료, AI 기본계획 (2026~2028) 두 페이지로 분리