### PR TITLE
feat: 민원분석 API Action 구현

### DIFF
--- a/src/inference/api_server.py
+++ b/src/inference/api_server.py
@@ -45,6 +45,7 @@ from .schemas import (
 )
 from .feature_flags import FeatureFlags
 from .tools.base import ToolRegistry
+from .tools.complaint_analysis import ComplaintAnalysisInput, ComplaintAnalysisTool
 from .tools.rag_search import RAGSearchInput, RAGSearchTool
 
 if not SKIP_MODEL_LOAD:
@@ -231,9 +232,12 @@ class vLLMEngineManager:
                 pii_masker=self.pii_masker,
             )
             self.tool_registry.register(rag_tool)
-            logger.info(f"Tool 등록 완료: {self.tool_registry.list_tools()}")
         else:
             logger.warning("검색 엔진 미초기화 — rag_search tool 미등록")
+
+        # 외부 API tool은 검색 엔진 유무와 무관하게 등록
+        self.tool_registry.register(ComplaintAnalysisTool())
+        logger.info(f"Tool 등록 완료: {self.tool_registry.list_tools()}")
 
     def _escape_special_tokens(self, text: str) -> str:
         """Escape EXAONE chat template tokens to prevent prompt injection."""
@@ -722,9 +726,14 @@ async def execute_tool(
         )
 
     # tool별 입력 스키마로 변환
-    if request.tool_name == "rag_search":
+    input_schemas = {
+        "rag_search": RAGSearchInput,
+        "complaint_analysis": ComplaintAnalysisInput,
+    }
+    schema_cls = input_schemas.get(request.tool_name)
+    if schema_cls is not None:
         try:
-            tool_input = RAGSearchInput(**request.parameters)
+            tool_input = schema_cls(**request.parameters)
         except Exception as e:
             raise HTTPException(status_code=422, detail=f"입력 검증 실패: {e}")
     else:

