### PR TITLE
feat: [Task 2.1] GovOn Runtime 서빙 프로필 및 모델 설정 구성 (#392)

### DIFF
--- a/.env.airgap.example
+++ b/.env.airgap.example
@@ -1,0 +1,70 @@
+# =============================================================================
+# GovOn Runtime — 폐쇄망(에어갭) 설치 프로필 (.env.airgap)
+# =============================================================================
+# 사용법: cp .env.airgap.example .env
+# 주의: 폐쇄망 환경에서는 모델을 로컬 경로에서 로드해야 합니다.
+#        HuggingFace Hub 다운로드가 불가하므로 사전에 모델을 복사해 두세요.
+
+# --- 서빙 프로필 ---
+SERVING_PROFILE=airgap
+
+# --- 서버 ---
+HOST=0.0.0.0
+PORT=8000
+LOG_LEVEL=INFO
+RELOAD=false
+
+# --- 모델 (로컬 경로 필수) ---
+# 폐쇄망에서는 HuggingFace 다운로드가 불가하므로 로컬 모델 경로를 지정
+MODEL_PATH=/opt/govon/models/GovOn-EXAONE-LoRA-v2
+GPU_UTILIZATION=0.8
+MAX_MODEL_LEN=8192
+SKIP_MODEL_LOAD=false
+# 로컬 모델이므로 trust_remote_code는 유지 (EXAONE 커스텀 코드 필요)
+TRUST_REMOTE_CODE=true
+
+# --- 데이터 경로 (로컬 절대경로) ---
+DATA_PATH=/opt/govon/data/processed/v2_train.jsonl
+INDEX_PATH=/opt/govon/models/faiss_index/complaints.index
+FAISS_INDEX_DIR=/opt/govon/models/faiss_index
+BM25_INDEX_DIR=/opt/govon/models/bm25_index
+AGENTS_DIR=/opt/govon/agents
+
+# --- 로그 / 캐시 ---
+LOG_DIR=/var/log/govon
+CACHE_DIR=/opt/govon/.cache
+
+# --- 보안 (필수) ---
+API_KEY=CHANGE_ME_TO_SECURE_RANDOM_KEY
+# 폐쇄망에서는 내부 네트워크 주소를 명시
+CORS_ORIGINS=http://10.0.0.100:3000
+
+# --- Rate Limiting ---
+RATE_LIMIT_ENABLED=true
+
+# --- 타임아웃 ---
+# 폐쇄망에서는 네트워크 지연이 적으므로 적절한 값으로 설정
+REQUEST_TIMEOUT_SEC=90
+
+# --- Generation Defaults ---
+GEN_MAX_TOKENS=512
+GEN_TEMPERATURE=0.7
+GEN_TOP_P=0.9
+GEN_REPETITION_PENALTY=1.1
+
+# --- Feature Flags ---
+USE_RAG_PIPELINE=true
+MODEL_VERSION=v2_lora
+
+# --- 검색 인덱스 무결성 (필수) ---
+BM25_INDEX_HMAC_KEY=CHANGE_ME_TO_SECURE_HMAC_KEY
+
+# --- 헬스체크 ---
+HEALTH_INTERVAL_SEC=30
+HEALTH_TIMEOUT_SEC=10
+
+# --- 폐쇄망 전용 설정 ---
+# HuggingFace 오프라인 모드 활성화
+HF_HUB_OFFLINE=1
+TRANSFORMERS_OFFLINE=1
+HF_DATASETS_OFFLINE=1

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,58 @@
+# =============================================================================
+# GovOn Runtime — 로컬 개발 프로필 (.env.local)
+# =============================================================================
+# 사용법: cp .env.local.example .env && uvicorn src.inference.api_server:app --reload
+
+# --- 서빙 프로필 ---
+SERVING_PROFILE=local
+
+# --- 서버 ---
+HOST=127.0.0.1
+PORT=8000
+LOG_LEVEL=DEBUG
+RELOAD=true
+
+# --- 모델 ---
+MODEL_PATH=umyunsang/GovOn-EXAONE-LoRA-v2
+GPU_UTILIZATION=0.7
+MAX_MODEL_LEN=4096
+# 모델 없이 API 서버만 기동할 때 true로 설정
+SKIP_MODEL_LOAD=false
+
+# --- 데이터 경로 ---
+DATA_PATH=data/processed/v2_train.jsonl
+INDEX_PATH=models/faiss_index/complaints.index
+FAISS_INDEX_DIR=models/faiss_index
+BM25_INDEX_DIR=models/bm25_index
+
+# --- 로그 / 캐시 ---
+LOG_DIR=logs
+CACHE_DIR=.cache
+
+# --- 보안 ---
+# 로컬 개발에서는 API_KEY 미설정 시 인증을 건너뜀
+# API_KEY=dev_test_key
+CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+
+# --- Rate Limiting ---
+RATE_LIMIT_ENABLED=false
+
+# --- 타임아웃 ---
+REQUEST_TIMEOUT_SEC=120
+
+# --- Generation Defaults ---
+GEN_MAX_TOKENS=512
+GEN_TEMPERATURE=0.7
+GEN_TOP_P=0.9
+GEN_REPETITION_PENALTY=1.1
+
+# --- Feature Flags ---
+USE_RAG_PIPELINE=true
+MODEL_VERSION=v2_lora
+
+# --- 검색 인덱스 무결성 ---
+# BM25_INDEX_HMAC_KEY=dev_hmac_key
+
+# --- 헬스체크 ---
+HEALTH_INTERVAL_SEC=30
+HEALTH_TIMEOUT_SEC=10

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,57 @@
+# =============================================================================
+# GovOn Runtime — 단일 서버 프로덕션 프로필 (.env.prod)
+# =============================================================================
+# 사용법: cp .env.prod.example .env
+
+# --- 서빙 프로필 ---
+SERVING_PROFILE=single
+
+# --- 서버 ---
+HOST=0.0.0.0
+PORT=8000
+LOG_LEVEL=INFO
+RELOAD=false
+
+# --- 모델 ---
+MODEL_PATH=umyunsang/GovOn-EXAONE-LoRA-v2
+GPU_UTILIZATION=0.85
+MAX_MODEL_LEN=8192
+SKIP_MODEL_LOAD=false
+
+# --- 데이터 경로 ---
+DATA_PATH=/app/data/processed/v2_train.jsonl
+INDEX_PATH=/app/models/faiss_index/complaints.index
+FAISS_INDEX_DIR=/app/models/faiss_index
+BM25_INDEX_DIR=/app/models/bm25_index
+AGENTS_DIR=/app/agents
+
+# --- 로그 / 캐시 ---
+LOG_DIR=/var/log/govon
+CACHE_DIR=/app/.cache
+
+# --- 보안 (필수) ---
+API_KEY=CHANGE_ME_TO_SECURE_RANDOM_KEY
+CORS_ORIGINS=https://govon.example.com
+
+# --- Rate Limiting ---
+RATE_LIMIT_ENABLED=true
+
+# --- 타임아웃 ---
+REQUEST_TIMEOUT_SEC=60
+
+# --- Generation Defaults ---
+GEN_MAX_TOKENS=512
+GEN_TEMPERATURE=0.7
+GEN_TOP_P=0.9
+GEN_REPETITION_PENALTY=1.1
+
+# --- Feature Flags ---
+USE_RAG_PIPELINE=true
+MODEL_VERSION=v2_lora
+
+# --- 검색 인덱스 무결성 (필수) ---
+BM25_INDEX_HMAC_KEY=CHANGE_ME_TO_SECURE_HMAC_KEY
+
+# --- 헬스체크 ---
+HEALTH_INTERVAL_SEC=30
+HEALTH_TIMEOUT_SEC=10

--- a/src/inference/api_server.py
+++ b/src/inference/api_server.py
@@ -12,6 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from fastapi.security import APIKeyHeader
 from loguru import logger
+
 try:
     from vllm import AsyncLLM, SamplingParams
 except ImportError:
@@ -23,13 +24,16 @@ except ImportError:
         SamplingParams = None
 
 # SKIP_MODEL_LOAD: E2E 테스트 등 모델 없이 서버만 기동할 때 사용
+# RuntimeConfig 로드 전 조기 참조용 (import 순서 의존성)
 SKIP_MODEL_LOAD = os.getenv("SKIP_MODEL_LOAD", "false").lower() in ("true", "1", "yes")
 
 from .agent_manager import AgentManager
 from .bm25_indexer import BM25Indexer
+from .feature_flags import FeatureFlags
 from .hybrid_search import HybridSearchEngine, SearchMode
 from .index_manager import IndexType, MultiIndexManager
 from .retriever import CivilComplaintRetriever
+from .runtime_config import RuntimeConfig, ServingProfile
 from .schemas import (
     ClassificationResult,
     ClassifyRequest,
@@ -42,13 +46,13 @@ from .schemas import (
     SearchResult,
     StreamResponse,
 )
-from .feature_flags import FeatureFlags
 
 if not SKIP_MODEL_LOAD:
     try:
         from vllm.engine.arg_utils import AsyncEngineArgs
         from vllm.engine.async_llm_engine import AsyncLLMEngine
         from vllm.sampling_params import SamplingParams
+
         from .vllm_stabilizer import apply_transformers_patch
     except ImportError:
         logger.warning("vllm modules not found. Model loading will fail if attempted.")
@@ -82,17 +86,19 @@ async def verify_api_key(api_key: str = Security(_api_key_header)):
         raise HTTPException(status_code=401, detail="유효하지 않은 API 키입니다.")
 
 
-# --- M3 Optimized Configuration ---
-MODEL_PATH = os.getenv("MODEL_PATH", "umyunsang/GovOn-EXAONE-LoRA-v2")
-DATA_PATH = os.getenv("DATA_PATH", "data/processed/v2_train.jsonl")
-INDEX_PATH = os.getenv("INDEX_PATH", "models/faiss_index/complaints.index")
+# --- Runtime Configuration ---
+runtime_config = RuntimeConfig.from_env()
+runtime_config.log_summary()
 
-# Optimized for 16GB VRAM with AWQ INT4 model
-GPU_UTILIZATION = float(os.getenv("GPU_UTILIZATION", "0.8"))
-MAX_MODEL_LEN = int(os.getenv("MAX_MODEL_LEN", "8192"))
-TRUST_REMOTE_CODE = True
+# 하위 호환을 위해 기존 모듈 레벨 변수 유지 (RuntimeConfig에서 참조)
+MODEL_PATH = runtime_config.model.model_path
+DATA_PATH = runtime_config.paths.data_path
+INDEX_PATH = runtime_config.paths.index_path
+GPU_UTILIZATION = runtime_config.gpu_utilization
+MAX_MODEL_LEN = runtime_config.max_model_len
+TRUST_REMOTE_CODE = runtime_config.model.trust_remote_code
 _PROJECT_ROOT = str(Path(__file__).resolve().parent.parent.parent)
-AGENTS_DIR = os.getenv("AGENTS_DIR", os.path.join(_PROJECT_ROOT, "agents"))
+AGENTS_DIR = runtime_config.paths.agents_dir
 
 # Apply EXAONE-specific runtime patches (모델 로드 시에만)
 if not SKIP_MODEL_LOAD:
@@ -120,7 +126,7 @@ class vLLMEngineManager:
 
         # 1. Initialize Optimized vLLM Engine
         logger.info(f"Initializing vLLM M3 engine with model: {MODEL_PATH}")
-        
+
         # vllm.v1.engine.async_llm.AsyncLLM 또는 vllm.engine.async_llm_engine.AsyncLLMEngine 모두
         # from_engine_args를 지원하므로 이를 통해 초기화한다.
         try:
@@ -129,10 +135,10 @@ class vLLMEngineManager:
                 trust_remote_code=TRUST_REMOTE_CODE,
                 gpu_memory_utilization=GPU_UTILIZATION,
                 max_model_len=MAX_MODEL_LEN,
-                dtype="half",
-                enforce_eager=True,
+                dtype=runtime_config.model.dtype,
+                enforce_eager=runtime_config.model.enforce_eager,
             )
-            
+
             if hasattr(AsyncLLM, "from_engine_args"):
                 self.engine = AsyncLLM.from_engine_args(engine_args)
             else:
@@ -303,13 +309,14 @@ class vLLMEngineManager:
             if retrieved_cases:
                 augmented_prompt = self._augment_prompt(request.prompt, retrieved_cases)
 
-        # 3. Sampling parameters
+        # 3. Sampling parameters (generation defaults from RuntimeConfig)
+        gen_defaults = runtime_config.generation
         sampling_params = SamplingParams(
             temperature=request.temperature,
             top_p=request.top_p,
             max_tokens=request.max_tokens,
-            stop=request.stop,
-            repetition_penalty=1.1,  # Added for EXAONE stability
+            stop=request.stop or gen_defaults.stop_sequences,
+            repetition_penalty=gen_defaults.repetition_penalty,
         )
 
         return augmented_prompt, sampling_params, retrieved_cases
@@ -317,7 +324,7 @@ class vLLMEngineManager:
     async def _run_engine(self, prompt: str, sampling_params: SamplingParams, request_id: str):
         """vLLM 엔진의 generate를 실행하고 최종 결과를 반환한다. (제너레이터 처리 포함)"""
         result = self.engine.generate(prompt, sampling_params, request_id)
-        
+
         if hasattr(result, "__aiter__"):
             final_output = None
             async for output in result:
@@ -348,7 +355,7 @@ class vLLMEngineManager:
             stream = self.engine.stream(augmented_prompt, sampling_params, request_id)
         else:
             stream = self.engine.generate(augmented_prompt, sampling_params, request_id)
-            
+
         return stream, retrieved_cases
 
 
@@ -409,6 +416,8 @@ async def health():
 
     return {
         "status": "healthy",
+        "profile": runtime_config.profile.value,
+        "model": runtime_config.model.model_path,
         "rag_enabled": manager.index_manager is not None or manager.retriever is not None,
         "agents_loaded": manager.agent_manager.list_agents() if manager.agent_manager else [],
         "indexes": index_summary,
@@ -673,4 +682,4 @@ async def search(request: SearchRequest, req: Request, _: None = Depends(verify_
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, **runtime_config.to_uvicorn_kwargs())

--- a/src/inference/runtime_config.py
+++ b/src/inference/runtime_config.py
@@ -1,0 +1,310 @@
+"""GovOn Runtime 서빙 프로필 및 모델 설정 구성.
+
+환경변수 기반으로 로컬 개발, 단일 서버(프로덕션), 폐쇄망(에어갭) 설치용
+프로필을 정의하고, generation defaults와 timeout 설정을 표준화한다.
+
+사용법:
+    config = RuntimeConfig.from_env()
+    config.log_summary()
+"""
+
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from loguru import logger
+
+# 프로젝트 루트 경로 (src/inference/runtime_config.py → ../../..)
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+class ServingProfile(str, Enum):
+    """서빙 프로필. SERVING_PROFILE 환경변수로 선택한다."""
+
+    LOCAL = "local"  # 로컬 개발 환경
+    SINGLE = "single"  # 단일 서버 프로덕션
+    AIRGAP = "airgap"  # 폐쇄망 설치
+
+
+# ---------------------------------------------------------------------------
+# 프로필별 기본값 정의
+# ---------------------------------------------------------------------------
+
+_PROFILE_DEFAULTS: Dict[ServingProfile, Dict] = {
+    ServingProfile.LOCAL: {
+        "host": "127.0.0.1",
+        "port": 8000,
+        "workers": 1,
+        "gpu_utilization": 0.7,
+        "max_model_len": 4096,
+        "log_level": "DEBUG",
+        "reload": True,
+        "rate_limit_enabled": False,
+        "request_timeout_sec": 120,
+        "cors_origins": ["http://localhost:3000", "http://127.0.0.1:3000"],
+    },
+    ServingProfile.SINGLE: {
+        "host": "0.0.0.0",
+        "port": 8000,
+        "workers": 1,
+        "gpu_utilization": 0.85,
+        "max_model_len": 8192,
+        "log_level": "INFO",
+        "reload": False,
+        "rate_limit_enabled": True,
+        "request_timeout_sec": 60,
+        "cors_origins": [],
+    },
+    ServingProfile.AIRGAP: {
+        "host": "0.0.0.0",
+        "port": 8000,
+        "workers": 1,
+        "gpu_utilization": 0.8,
+        "max_model_len": 8192,
+        "log_level": "INFO",
+        "reload": False,
+        "rate_limit_enabled": True,
+        "request_timeout_sec": 90,
+        "cors_origins": [],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Generation Defaults
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GenerationDefaults:
+    """텍스트 생성 기본 파라미터. 엔드포인트 요청에 값이 없을 때 사용된다."""
+
+    max_tokens: int = 512
+    temperature: float = 0.7
+    top_p: float = 0.9
+    repetition_penalty: float = 1.1
+    stop_sequences: List[str] = field(default_factory=lambda: ["[|endofturn|]"])
+
+    @classmethod
+    def from_env(cls) -> "GenerationDefaults":
+        return cls(
+            max_tokens=int(os.getenv("GEN_MAX_TOKENS", "512")),
+            temperature=float(os.getenv("GEN_TEMPERATURE", "0.7")),
+            top_p=float(os.getenv("GEN_TOP_P", "0.9")),
+            repetition_penalty=float(os.getenv("GEN_REPETITION_PENALTY", "1.1")),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Model Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ModelConfig:
+    """모델 및 어댑터 설정."""
+
+    model_path: str = "umyunsang/GovOn-EXAONE-LoRA-v2"
+    trust_remote_code: bool = True
+    dtype: str = "half"
+    enforce_eager: bool = True
+    # 향후 Multi-LoRA 확장 시 adapter_paths 활용 (R1 이후)
+    adapter_paths: List[str] = field(default_factory=list)
+
+    @classmethod
+    def from_env(cls) -> "ModelConfig":
+        return cls(
+            model_path=os.getenv("MODEL_PATH", "umyunsang/GovOn-EXAONE-LoRA-v2"),
+            trust_remote_code=os.getenv("TRUST_REMOTE_CODE", "true").lower()
+            in ("true", "1", "yes"),
+            dtype=os.getenv("MODEL_DTYPE", "half"),
+            enforce_eager=os.getenv("ENFORCE_EAGER", "true").lower() in ("true", "1", "yes"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Path Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PathConfig:
+    """데이터·인덱스·로그 경로 설정."""
+
+    data_path: str = ""
+    index_path: str = ""
+    faiss_index_dir: str = ""
+    bm25_index_dir: str = ""
+    agents_dir: str = ""
+    log_dir: str = ""
+    cache_dir: str = ""
+
+    @classmethod
+    def from_env(cls) -> "PathConfig":
+        project_root = str(_PROJECT_ROOT)
+        return cls(
+            data_path=os.getenv("DATA_PATH", "data/processed/v2_train.jsonl"),
+            index_path=os.getenv("INDEX_PATH", "models/faiss_index/complaints.index"),
+            faiss_index_dir=os.getenv("FAISS_INDEX_DIR", "models/faiss_index"),
+            bm25_index_dir=os.getenv("BM25_INDEX_DIR", "models/bm25_index"),
+            agents_dir=os.getenv("AGENTS_DIR", os.path.join(project_root, "agents")),
+            log_dir=os.getenv("LOG_DIR", os.path.join(project_root, "logs")),
+            cache_dir=os.getenv("CACHE_DIR", os.path.join(project_root, ".cache")),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Healthcheck Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HealthcheckConfig:
+    """헬스체크 설정. shell client readiness probe 용도."""
+
+    endpoint: str = "/health"
+    interval_sec: int = 30
+    timeout_sec: int = 10
+    startup_probe_path: str = "/health"
+    readiness_probe_path: str = "/health"
+
+    @classmethod
+    def from_env(cls) -> "HealthcheckConfig":
+        return cls(
+            interval_sec=int(os.getenv("HEALTH_INTERVAL_SEC", "30")),
+            timeout_sec=int(os.getenv("HEALTH_TIMEOUT_SEC", "10")),
+        )
+
+
+# ---------------------------------------------------------------------------
+# RuntimeConfig (통합 설정)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RuntimeConfig:
+    """GovOn Runtime 통합 설정.
+
+    SERVING_PROFILE 환경변수에 따라 프로필별 기본값을 로드하고,
+    개별 환경변수로 오버라이드할 수 있다.
+    """
+
+    # 서빙 프로필
+    profile: ServingProfile = ServingProfile.LOCAL
+
+    # 서버 설정
+    host: str = "127.0.0.1"
+    port: int = 8000
+    workers: int = 1
+    log_level: str = "DEBUG"
+    reload: bool = True
+
+    # GPU / vLLM 설정
+    gpu_utilization: float = 0.7
+    max_model_len: int = 4096
+    skip_model_load: bool = False
+
+    # 보안
+    api_key: Optional[str] = None
+    cors_origins: List[str] = field(default_factory=list)
+    rate_limit_enabled: bool = False
+
+    # 타임아웃
+    request_timeout_sec: int = 120
+
+    # 하위 설정 객체
+    model: ModelConfig = field(default_factory=ModelConfig)
+    paths: PathConfig = field(default_factory=PathConfig)
+    generation: GenerationDefaults = field(default_factory=GenerationDefaults)
+    healthcheck: HealthcheckConfig = field(default_factory=HealthcheckConfig)
+
+    @classmethod
+    def from_env(cls) -> "RuntimeConfig":
+        """환경변수에서 전체 런타임 설정을 로드한다.
+
+        1. SERVING_PROFILE에 따른 프로필 기본값 적용
+        2. 개별 환경변수로 오버라이드
+        """
+        profile_name = os.getenv("SERVING_PROFILE", "local").lower()
+        try:
+            profile = ServingProfile(profile_name)
+        except ValueError:
+            logger.warning(f"알 수 없는 SERVING_PROFILE '{profile_name}', 기본값 'local' 사용")
+            profile = ServingProfile.LOCAL
+
+        defaults = _PROFILE_DEFAULTS[profile]
+
+        skip_model_load = os.getenv("SKIP_MODEL_LOAD", "false").lower() in (
+            "true",
+            "1",
+            "yes",
+        )
+
+        # CORS: 환경변수가 있으면 우선, 없으면 프로필 기본값
+        cors_env = os.getenv("CORS_ORIGINS", "")
+        if cors_env:
+            cors_origins = [o.strip() for o in cors_env.split(",") if o.strip()]
+        else:
+            cors_origins = defaults["cors_origins"]
+
+        return cls(
+            profile=profile,
+            host=os.getenv("HOST", defaults["host"]),
+            port=int(os.getenv("PORT", str(defaults["port"]))),
+            workers=int(os.getenv("WORKERS", str(defaults["workers"]))),
+            log_level=os.getenv("LOG_LEVEL", defaults["log_level"]),
+            reload=os.getenv("RELOAD", str(defaults["reload"])).lower() in ("true", "1", "yes"),
+            gpu_utilization=float(os.getenv("GPU_UTILIZATION", str(defaults["gpu_utilization"]))),
+            max_model_len=int(os.getenv("MAX_MODEL_LEN", str(defaults["max_model_len"]))),
+            skip_model_load=skip_model_load,
+            api_key=os.getenv("API_KEY"),
+            cors_origins=cors_origins,
+            rate_limit_enabled=os.getenv(
+                "RATE_LIMIT_ENABLED", str(defaults["rate_limit_enabled"])
+            ).lower()
+            in ("true", "1", "yes"),
+            request_timeout_sec=int(
+                os.getenv("REQUEST_TIMEOUT_SEC", str(defaults["request_timeout_sec"]))
+            ),
+            model=ModelConfig.from_env(),
+            paths=PathConfig.from_env(),
+            generation=GenerationDefaults.from_env(),
+            healthcheck=HealthcheckConfig.from_env(),
+        )
+
+    def log_summary(self) -> None:
+        """현재 설정 요약을 로그로 출력한다."""
+        logger.info("=" * 60)
+        logger.info("GovOn Runtime Configuration")
+        logger.info("=" * 60)
+        logger.info(f"  Profile       : {self.profile.value}")
+        logger.info(f"  Host          : {self.host}:{self.port}")
+        logger.info(f"  Workers       : {self.workers}")
+        logger.info(f"  Log Level     : {self.log_level}")
+        logger.info(f"  GPU Util      : {self.gpu_utilization}")
+        logger.info(f"  Max Model Len : {self.max_model_len}")
+        logger.info(f"  Model Path    : {self.model.model_path}")
+        logger.info(f"  Skip Model    : {self.skip_model_load}")
+        logger.info(f"  Request Timeout: {self.request_timeout_sec}s")
+        logger.info(f"  Rate Limit    : {self.rate_limit_enabled}")
+        logger.info(f"  CORS Origins  : {self.cors_origins}")
+        logger.info(f"  Healthcheck   : {self.healthcheck.endpoint}")
+        logger.info(f"  Data Path     : {self.paths.data_path}")
+        logger.info(f"  Index Path    : {self.paths.index_path}")
+        logger.info(f"  Log Dir       : {self.paths.log_dir}")
+        logger.info("=" * 60)
+
+    def to_uvicorn_kwargs(self) -> Dict:
+        """uvicorn.run()에 전달할 키워드 인자를 반환한다."""
+        kwargs = {
+            "host": self.host,
+            "port": self.port,
+            "workers": self.workers,
+            "log_level": self.log_level.lower(),
+            "timeout_keep_alive": self.request_timeout_sec,
+        }
+        if self.reload:
+            kwargs["reload"] = True
+        return kwargs

--- a/tests/test_inference/test_runtime_config.py
+++ b/tests/test_inference/test_runtime_config.py
@@ -1,0 +1,181 @@
+"""RuntimeConfig 단위 테스트."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from src.inference.runtime_config import (
+    GenerationDefaults,
+    HealthcheckConfig,
+    ModelConfig,
+    PathConfig,
+    RuntimeConfig,
+    ServingProfile,
+)
+
+
+class TestServingProfile:
+    def test_enum_values(self):
+        assert ServingProfile.LOCAL.value == "local"
+        assert ServingProfile.SINGLE.value == "single"
+        assert ServingProfile.AIRGAP.value == "airgap"
+
+
+class TestRuntimeConfigFromEnv:
+    def test_default_is_local(self):
+        """SERVING_PROFILE 미설정 시 local 프로필이 기본값이다."""
+        with patch.dict(os.environ, {}, clear=True):
+            config = RuntimeConfig.from_env()
+        assert config.profile == ServingProfile.LOCAL
+        assert config.host == "127.0.0.1"
+        assert config.reload is True
+        assert config.rate_limit_enabled is False
+
+    def test_single_profile(self):
+        """SERVING_PROFILE=single 시 프로덕션 기본값이 적용된다."""
+        with patch.dict(os.environ, {"SERVING_PROFILE": "single"}, clear=True):
+            config = RuntimeConfig.from_env()
+        assert config.profile == ServingProfile.SINGLE
+        assert config.host == "0.0.0.0"
+        assert config.gpu_utilization == 0.85
+        assert config.max_model_len == 8192
+        assert config.reload is False
+        assert config.rate_limit_enabled is True
+        assert config.request_timeout_sec == 60
+
+    def test_airgap_profile(self):
+        """SERVING_PROFILE=airgap 시 폐쇄망 기본값이 적용된다."""
+        with patch.dict(os.environ, {"SERVING_PROFILE": "airgap"}, clear=True):
+            config = RuntimeConfig.from_env()
+        assert config.profile == ServingProfile.AIRGAP
+        assert config.request_timeout_sec == 90
+
+    def test_unknown_profile_falls_back_to_local(self):
+        """알 수 없는 프로필은 local로 폴백한다."""
+        with patch.dict(os.environ, {"SERVING_PROFILE": "unknown"}, clear=True):
+            config = RuntimeConfig.from_env()
+        assert config.profile == ServingProfile.LOCAL
+
+    def test_env_override_takes_precedence(self):
+        """개별 환경변수가 프로필 기본값을 오버라이드한다."""
+        env = {
+            "SERVING_PROFILE": "local",
+            "GPU_UTILIZATION": "0.95",
+            "MAX_MODEL_LEN": "16384",
+            "PORT": "9000",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = RuntimeConfig.from_env()
+        assert config.gpu_utilization == 0.95
+        assert config.max_model_len == 16384
+        assert config.port == 9000
+
+    def test_skip_model_load(self):
+        with patch.dict(os.environ, {"SKIP_MODEL_LOAD": "true"}, clear=True):
+            config = RuntimeConfig.from_env()
+        assert config.skip_model_load is True
+
+    def test_cors_from_env(self):
+        env = {"CORS_ORIGINS": "https://a.com,https://b.com"}
+        with patch.dict(os.environ, env, clear=True):
+            config = RuntimeConfig.from_env()
+        assert config.cors_origins == ["https://a.com", "https://b.com"]
+
+    def test_cors_default_for_local(self):
+        with patch.dict(os.environ, {"SERVING_PROFILE": "local"}, clear=True):
+            config = RuntimeConfig.from_env()
+        assert "http://localhost:3000" in config.cors_origins
+
+
+class TestModelConfig:
+    def test_defaults(self):
+        with patch.dict(os.environ, {}, clear=True):
+            mc = ModelConfig.from_env()
+        assert mc.model_path == "umyunsang/GovOn-EXAONE-LoRA-v2"
+        assert mc.trust_remote_code is True
+        assert mc.dtype == "half"
+        assert mc.enforce_eager is True
+
+    def test_env_override(self):
+        env = {
+            "MODEL_PATH": "/local/model",
+            "MODEL_DTYPE": "float16",
+            "ENFORCE_EAGER": "false",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            mc = ModelConfig.from_env()
+        assert mc.model_path == "/local/model"
+        assert mc.dtype == "float16"
+        assert mc.enforce_eager is False
+
+
+class TestGenerationDefaults:
+    def test_defaults(self):
+        with patch.dict(os.environ, {}, clear=True):
+            gd = GenerationDefaults.from_env()
+        assert gd.max_tokens == 512
+        assert gd.temperature == 0.7
+        assert gd.repetition_penalty == 1.1
+
+    def test_env_override(self):
+        env = {"GEN_MAX_TOKENS": "1024", "GEN_TEMPERATURE": "0.3"}
+        with patch.dict(os.environ, env, clear=True):
+            gd = GenerationDefaults.from_env()
+        assert gd.max_tokens == 1024
+        assert gd.temperature == 0.3
+
+
+class TestPathConfig:
+    def test_defaults(self):
+        with patch.dict(os.environ, {}, clear=True):
+            pc = PathConfig.from_env()
+        assert pc.data_path == "data/processed/v2_train.jsonl"
+        assert pc.index_path == "models/faiss_index/complaints.index"
+
+    def test_env_override(self):
+        env = {"DATA_PATH": "/opt/data.jsonl"}
+        with patch.dict(os.environ, env, clear=True):
+            pc = PathConfig.from_env()
+        assert pc.data_path == "/opt/data.jsonl"
+
+
+class TestHealthcheckConfig:
+    def test_defaults(self):
+        with patch.dict(os.environ, {}, clear=True):
+            hc = HealthcheckConfig.from_env()
+        assert hc.interval_sec == 30
+        assert hc.timeout_sec == 10
+        assert hc.endpoint == "/health"
+
+    def test_env_override(self):
+        env = {"HEALTH_INTERVAL_SEC": "60", "HEALTH_TIMEOUT_SEC": "5"}
+        with patch.dict(os.environ, env, clear=True):
+            hc = HealthcheckConfig.from_env()
+        assert hc.interval_sec == 60
+        assert hc.timeout_sec == 5
+
+
+class TestToUvicornKwargs:
+    def test_local_profile(self):
+        with patch.dict(os.environ, {"SERVING_PROFILE": "local"}, clear=True):
+            config = RuntimeConfig.from_env()
+        kwargs = config.to_uvicorn_kwargs()
+        assert kwargs["host"] == "127.0.0.1"
+        assert kwargs["port"] == 8000
+        assert kwargs["reload"] is True
+        assert kwargs["log_level"] == "debug"
+
+    def test_prod_profile_no_reload(self):
+        with patch.dict(os.environ, {"SERVING_PROFILE": "single"}, clear=True):
+            config = RuntimeConfig.from_env()
+        kwargs = config.to_uvicorn_kwargs()
+        assert "reload" not in kwargs
+
+
+class TestLogSummary:
+    def test_log_summary_does_not_raise(self):
+        """log_summary 호출이 예외 없이 완료된다."""
+        with patch.dict(os.environ, {}, clear=True):
+            config = RuntimeConfig.from_env()
+        config.log_summary()


### PR DESCRIPTION
## 개요

GovOn Runtime을 shell release 기준으로 안정적으로 기동할 수 있도록 서빙 프로필과 모델 설정 구성을 마련한다.
`RuntimeConfig` 클래스를 도입하여 로컬 개발, 단일 서버 프로덕션, 폐쇄망(에어갭) 설치용 프로필을 환경변수 기반으로 관리한다.

## 작업 내용

### 신규 파일
- **`src/inference/runtime_config.py`** — `RuntimeConfig` 통합 설정 클래스
  - `ServingProfile` enum: `local`, `single`, `airgap` 3가지 프로필
  - 프로필별 기본값 정의 (host, port, GPU 설정, timeout, rate limit 등)
  - `ModelConfig`: 모델 경로, dtype, enforce_eager 등 vLLM 엔진 설정
  - `GenerationDefaults`: max_tokens, temperature, top_p, repetition_penalty 표준화
  - `PathConfig`: 데이터, 인덱스, 로그, 캐시 경로 일괄 관리
  - `HealthcheckConfig`: shell client readiness probe 설정
  - `to_uvicorn_kwargs()`: uvicorn 실행 파라미터 자동 생성
- **`.env.local.example`** — 로컬 개발 환경변수 템플릿
- **`.env.prod.example`** — 단일 서버 프로덕션 환경변수 템플릿
- **`.env.airgap.example`** — 폐쇄망 설치 환경변수 템플릿 (HF_HUB_OFFLINE 포함)
- **`tests/test_inference/test_runtime_config.py`** — RuntimeConfig 단위 테스트 20건

### 수정 파일
- **`src/inference/api_server.py`**
  - 기존 하드코딩된 환경변수 참조를 `RuntimeConfig.from_env()`로 통합
  - vLLM 엔진 초기화 시 `ModelConfig`의 dtype, enforce_eager 활용
  - generation SamplingParams에 `GenerationDefaults` 적용
  - `/health` 엔드포인트에 `profile`, `model` 정보 추가
  - `__main__` 블록에서 `to_uvicorn_kwargs()` 활용

## 완료 조건 체크
- [x] 환경변수 기반 runtime 설정 정리
- [x] 단일 노드 안정적 기동 확인 (SKIP_MODEL_LOAD 모드 테스트 통과)
- [x] healthcheck 경로 확인 (`/health` — profile, model 정보 포함)
- [x] R1 필수 모델 구성 문서화 (3종 env 템플릿)

## 테스트
- `pytest tests/test_inference/test_runtime_config.py -v` → 20건 전체 통과
- 기존 inference 테스트 regression 없음

## 비고
- Multi-LoRA 강제 구성은 R1 이후 고도화 범위 (`ModelConfig.adapter_paths` 예약)

## 관련 이슈
Closes #392