--- a/src/inference/tools/complaint_analysis.py
+++ b/src/inference/tools/complaint_analysis.py
@@ -1,0 +1,270 @@
+"""
+민원분석 API Tool: 공공데이터포털 민원분석 API를 표준 tool 인터페이스로 래핑.
+
+GovOn shell agent가 ``complaint_analysis`` 이름으로 호출하여
+공공데이터포털의 민원분석 정보를 조회한다.
+
+API: GET https://apis.data.go.kr/1140100/minAnalsInfoView5
+인증: serviceKey 파라미터 (환경변수 DATA_GO_KR_API_KEY)
+
+Issue: #394
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, ClassVar, Dict, List, Optional
+
+import httpx
+from loguru import logger
+from pydantic import Field, field_validator
+
+from src.inference.tools.base import BaseTool, ToolInput, ToolOutput
+
+
+# ---------------------------------------------------------------------------
+# 입출력 스키마
+# ---------------------------------------------------------------------------
+
+
+class ComplaintAnalysisInput(ToolInput):
+    """민원분석 API 입력 스키마.
+
+    Attributes
+    ----------
+    keyword : str
+        검색 키워드 (필수).
+    num_of_rows : int
+        한 페이지 결과 수 (기본 10, 최대 100).
+    page_no : int
+        페이지 번호 (기본 1).
+    """
+
+    keyword: str = Field(..., min_length=1, max_length=500, description="검색 키워드")
+    num_of_rows: int = Field(default=10, gt=0, le=100, description="한 페이지 결과 수")
+    page_no: int = Field(default=1, gt=0, description="페이지 번호")
+
+    @field_validator("keyword")
+    @classmethod
+    def keyword_must_not_be_blank(cls, v: str) -> str:
+        """공백만으로 이루어진 keyword를 거부한다."""
+        if not v.strip():
+            raise ValueError("keyword는 공백만으로 구성될 수 없습니다.")
+        return v.strip()
+
+
+# ---------------------------------------------------------------------------
+# 민원분석 Tool
+# ---------------------------------------------------------------------------
+
+_API_BASE_URL = "https://apis.data.go.kr/1140100/minAnalsInfoView5"
+_TIMEOUT_SECONDS = 10
+
+
+class ComplaintAnalysisTool(BaseTool):
+    """공공데이터포털 민원분석 API를 표준 tool 인터페이스로 제공한다.
+
+    환경변수 ``DATA_GO_KR_API_KEY`` 에 설정된 서비스 키로 인증하며,
+    httpx.AsyncClient를 사용하여 비동기로 API를 호출한다.
+    """
+
+    name: ClassVar[str] = "complaint_analysis"
+    description: ClassVar[str] = (
+        "공공데이터포털 민원분석 API를 호출하여 민원 분석 정보를 조회합니다. "
+        "키워드를 입력하면 관련 민원분석 결과를 반환합니다."
+    )
+
+    def _get_input_schema(self) -> Dict[str, Any]:
+        return ComplaintAnalysisInput.model_json_schema()
+
+    async def execute(self, tool_input: ToolInput) -> ToolOutput:
+        """민원분석 API를 호출하고 결과를 ToolOutput으로 반환한다."""
+        if not isinstance(tool_input, ComplaintAnalysisInput):
+            return ToolOutput(
+                success=False,
+                error="잘못된 입력 타입입니다. ComplaintAnalysisInput이 필요합니다.",
+            )
+
+        inp: ComplaintAnalysisInput = tool_input
+
+        # API 키 확인
+        api_key = os.getenv("DATA_GO_KR_API_KEY")
+        if not api_key:
+            return ToolOutput(
+                success=False,
+                error="DATA_GO_KR_API_KEY 환경변수가 설정되지 않았습니다.",
+            )
+
+        # API 호출
+        params = {
+            "serviceKey": api_key,
+            "keyword": inp.keyword,
+            "numOfRows": str(inp.num_of_rows),
+            "pageNo": str(inp.page_no),
+            "type": "json",
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT_SECONDS) as client:
+                response = await client.get(_API_BASE_URL, params=params)
+        except httpx.TimeoutException:
+            logger.warning(f"민원분석 API 타임아웃 (keyword={inp.keyword})")
+            return ToolOutput(
+                success=False,
+                error="민원분석 API 요청이 시간 초과되었습니다. 잠시 후 다시 시도해 주세요.",
+            )
+        except httpx.HTTPError as e:
+            logger.error(f"민원분석 API HTTP 오류: {e}")
+            return ToolOutput(
+                success=False,
+                error=f"민원분석 API 통신 오류가 발생했습니다: {type(e).__name__}",
+            )
+
+        # HTTP 상태 코드 확인
+        if response.status_code != 200:
+            logger.warning(
+                f"민원분석 API 비정상 응답: status={response.status_code}, "
+                f"keyword={inp.keyword}"
+            )
+            return ToolOutput(
+                success=False,
+                error=f"민원분석 API 오류 (HTTP {response.status_code})",
+            )
+
+        # 응답 파싱
+        try:
+            body = response.json()
+        except Exception:
+            logger.error("민원분석 API 응답 JSON 파싱 실패")
+            return ToolOutput(
+                success=False,
+                error="민원분석 API 응답을 파싱할 수 없습니다.",
+            )
+
+        items, total_count, page_no, num_of_rows = _parse_api_response(body)
+
+        # LLM 컨텍스트에 적합한 형태로 변환
+        results = _transform_items(items)
+
+        return ToolOutput(
+            success=True,
+            data={
+                "keyword": inp.keyword,
+                "total_count": total_count,
+                "page_no": page_no,
+                "num_of_rows": num_of_rows,
+                "results": results,
+                "result_count": len(results),
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# 헬퍼
+# ---------------------------------------------------------------------------
+
+
+def _parse_api_response(body: dict) -> tuple[List[dict], int, int, int]:
+    """공공데이터포털 API 응답을 유연하게 파싱한다.
+
+    표준 형식(response > body > items)을 우선 시도하되,
+    구조가 다를 경우에도 graceful하게 처리한다.
+
+    Returns
+    -------
+    tuple[List[dict], int, int, int]
+        (items 리스트, totalCount, pageNo, numOfRows)
+    """
+    # 표준 공공데이터포털 응답 구조
+    resp = body.get("response", body)
+    resp_body = resp.get("body", resp)
+
+    total_count = resp_body.get("totalCount", 0)
+    page_no = resp_body.get("pageNo", 1)
+    num_of_rows = resp_body.get("numOfRows", 10)
+
+    # items 추출: 다양한 구조 대응
+    raw_items = resp_body.get("items", [])
+
+    if isinstance(raw_items, dict):
+        # {"items": {"item": [...]}} 형태
+        item_list = raw_items.get("item", [])
+        if isinstance(item_list, dict):
+            item_list = [item_list]
+        items = item_list if isinstance(item_list, list) else []
+    elif isinstance(raw_items, list):
+        # {"items": [{...}, {...}]} 형태
+        # 각 원소가 {"item": {...}} 구조일 수도 있음
+        items = []
+        for entry in raw_items:
+            if isinstance(entry, dict) and "item" in entry and len(entry) == 1:
+                items.append(entry["item"])
+            else:
+                items.append(entry)
+    else:
+        items = []
+
+    return items, total_count, page_no, num_of_rows
+
+
+def _transform_items(items: List[dict]) -> List[Dict[str, Any]]:
+    """API 응답 항목들을 LLM 컨텍스트에 적합한 구조화된 형태로 변환한다.
+
+    공공데이터포털 민원분석 API 필드명이 다양할 수 있으므로
+    핵심 필드를 유연하게 추출한다.
+    """
+    results: List[Dict[str, Any]] = []
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+
+        result: Dict[str, Any] = {
+            "title": _extract_field(item, ["sj", "title", "minSj", "complaintTitle"]),
+            "content": _extract_field(
+                item, ["cn", "content", "minCn", "complaintContent", "dtlCn"]
+            ),
+            "category": _extract_field(
+                item, ["ctgry", "category", "minCtgry", "complaintCategory", "upperCtgryNm"]
+            ),
+            "agency": _extract_field(
+                item, ["insttNm", "agency", "orgNm", "chargerInsttNm"]
+            ),
+            "date": _extract_field(
+                item, ["regDt", "date", "registDt", "creatDt", "rceptDt"]
+            ),
+            "status": _extract_field(
+                item, ["sttus", "status", "processSttus", "resultCode"]
+            ),
+            "url": _extract_field(item, ["url", "dtlUrl", "linkUrl"]),
+        }
+
+        # 원본 항목에서 추가 메타데이터 수집 (변환되지 않은 필드)
+        known_keys = set()
+        for candidates in [
+            ["sj", "title", "minSj", "complaintTitle"],
+            ["cn", "content", "minCn", "complaintContent", "dtlCn"],
+            ["ctgry", "category", "minCtgry", "complaintCategory", "upperCtgryNm"],
+            ["insttNm", "agency", "orgNm", "chargerInsttNm"],
+            ["regDt", "date", "registDt", "creatDt", "rceptDt"],
+            ["sttus", "status", "processSttus", "resultCode"],
+            ["url", "dtlUrl", "linkUrl"],
+        ]:
+            known_keys.update(candidates)
+
+        extras = {k: v for k, v in item.items() if k not in known_keys and v}
+        if extras:
+            result["metadata"] = extras
+
+        results.append(result)
+
+    return results
+
+
+def _extract_field(item: dict, candidates: List[str]) -> str:
+    """후보 필드명 목록에서 첫 번째로 존재하는 값을 반환한다."""
+    for key in candidates:
+        value = item.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return ""

--- a/tests/test_inference/test_tools/test_complaint_analysis.py
+++ b/tests/test_inference/test_tools/test_complaint_analysis.py
@@ -1,0 +1,343 @@
+"""
+ComplaintAnalysisTool 단위 테스트.
+
+공공데이터포털 민원분석 API를 mock하여
+tool 인터페이스의 입출력 계약과 에러 처리를 검증한다.
+
+Issue: #394
+"""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# 무거운 의존성 mock 등록
+sys.modules.setdefault("sentence_transformers", MagicMock())
+sys.modules.setdefault("faiss", MagicMock())
+
+import httpx
+import pytest
+
+from src.inference.tools.base import ToolInput, ToolOutput
+from src.inference.tools.complaint_analysis import (
+    ComplaintAnalysisInput,
+    ComplaintAnalysisTool,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tool():
+    """ComplaintAnalysisTool 인스턴스."""
+    return ComplaintAnalysisTool()
+
+
+@pytest.fixture
+def sample_api_response():
+    """공공데이터포털 표준 API 응답 mock 데이터."""
+    return {
+        "response": {
+            "header": {"resultCode": "00", "resultMsg": "NORMAL SERVICE"},
+            "body": {
+                "items": [
+                    {
+                        "sj": "도로 파손 관련 민원 분석",
+                        "cn": "최근 3개월간 도로 파손 민원이 증가하고 있습니다.",
+                        "ctgry": "도로/교통",
+                        "insttNm": "국토교통부",
+                        "regDt": "2025-01-15",
+                        "sttus": "완료",
+                        "url": "https://example.go.kr/detail/1234",
+                    },
+                    {
+                        "sj": "보도블록 파손 민원 현황",
+                        "cn": "보도블록 파손 관련 민원이 전년 대비 20% 증가했습니다.",
+                        "ctgry": "도로/교통",
+                        "insttNm": "행정안전부",
+                        "regDt": "2025-02-01",
+                        "sttus": "진행중",
+                    },
+                ],
+                "totalCount": 42,
+                "pageNo": 1,
+                "numOfRows": 10,
+            },
+        }
+    }
+
+
+def _make_mock_response(
+    status_code: int = 200,
+    json_data: dict | None = None,
+) -> httpx.Response:
+    """httpx.Response mock 객체를 생성한다."""
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.json.return_value = json_data or {}
+    return response
+
+
+# ---------------------------------------------------------------------------
+# 1. 성공 케이스
+# ---------------------------------------------------------------------------
+
+
+class TestComplaintAnalysisSuccess:
+    @pytest.mark.asyncio
+    async def test_successful_api_call(self, tool, sample_api_response):
+        """httpx 응답 mock -> 정상 결과 반환."""
+        mock_response = _make_mock_response(200, sample_api_response)
+
+        with patch.dict("os.environ", {"DATA_GO_KR_API_KEY": "test-api-key"}):
+            with patch("httpx.AsyncClient") as mock_client_cls:
+                mock_client = AsyncMock()
+                mock_client.get = AsyncMock(return_value=mock_response)
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                mock_client_cls.return_value = mock_client
+
+                inp = ComplaintAnalysisInput(keyword="도로 파손")
+                output = await tool.run(inp)
+
+        assert output.success is True
+        assert output.tool_name == "complaint_analysis"
+        assert output.data["keyword"] == "도로 파손"
+        assert output.data["total_count"] == 42
+        assert output.data["result_count"] == 2
+
+        first = output.data["results"][0]
+        assert first["title"] == "도로 파손 관련 민원 분석"
+        assert "도로 파손 민원이 증가" in first["content"]
+        assert first["category"] == "도로/교통"
+        assert first["agency"] == "국토교통부"
+        assert first["date"] == "2025-01-15"
+        assert first["url"] == "https://example.go.kr/detail/1234"
+
+
+# ---------------------------------------------------------------------------
+# 2. 타임아웃 케이스
+# ---------------------------------------------------------------------------
+
+
+class TestComplaintAnalysisTimeout:
+    @pytest.mark.asyncio
+    async def test_timeout_returns_error(self, tool):
+        """httpx.TimeoutException mock -> success=False, 적절한 에러 메시지."""
+        with patch.dict("os.environ", {"DATA_GO_KR_API_KEY": "test-api-key"}):
+            with patch("httpx.AsyncClient") as mock_client_cls:
+                mock_client = AsyncMock()
+                mock_client.get = AsyncMock(side_effect=httpx.TimeoutException("timeout"))
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                mock_client_cls.return_value = mock_client
+
+                inp = ComplaintAnalysisInput(keyword="테스트")
+                output = await tool.run(inp)
+
+        assert output.success is False
+        assert "시간 초과" in output.error
+
+
+# ---------------------------------------------------------------------------
+# 3. API 실패 케이스
+# ---------------------------------------------------------------------------
+
+
+class TestComplaintAnalysisAPIFailure:
+    @pytest.mark.asyncio
+    async def test_http_500_returns_error(self, tool):
+        """HTTP 500 mock -> success=False, 적절한 에러 메시지."""
+        mock_response = _make_mock_response(500)
+
+        with patch.dict("os.environ", {"DATA_GO_KR_API_KEY": "test-api-key"}):
+            with patch("httpx.AsyncClient") as mock_client_cls:
+                mock_client = AsyncMock()
+                mock_client.get = AsyncMock(return_value=mock_response)
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                mock_client_cls.return_value = mock_client
+
+                inp = ComplaintAnalysisInput(keyword="테스트")
+                output = await tool.run(inp)
+
+        assert output.success is False
+        assert "500" in output.error
+
+    @pytest.mark.asyncio
+    async def test_http_error_returns_error(self, tool):
+        """httpx.HTTPError 발생 시 success=False."""
+        with patch.dict("os.environ", {"DATA_GO_KR_API_KEY": "test-api-key"}):
+            with patch("httpx.AsyncClient") as mock_client_cls:
+                mock_client = AsyncMock()
+                mock_client.get = AsyncMock(
+                    side_effect=httpx.ConnectError("connection refused")
+                )
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                mock_client_cls.return_value = mock_client
+
+                inp = ComplaintAnalysisInput(keyword="테스트")
+                output = await tool.run(inp)
+
+        assert output.success is False
+        assert "통신 오류" in output.error
+
+
+# ---------------------------------------------------------------------------
+# 4. API 키 미설정
+# ---------------------------------------------------------------------------
+
+
+class TestComplaintAnalysisNoAPIKey:
+    @pytest.mark.asyncio
+    async def test_missing_api_key_returns_error(self, tool):
+        """DATA_GO_KR_API_KEY 미설정 시 에러."""
+        with patch.dict("os.environ", {}, clear=True):
+            # 기존 환경변수에서 DATA_GO_KR_API_KEY 제거 보장
+            import os
+
+            orig = os.environ.pop("DATA_GO_KR_API_KEY", None)
+            try:
+                inp = ComplaintAnalysisInput(keyword="테스트")
+                output = await tool.run(inp)
+            finally:
+                if orig is not None:
+                    os.environ["DATA_GO_KR_API_KEY"] = orig
+
+        assert output.success is False
+        assert "DATA_GO_KR_API_KEY" in output.error
+
+
+# ---------------------------------------------------------------------------
+# 5. 입력 검증
+# ---------------------------------------------------------------------------
+
+
+class TestComplaintAnalysisInputValidation:
+    def test_empty_keyword_rejected(self):
+        """빈 keyword 거부."""
+        with pytest.raises(Exception):
+            ComplaintAnalysisInput(keyword="")
+
+    def test_blank_keyword_rejected(self):
+        """공백만 있는 keyword 거부."""
+        with pytest.raises(Exception):
+            ComplaintAnalysisInput(keyword="   ")
+
+    def test_valid_input(self):
+        """정상 입력 검증."""
+        inp = ComplaintAnalysisInput(keyword="도로 파손", num_of_rows=20, page_no=2)
+        assert inp.keyword == "도로 파손"
+        assert inp.num_of_rows == 20
+        assert inp.page_no == 2
+
+    def test_default_values(self):
+        """기본값 검증."""
+        inp = ComplaintAnalysisInput(keyword="테스트")
+        assert inp.num_of_rows == 10
+        assert inp.page_no == 1
+
+    def test_num_of_rows_max_100(self):
+        """num_of_rows 최대 100 제한."""
+        with pytest.raises(Exception):
+            ComplaintAnalysisInput(keyword="테스트", num_of_rows=101)
+
+    @pytest.mark.asyncio
+    async def test_wrong_input_type(self, tool):
+        """잘못된 입력 타입 거부."""
+        output = await tool.run(ToolInput())
+        assert output.success is False
+        assert "잘못된 입력 타입" in output.error
+
+
+# ---------------------------------------------------------------------------
+# 6. 스키마 검증
+# ---------------------------------------------------------------------------
+
+
+class TestComplaintAnalysisSchema:
+    def test_get_schema(self, tool):
+        """get_schema() 반환값 검증."""
+        schema = tool.get_schema()
+        assert schema["name"] == "complaint_analysis"
+        assert "description" in schema
+        assert "parameters" in schema
+
+        params = schema["parameters"]
+        assert "properties" in params
+        assert "keyword" in params["properties"]
+        assert "num_of_rows" in params["properties"]
+        assert "page_no" in params["properties"]
+
+    def test_tool_name_and_description(self, tool):
+        """tool 이름과 설명 검증."""
+        assert tool.name == "complaint_analysis"
+        assert "민원분석" in tool.description
+
+
+# ---------------------------------------------------------------------------
+# 7. 응답 파싱 유연성 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestComplaintAnalysisResponseParsing:
+    @pytest.mark.asyncio
+    async def test_nested_item_format(self, tool):
+        """items가 {"item": [...]} 형태인 경우 파싱."""
+        nested_response = {
+            "response": {
+                "header": {"resultCode": "00", "resultMsg": "NORMAL SERVICE"},
+                "body": {
+                    "items": {
+                        "item": [
+                            {
+                                "sj": "중첩 구조 테스트",
+                                "cn": "중첩 items 구조입니다.",
+                                "ctgry": "테스트",
+                            }
+                        ]
+                    },
+                    "totalCount": 1,
+                    "pageNo": 1,
+                    "numOfRows": 10,
+                },
+            }
+        }
+        mock_response = _make_mock_response(200, nested_response)
+
+        with patch.dict("os.environ", {"DATA_GO_KR_API_KEY": "test-api-key"}):
+            with patch("httpx.AsyncClient") as mock_client_cls:
+                mock_client = AsyncMock()
+                mock_client.get = AsyncMock(return_value=mock_response)
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                mock_client_cls.return_value = mock_client
+
+                inp = ComplaintAnalysisInput(keyword="테스트")
+                output = await tool.run(inp)
+
+        assert output.success is True
+        assert output.data["result_count"] == 1
+        assert output.data["results"][0]["title"] == "중첩 구조 테스트"
+
+    @pytest.mark.asyncio
+    async def test_elapsed_time_recorded(self, tool, sample_api_response):
+        """실행 소요 시간이 기록되는지 확인."""
+        mock_response = _make_mock_response(200, sample_api_response)
+
+        with patch.dict("os.environ", {"DATA_GO_KR_API_KEY": "test-api-key"}):
+            with patch("httpx.AsyncClient") as mock_client_cls:
+                mock_client = AsyncMock()
+                mock_client.get = AsyncMock(return_value=mock_response)
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                mock_client_cls.return_value = mock_client
+
+                inp = ComplaintAnalysisInput(keyword="성능 테스트")
+                output = await tool.run(inp)
+
+        assert output.elapsed_ms is not None
+        assert output.elapsed_ms >= 0


### PR DESCRIPTION
## Summary
- 공공데이터포털 민원분석 API(`apis.data.go.kr/1140100/minAnalsInfoView5`)를 `ComplaintAnalysisTool`로 래핑
- `httpx.AsyncClient`로 비동기 호출, 10초 타임아웃, graceful fallback
- `ToolRegistry`에 자동 등록, `/v1/tools/execute`에서 실행 가능

## Acceptance Criteria (#394)
- [x] 키워드 기반 유사 민원 사례 조회
- [x] LLM 컨텍스트용 JSON/문자열 변환
- [x] 10초 타임아웃 구현
- [x] 표준 오류 응답 반환
- [x] `.env`의 Data.go.kr API 키 사용
- [x] 단위 테스트 (성공/타임아웃/실패 + 12개 추가)

## Test plan
- [x] `pytest tests/test_inference/test_tools/ -v` — 41개 전체 통과
- [x] 기존 테스트 647개 회귀 없음

> **Note**: #395 브랜치 기반. #395 머지 후 main으로 rebase 필요.

Closes #394