### PR TITLE
docs: 첫 릴리즈 에이전틱 아키텍처 문서 동기화

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,26 +67,34 @@ Roadmap는 **Initiative 계층만** 표시한다. 세부 task는 각 initiative 
 
 ```mermaid
 graph TB
-    subgraph Frontend
-        A[Next.js 웹앱]
+    subgraph Shell
+        A[govon Interactive Shell]
+        B[Session Commands<br/>sources / retry / resume]
     end
 
-    subgraph Backend
-        B[FastAPI + vLLM]
-        C[EXAONE-Deep-7.8B<br/>AWQ 양자화]
-        D[FAISS + BM25<br/>하이브리드 검색]
+    subgraph Runtime
+        C[FastAPI Runtime Adapter]
+        D[LangGraph Decision Runtime]
+        E[vLLM Model Adapter]
+        F[Tool Registry]
+        G[Checkpoint + Audit Log]
     end
 
     subgraph Data
-        E[multilingual-e5-large<br/>임베딩]
-        F[4종 인덱스<br/>CASE/LAW/MANUAL/NOTICE]
+        H[FAISS + BM25<br/>하이브리드 검색]
+        I[민원분석 외부 API]
+        J[Session Store]
     end
 
-    A -->|SSE 스트리밍| B
-    B --> C
-    B --> D
+    A --> C
+    B --> A
+    C --> D
     D --> E
     D --> F
+    F --> H
+    F --> I
+    D --> G
+    G --> J
 ```
 
 ## 기술 스택
@@ -97,10 +105,11 @@ graph TB
 | **파인튜닝** | QLoRA (PEFT, SFTTrainer, WandB) |
 | **양자화** | AWQ INT4 (AutoAWQ) |
 | **LLM 서빙** | vLLM (PagedAttention) |
+| **오케스트레이션** | LangGraph 기반 decision runtime |
 | **임베딩** | multilingual-e5-large (1024차원) |
 | **벡터 검색** | FAISS (IndexFlatIP) + BM25 하이브리드 |
 | **백엔드** | FastAPI + Pydantic + SQLAlchemy |
-| **프론트엔드** | React / Next.js + TypeScript |
+| **클라이언트** | Python package entrypoint + interactive shell |
 | **컨테이너** | Docker Compose + NVIDIA Container Toolkit |
 | **CI/CD** | GitHub Actions (CI, Docker Publish, Offline Package) |
 | **모니터링** | DORA Metrics + Grafana Cloud |

--- a/docs/architecture/ADR-006-agentic-architecture.md
+++ b/docs/architecture/ADR-006-agentic-architecture.md
@@ -1,143 +1,146 @@
-# ADR-006: 3-Tier Agentic Architecture & Multi-LoRA Serving for GovOn
+# ADR-006: GovOn Shell-First Agentic Architecture for First Release
 
 ## Status
 Accepted
 
+## Date
+2026-04-02
+
 ## Context
-GovOn은 기존에 단일 방향의 정적 파이프라인(민원 입력 -> LLM 추론 -> 답변 반환)으로 구축되었습니다. 하지만, 사용자의 요구사항이 복잡해지고(유사 사례 검색, 외부 API를 통한 통계 확인, 공문서 자동 초안 작성 등), 다양한 도구(Tools)의 연동이 필수적이게 되었습니다. 기존 구조로는 이러한 도구들을 유연하게 조합하여 자율적으로 목표를 달성하는 "에이전트(Agent)"로서의 기능을 수행하기 어렵습니다. 따라서 전체 아키텍처를 유연하고 확장 가능한 에이전트 기반 구조로 재설계해야 합니다.
 
-또한, 뇌(Brain) 역할을 하는 모델은 "도구 호출(Tool Calling)"에 최적화되어야 하고, 손과 발(Tools) 역할을 하는 문서 생성 모델은 "민원 답변"이나 "공문서 포맷팅"에 최적화되어야 합니다. 이 이질적인 능력들을 하나의 모델에 모두 파인튜닝(Mixed Training)할 경우 파국적 망각(Catastrophic Forgetting)이 발생할 확률이 높습니다. 하지만 보급형 GPU(RTX 3060급) 환경의 온프레미스 제약상 여러 개의 무거운 독립 모델을 동시에 띄우는 것은 VRAM(OOM 리스크) 및 지연 시간 측면에서 불가능합니다.
+GovOn은 현재 FastAPI 기반 추론 API, vLLM 서빙, RAG 검색, 패키징 자산을 이미 보유하고 있다. 그러나 기존 문서는 첫 릴리즈의 사용자 표면을 `웹 UI/사이드바`로 설명하고, 에이전트 프레임워크도 `Smolagents Phase 1 -> LangGraph Phase 2`로 분리해 설명하고 있었다.
 
-### 참고: 에이전트 프레임워크 선택 (Discussion #403)
+이 구조는 현재 팀의 릴리즈 결정과 충돌한다.
 
-[Discussion #403: 에이전틱 AI 시스템 기술 검토](../../discussions/403)에서 EXAONE-Deep-7.8B의 네이티브 tool calling 미지원 제약을 분석한 결과, 다음과 같은 기술 선택이 이루어졌습니다:
+- 첫 릴리즈의 제품 표면은 `govon` 명령으로 진입하는 대화형 셸이다.
+- 첫 릴리즈 안에 graph-based decision framework를 포함한다.
+- LLM이 무작정 tool을 호출하지 않도록 state, guardrail, checkpoint, recovery를 런타임 기본 기능으로 둔다.
+- 웹/앱 UI는 같은 런타임 위에 추가되는 후속 표면이며, R1의 주제품이 아니다.
 
-- **Phase 1**: Smolagents 우선 도입 (코드 에이전트 방식, 네이티브 tool calling 불필요)
-- **Phase 2**: EXAONE 4.0 도입 시 LangGraph 전환 (네이티브 tool calling 활용)
-
-이 ADR은 위 의사결정을 Architecture 레벨에서 구체화합니다.
+따라서 첫 릴리즈 기준의 아키텍처를 `GovOn Agentic Shell + LangGraph-based decision framework`로 재정의해야 한다.
 
 ## Decision
-시스템을 **3-Tier Agentic Architecture (3계층 에이전틱 아키텍처)**와 **Multi-LoRA 서빙 아키텍처**를 결합하여 전면 개편합니다.
-이 아키텍처는 사람의 역할과 AI의 인지/행동 역할을 명확히 분리하며, 다음과 같은 3가지 핵심 구성요소로 이루어집니다.
 
-### 1. 3계층 역할 분리
-1. **Human (UI 계층 - 인간)**
-   - **역할**: 사용자가 지시(명령)를 내리고 결과를 확인하며 상호작용하는 창구입니다.
-   - **구현**: React/Next.js 기반의 에이전트 사이드바 및 메인 화면. 멀티턴 대화를 통해 의도를 명확히 전달하고, 스트리밍된 응답을 받습니다.
+### 1. 첫 릴리즈 제품 표면은 Shell-First로 고정한다
 
-2. **Brain (Query Engine / Orchestrator 계층 - 뇌)**
-   - **역할**: 사용자의 의도를 분석하고, 목표 달성을 위해 어떤 도구를 사용할지 결정(Planning & Routing)하는 제어 센터입니다.
-   - **구현**: FastAPI 백엔드가 사용자의 메시지를 받아 사용 가능한 도구 목록(JSON Schema)과 함께 프롬프트를 구성하고, 도구 호출 여부(Tool Calling)를 판단합니다. 도구 실행 결과를 취합하여 최종적인 자연어 응답을 합성(Synthesis)합니다.
+R1의 사용자 진입점은 웹 사이드바가 아니라 터미널에서 실행하는 `govon` 셸이다.
 
-3. **Hands and Feet (Tools 계층 - 손과 발)**
-   - **역할**: 뇌(Query Engine)의 지시에 따라 실제로 물리적/논리적 작업을 수행하는 실행 장치들입니다.
-   - **구현**:
-     - **민원답변 생성 기능**: 자체 파인튜닝된 지식을 바탕으로 문서 초안 생성.
-     - **공문서 생성 기능**: 보도자료, 연설문 등 공공 문서 초안을 생성하는 내부 로직.
-     - **유사 사례 검색 (RAG)**: FAISS 벡터 DB를 활용한 내부 매뉴얼 및 과거 민원 이력 검색.
-     - **외부 API 연동**: 공공데이터포털 등의 실시간 외부 민원 통계/사례 조회.
+- 사용자는 설치 후 shell/bash에서 `govon` 명령으로 세션을 시작한다.
+- 공무원은 기존 행정 시스템을 유지한 채 GovOn 셸을 독립형 업무 어시스턴트로 병행 사용한다.
+- 웹/앱 UI는 동일한 런타임을 재사용하는 후속 표면으로 취급한다.
 
-### 2. Multi-LoRA 동적 서빙 (vLLM)
-보급형 GPU 제약을 극복하고 전문성을 유지하기 위해 물리적인 다중 모델 배포 대신 **논리적인 어댑터 교체 방식**을 채택합니다.
-- **Base Model (메모리 상주)**: `EXAONE-Deep-7.8B-AWQ` (GPU VRAM에 1번만 로드, 약 5GB)
-- **Adapter 1 (Brain 용)**: Tool-Calling 최적화 LoRA
-- **Adapter 2 (Tool 용)**: 민원 답변 생성 최적화 LoRA
-- **Adapter 3 (Tool 용)**: 공문서 생성(보도자료 등) 최적화 LoRA
+### 2. 런타임의 핵심은 LangGraph 기반 상태 그래프다
 
-**작동 흐름 (Orchestrator Loop)**:
-FastAPI 백엔드(Orchestrator)가 추론 단계(Intent 파악 vs 문서 생성)에 맞춰 vLLM 서버에 `lora_request` 파라미터를 동적으로 스위칭하며 API를 호출합니다. 베이스 모델은 고정된 상태에서 수십 MB 크기의 어댑터 연산만 교체되므로 속도 저하(스와핑) 없이 고품질의 결과물을 얻을 수 있습니다.
+R1 런타임은 LangGraph 또는 동급의 graph runtime을 사용해 다음을 명시적으로 관리한다.
 
-### 3. 에이전트 프레임워크 (Phase별 전략)
+- 세션 상태
+- 사용자 의도와 route 결정
+- tool eligibility와 입력 검증
+- tool 실행 결과와 citations
+- draft 생성과 합성
+- checkpoint, retry, recovery
+- audit trace
 
-**Problem**: EXAONE-Deep-7.8B은 추론 특화 모델로 네이티브 function calling / tool calling을 지원하지 않습니다. 기존 프롬프트 엔지니어링 + JSON 파싱 방식은 구조화된 도구 호출의 안정성과 확장성에 한계가 있습니다.
+이 decision layer는 단순한 `LLM -> tool -> LLM` 루프가 아니라, 상태 전이와 중단 지점을 가진 agentic runtime이어야 한다.
 
-**Decision**:
+### 3. R1 아키텍처는 5개 계층으로 구성한다
 
-#### Phase 1: Smolagents 기반 코드 에이전트 (현재 → M3)
-- **프레임워크**: `smolagents[vllm] >= 1.11.0` (HuggingFace 공식, ~1,000줄 경량 코어)
-- **모델 연결**: EXAONE-Deep-7.8B를 vLLM OpenAI-compatible 엔드포인트(`/v1/chat/completions`)를 통해 Smolagents `OpenAIServerModel`로 래핑
-- **의도 파악**: Smolagents `ToolCallingAgent` 또는 `CodeAgent`가 User query → Tool 의도 결정 (JSON 함수 호출 불필요)
-- **Architecture 매핑**:
-  - **Brain (Query Engine)**: Smolagents Agent (Planning → Tool Selection → Execution → Synthesis)
-  - **Hands and Feet (Tools)**: 4개 `@tool` 데코레이터 (search_similar_cases, search_civil_complaints, generate_civil_reply, draft_public_document)
-  - **FastAPI Backend**: I/O Adapter + 세션 영속성 + 컨텍스트 윈도우 관리
-- **Milestone**: M3 (완료 대상)
+#### 3.1 User Surface
+- `govon` interactive shell
+- 자유 입력, 멀티라인 붙여넣기, slash commands
+- 스트리밍 응답, sources 확인, 세션 재개
 
-#### Phase 2: LangGraph 기반 상태 머신 (선택적, EXAONE 4.0 이후)
-- **트리거 조건**: EXAONE 4.0 라우터 모델 도입 + 네이티브 tool calling 검증 완료
-- **프레임워크**: `langgraph` + `langchain-openai`
-- **모델 연결**: EXAONE 4.0을 ChatOpenAI-compatible 엔드포인트로 연결
-- **의도 파악**: 네이티브 `tool_choice="auto"` 기반 (Smolagents 코드 에이전트 불필요)
-- **이점**:
-  - 체크포인팅 (실행 중단 후 재개)
-  - Human-in-the-loop (승인 필요 작업 지원)
-  - 더 정교한 상태 관리
-- **마이그레이션**: `docs/architecture/MIGRATION-smolagents-to-langgraph.md` 참고
-- **Milestone**: TBD (미정)
+#### 3.2 Runtime Adapter
+- FastAPI 기반 API 계층
+- shell client와 decision graph 사이의 I/O 어댑터
+- 스트리밍, 요청 검증, 환경 상태, 세션 식별자 처리
 
-**책임 경계**:
-| 계층 | 기술 | 책임 | 소유자 |
-|------|------|------|-------|
-| **I/O Adapter** | FastAPI 미들웨어 | HTTP 요청/응답 | backend/api_server.py |
-| **Reasoning Engine** | Smolagents Agent | 의도 파악 → Tool 선택 | backend/agent/orchestrator.py |
-| **Tools** | @tool 데코레이터 | 개별 Tool 구현 | backend/inference/tools/ |
-| **Session Management** | SQLAlchemy ORM | 대화 이력 영속성, Context Window 관리 | backend/db/ |
-| **Serving** | vLLM Multi-LoRA | 모델 추론 + LoRA 동적 스위칭 | vllm_server (별도 프로세스) |
+#### 3.3 Decision Graph
+- LangGraph state machine
+- route 결정: `no-tool`, `search-first`, `search-then-draft`, `ask-back`, `retry`, `fallback`
+- guardrail: 불필요한 tool 호출 억제, 입력 부족 시 재질문, 실패 시 복구 규칙 적용
+
+#### 3.4 Tooling and Model Execution
+- 표준 tool interface로 래핑된 검색/외부 API/초안 생성 action
+- vLLM OpenAI-compatible endpoint에 연결되는 model adapter
+- 필요 시 문서 유형 또는 태스크별 모델 프로필/LoRA 프로필 선택
+
+#### 3.5 Persistence
+- session transcript
+- graph checkpoint store
+- audit log / execution trace
+- recovery metadata
+
+### 4. Graph state를 R1의 공통 계약으로 사용한다
+
+다음 정보는 graph state 또는 연결된 persistence 계층에서 일관되게 유지한다.
+
+- `session_id`
+- `messages`
+- `user_intent`
+- `selected_route`
+- `eligible_tools`
+- `tool_inputs`
+- `tool_results`
+- `citations`
+- `draft_candidates`
+- `final_response`
+- `checkpoint_id`
+- `audit_trace`
+- `error_state`
+
+이 state schema는 shell, runtime, testing, recovery 문서가 공유하는 공통 용어 집합이다.
+
+### 5. Tool 호출은 "의사결정 이후"에만 허용한다
+
+모든 요청은 먼저 decision node를 통과해야 한다.
+
+- 단순 안내/설명 요청이면 `no-tool`
+- 사실 근거가 필요하면 `search-first`
+- 검색 근거를 바탕으로 답변 초안이 필요하면 `search-then-draft`
+- 입력이 부족하거나 모호하면 `ask-back`
+- 실패 시 `retry` 또는 `fallback`
+
+즉, tool 호출은 LLM의 자유 행동이 아니라 policy와 state에 의해 제약되는 실행 단계다.
+
+### 6. Checkpoint와 recovery를 R1 기본 기능으로 포함한다
+
+각 주요 graph node 실행 후 checkpoint를 저장한다.
+
+- 세션 재개
+- 특정 node부터 재시도
+- tool failure 이후 fallback
+- human-in-the-loop 승인 또는 확인
+
+이 기능은 R2가 아니라 R1 agentic runtime의 일부로 정의한다.
+
+### 7. 웹/앱 UI는 동일한 런타임 위에 올린다
+
+향후 웹 사이드 패널 또는 데스크톱 앱을 도입하더라도 orchestration은 별도로 만들지 않는다.
+
+- shell과 웹은 동일한 decision graph와 tool layer를 공유한다.
+- 표면만 달라지고, 세션/도구/정책/감사 로그는 같은 런타임 계약을 사용한다.
 
 ## Consequences
-**장점 (What becomes easier)**:
-- **전문성 유지 (No Catastrophic Forgetting)**: Tool-Calling 능력과 도메인 지식(공문서 양식)이 섞이지 않아 양쪽 모두의 품질이 보장됩니다.
-- **인프라 제약 극복**: RTX 3060 등 VRAM이 제한적인 보급형 GPU 환경에서도 '에이전틱 구조 + 다중 전문가 모델' 효과를 완벽하게 낼 수 있습니다.
-- **확장성 및 유지보수성**: 새로운 문서 양식(예: 회의록)이 추가되어도 베이스 모델 재학습 없이 작은 LoRA 어댑터 1개만 추가 학습하여 서빙에 끼워넣으면 됩니다.
-- **Smolagents 경량성**: 코어 로직이 ~1,000줄의 미니말한 코드로 구성되어, 디버깅과 커스터마이제이션이 용이
-- **프레임워크 독립성**: Tool 인터페이스가 Smolagents-specific하지 않아, LangGraph로의 마이그레이션이 명확함
-- **폐쇄망 호환성**: 네이티브 API 호출 없이 로컬 vLLM 엔드포인트만으로 작동
 
-**단점 (What becomes harder)**:
-- **복잡한 MLOps 파이프라인**: 거대한 1개의 데이터셋이 아닌, 목적에 맞게 정제된 3개의 데이터셋을 유지 관리하고 3번의 파인튜닝 스크립트를 관리해야 합니다.
-- **백엔드 로직 고도화**: FastAPI 백엔드가 단순 프롬프트 전달을 넘어, 현재 컨텍스트에 맞는 적절한 `lora_name`을 동적으로 라우팅하는 로직을 완벽하게 처리해야 합니다.
-- **vLLM 설정 관리**: vLLM 서버 실행 시 `--enable-lora` 설정과 여러 LoRA 어댑터 경로를 명시하는 인프라 구성이 추가됩니다.
-- **Smolagents 제약사항**: 체크포인팅과 Human-in-the-loop을 직접 구현해야 함 (LangGraph의 네이티브 기능 부재)
-- **프레임워크 전환 비용**: Phase 1(Smolagents)에서 Phase 2(LangGraph)로 전환 시, `@tool` → `BaseTool` 마이그레이션 + Agent 아키텍처 재설계 필요
-- **모델 버전 의존성**: EXAONE 4.0 도입을 Phase 2 전환의 선행 조건으로 명확히 해야 함
+### 장점
 
-#### LoRA 어댑터 레지스트리
+- 첫 릴리즈 정의와 아키텍처 문서가 일치한다.
+- agentic runtime의 핵심 가치인 guardrail, checkpoint, recovery를 초기에 확보할 수 있다.
+- shell, 테스트, 후속 UI가 동일한 orchestration spine을 공유한다.
+- tool layer와 model adapter가 분리되어 유지보수와 교체가 쉬워진다.
+- 세션/감사 로그/재시도 흐름을 운영 요구사항으로 명확히 다룰 수 있다.
 
-3개의 LoRA 어댑터 메타데이터와 경로를 관리하기 위해 `config/lora_adapters.yaml` 파일을 정의합니다.
+### 단점
 
-**파일 포맷** (`config/lora_adapters.yaml`):
-```yaml
-adapters:
-  - name: "adapter_brain"
-    path: "/path/to/model_brain_lora_weights"
-    target_module: "q_proj,v_proj"  # QLoRA 대상 모듈
-    task: "intent_classification"
-    eval_metric: "json_accuracy"
-    eval_score: 0.92
-    created_at: "2026-03-15T10:30:00Z"
-    
-  - name: "adapter_civil"
-    path: "/path/to/model_civil_lora_weights"
-    target_module: "q_proj,v_proj"
-    task: "civil_complaint_reply"
-    eval_metric: "rouge_l"
-    eval_score: 0.47
-    created_at: "2026-03-20T14:45:00Z"
-    
-  - name: "adapter_public_doc"
-    path: "/path/to/model_public_doc_lora_weights"
-    target_module: "q_proj,v_proj"
-    task: "public_document_drafting"
-    eval_metric: "format_accuracy"
-    eval_score: 0.88
-    created_at: "2026-03-25T09:15:00Z"
-```
+- 단순 API 래핑보다 런타임 구조가 복잡해진다.
+- state schema, checkpoint 저장소, tool policy를 함께 설계해야 한다.
+- shell-first 제품이라 초기 사용자층이 웹 UI보다 제한적일 수 있다.
+- 문서, 테스트, 런타임 구현이 같은 계약을 따라야 하므로 정합성 비용이 높다.
 
-**사용처**:
-- vLLM 시작 시: `--lora-modules` 파라미터 자동 생성 (Task 2.1)
-- Smolagents Agent 초기화: 사용 가능한 어댑터 목록 로드 (Task 2.3)
-- Tool 구현: 특정 LoRA 어댑터 동적 선택 (Task 3.4, 9.2)
-- 모니터링: WandB/Prometheus 메트릭 스크래핑
+## Implementation Notes
 
-**책임**: I-1 Task 1.3에서 생성, I-2 Task 2.1에서 참조
+- 모델 실행은 vLLM OpenAI-compatible endpoint와 adapter 계층을 통해 연결한다.
+- 검색, 민원분석, 초안 생성 기능은 framework-specific decorator가 아니라 표준 tool interface로 노출한다.
+- shell client는 runtime API를 직접 호출하되, 내부 orchestration 세부 구현에 결합되지 않는다.
+- 문서 기준 canonical workstream은 `#406`, `#407`, `#409`, `#410`, `#415`, `#416`, `#417`, `#418`이다.

--- a/docs/architecture/WORKFLOW-orchestrator-tool-calling.md
+++ b/docs/architecture/WORKFLOW-orchestrator-tool-calling.md
@@ -1,168 +1,250 @@
-# WORKFLOW: Agent Orchestrator & Tool Calling
-**Version**: 2.0
-**Date**: 2026-04-01
-**Author**: Workflow Architect
-**Status**: Active (Smolagents Phase 1 기반)
-**Implements**: GovOn Orchestrator Upgrade with Smolagents Agent (vs v1.1의 Custom Orchestrator)
+# WORKFLOW: GovOn Agentic Shell Runtime
+
+**Version**: 3.0
+**Date**: 2026-04-02
+**Status**: Active Target for R1
+**Implements**: GovOn Agentic Shell + graph-based decision framework
 
 ## Overview
-This workflow defines the end-to-end execution path for the newly upgraded GovOn conversational AI system. When a public official sends a message, the system uses an LLM Orchestrator to determine the user's intent. If external data is needed, it calls the appropriate tool (Local RAG or Civil Complaint Analysis API). If the intent is to draft a public document (e.g., press release, speech), the LLM utilizes its fine-tuned knowledge (trained on the Ministry of the Interior and Safety Public Doc dataset) to generate the draft natively without an external API call at runtime.
 
-최종 자연어 응답을 합성(Synthesis)합니다.
+이 워크플로우는 첫 릴리즈에서 공무원이 `govon` 셸을 통해 민원성 질의, 유사 사례 검색, 답변 초안 생성을 수행하는 기본 실행 경로를 정의한다.
 
-### Phase 기술 선택
+핵심 원칙은 다음과 같다.
 
-이 워크플로우는 **Smolagents Phase 1** 기반으로 설계되었습니다.
-- EXAONE-Deep-7.8B의 네이티브 tool calling 미지원 제약을 극복하기 위해 Smolagents의 코드 에이전트 방식 채택
-- 향후 EXAONE 4.0 도입 시 LangGraph로 전환할 수 있도록 설계 (상세: `docs/architecture/ADR-006-agentic-architecture.md` 참고)
+- 모든 요청은 먼저 decision graph를 통과한다.
+- tool 호출은 필요성이 확인된 뒤에만 실행한다.
+- 세션, checkpoint, audit trace를 turn 단위로 유지한다.
+- 실패 시 바로 중단하지 않고 retry, fallback, ask-back 중 하나로 복구한다.
 
 ## Actors
-| Actor | Role in this workflow |
+
+| Actor | Role |
 |---|---|
-| Public Official (Customer) | Initiates the action via the Web UI Chat Sidebar |
-| FastAPI Backend | Validates requests, manages conversation state, and orchestrates the LLM/Tools |
-| LLM Engine (vLLM + Smolagents) | Smolagents ToolCallingAgent는 vLLM의 OpenAI-compatible 엔드포인트를 활용하여 의도 분류, 도구 호출 결정, 응답 생성. Brain LoRA (`adapter_brain`)을 사용해 Tool-Calling 최적화. |
-| Smolagents Agent | ToolCallingAgent 또는 CodeAgent로서, 사용자 쿼리를 분석하고 사용 가능한 Tool 목록(JSON Schema)을 참고해 실행할 Tool을 선택. 재시도 로직과 에러 핸들링 포함. |
-| Tool: Local RAG (FAISS) | Retrieves internal civil complaint histories and manuals |
-| Tool: Civil Complaint API | External API (`apis.data.go.kr/1140100/minAnalsInfoView5`) for real-time similar cases and statistics |
+| Public Official | 기존 행정 시스템과 병행하여 GovOn 셸에 질의를 입력 |
+| GovOn Shell Client | 입력 수집, 스트리밍 표시, slash command, 세션 재개 |
+| FastAPI Runtime Adapter | 요청 검증, stream 처리, graph runtime 호출 |
+| LangGraph Decision Runtime | state 기반 route 결정, tool orchestration, synthesis |
+| Tool Nodes | RAG 검색, 민원분석 API, 초안 생성 action |
+| Persistence Layer | transcript, checkpoint, audit log 저장 |
 
 ## Prerequisites
-- vLLM serving the EXAONE-Deep-7.8B model with Multi-LoRA enabled is healthy.
-- Smolagents `smolagents[vllm] >= 1.11.0` 설치 필수
-- EXAONE-Deep-7.8B를 vLLM의 `/v1/chat/completions` 엔드포인트로 서빙 중
-- 4개 Tool (@tool 데코레이터)이 `src/inference/tools/` 디렉토리에 등록되어 있음
-- FastAPI 애플리케이션이 Smolagents Agent를 초기화한 상태
-- Conversation history database (SQLAlchemy ORM) operational
-- External API Keys (Data.go.kr) configured in `.env`
+
+- `govon` shell client가 설치되어 있다.
+- FastAPI runtime이 실행 중이다.
+- vLLM 또는 호환 모델 endpoint가 응답 가능하다.
+- 표준 tool registry에 검색/민원분석/초안 생성 action이 등록되어 있다.
+- session store와 checkpoint store가 사용 가능하다.
+- 외부 API가 필요한 경우 기관 환경변수가 설정되어 있다.
 
 ## Trigger
-User submits a message through the chat input in the `PG-001` Main Screen.
-**Entry point**: `POST /api/v1/chat/message` (or WebSocket equivalent).
 
----
+사용자가 shell/bash에서 `govon`을 실행하고 질의를 제출한다.
 
-## Workflow Tree
+예시 입력:
 
-### STEP 1: Message Validation & Context Assembly
-**Actor**: FastAPI Backend
-**Action**: Receives user message, retrieves conversation history, and formats the system prompt with available tool schemas (JSON Schema).
-**Timeout**: 2s
-**Input**: `{ "session_id": "uuid", "message": "국토부 도로 공사 보도자료 초안 써줘" }`
-**Output on SUCCESS**: `{ "context": [...history, new_msg], "tools": [...] }` -> GO TO STEP 2
-**Output on FAILURE**:
-  - `FAILURE(validation_error)`: Invalid session or empty message -> return 400.
-
-**Observable states during this step**:
-  - Customer sees: `TypingIndicator` (Loading spinner)
-
-### STEP 2: Intent & Tool Selection (Smolagents Agent 의도 파악)
-
-**Actor**: Smolagents ToolCallingAgent
-
-**Action**: FastAPI 백엔드가 사용자 메시지와 대화 이력을 Smolagents Agent에 전달합니다. Agent는 다음을 수행합니다:
-1. `agent.run(user_input)` 호출 -> 내부적으로 vLLM의 OpenAI-compatible API를 사용하여 Brain LoRA (`lora_request="adapter_brain"`)로 추론
-2. Tool 목록(4개 @tool의 JSON Schema)을 분석해 실행할 Tool 결정
-3. Tool 의도가 감지되면 Tool 이름과 파라미터를 JSON 형식으로 결정
-4. Tool 의도가 없으면 (일반 대화) 직접 텍스트 응답 생성 후 반환
-
-**Timeout**: 5s (vLLM 추론 + Agent 의사결정)
-
-**Output on SUCCESS**:
-  - IF `Tool Call`: `{ "tool_name": "search_civil_complaints", "args": {...} }` -> GO TO STEP 3
-  - IF `Drafting Document Task`: `{ "tool_name": "draft_public_doc", "args": {"type": "press_release"} }` -> GO TO STEP 4
-  - IF `Direct Response`: `{ "type": "text", "content": "안녕하세요! ..." }` -> GO TO STEP 5
-
-**Output on FAILURE**:
-  - `FAILURE(generation_error)`: Agent가 유효한 Tool 호출이나 텍스트를 생성하지 못함 -> GO TO ABORT_CLEANUP
-  - `FAILURE(timeout)`: vLLM 추론 5초 초과 -> GO TO ABORT_CLEANUP
-
-**Observable states during this step**:
-  - Customer sees: `TypingIndicator` (기존과 동일)
-  - Backend logs: Agent의 Tool 선택 로직 (debug mode)
-
-### STEP 3: Non-Drafting Tool Execution (Data Fetching)
-**Actor**: FastAPI Backend
-**Action**: Routes the execution to the specific data-fetching tool handler based on STEP 2 output.
-
-더 구체적으로, Smolagents Agent가 Tool 호출을 결정하면, FastAPI는 다음을 수행합니다:
-1. Agent의 Tool 호출 결과를 파싱
-2. 실제 Tool 함수(`src/inference/tools/` 디렉토리)를 동기/비동기로 실행
-3. Tool 반환값(str 또는 dict)을 정규화해서 Agent에 피드백 -> Agent가 다음 Step으로 진행
-
-**Timeout**: 10s
-**Branches**:
-  - **Branch 3A: Local RAG (FAISS)**
-    - Queries the local vector DB for internal manuals.
-  - **Branch 3B: Civil Complaint Analysis API**
-    - Calls `apis.data.go.kr/1140100/minAnalsInfoView5` API for similar cases, trending keywords.
-**Output on SUCCESS**: `{ "tool_result": "Raw data or summarized JSON" }` -> GO TO STEP 4
-**Output on FAILURE**:
-  - `FAILURE(api_timeout)`: External API times out -> [recovery: Return graceful error context to LLM: "Tool API timed out"] -> GO TO STEP 4
-
-**Observable states during this step**:
-  - Customer sees: UI updates to show `Tool execution in progress... (e.g., "민원분석 API 조회 중...")`
-
-### STEP 4: Final Synthesis & Drafting (LLM 응답 생성)
-
-**Actor**: Smolagents Agent (또는 FastAPI 백엔드)
-
-**Action**: STEP 3의 Tool 결과를 포함해서 최종 응답을 생성합니다:
-- Tool 결과가 있다면: Agent는 Tool 결과를 컨텍스트에 추가하고, 적절한 LoRA 어댑터를 선택해서 최종 응답 생성
-  - 민원 답변 Task: `lora_request="adapter_civil"` 사용
-  - 공문서 생성 Task: `lora_request="adapter_public_doc"` 사용
-- Tool 결과가 없다면 (STEP 2에서 직접 응답): Agent가 이미 텍스트를 생성했으므로 이 Step 스킵
-
-**Timeout**: 10s (LoRA 스위칭 + vLLM 추론)
-
-**Output on SUCCESS**: Streaming text chunks `"...final response..."` -> GO TO STEP 5
-
-### STEP 5: Response Delivery & State Persistence
-**Actor**: FastAPI Backend
-**Action**: Streams the final response to the Frontend and saves the updated conversation history to the database.
-**Output on SUCCESS**: HTTP 200 OK (Stream closed), DB updated.
-**What customer sees**: Full text response or official document draft (with HTML tables/images) is rendered in the chat UI.
-
-### ABORT_CLEANUP: Error Handling
-**Triggered by**: LLM failure, Smolagents Agent failure, unrecoverable system error.
-**Actions**:
-  1. Save error state to conversation log.
-  2. Send standard error message to Frontend.
-**What customer sees**: Error message bubble in UI with a "Retry" button.
-
----
-
-## State Transitions
 ```text
-[idle]
-  -> (User sends message)
-  -> [agent_reasoning] (Smolagents Agent 실행)
-    -> (Tool 의도 감지) -> [executing_tool]
-    -> (직접 응답) -> [streaming_response]
-  [executing_tool]
-    -> (Tool 완료)
-    -> [agent_synthesis] (Agent가 최종 응답 생성)
-    -> [streaming_response]
-  [streaming_response]
-    -> (Done)
-    -> [idle]
+민원 내용 붙여넣기:
+"아파트 단지 앞 도로 포트홀 보수 지연에 대한 민원이 반복 접수되고 있습니다..."
 ```
 
-## Handoff Contracts
+## State Graph
 
-### [Backend] -> [Civil Complaint API]
-**Endpoint**: `GET apis.data.go.kr/1140100/minAnalsInfoView5`
-**Payload**: `serviceKey`, `searchKeyword`, `target` (similar cases)
-**Success response**: JSON containing similar complaint cases, keywords.
-**Timeout**: 10s
-**On Failure**: Do not crash user request. Pass `{"error": "API failed"}` to Step 4 so LLM can apologize.
+기본 실행 상태는 다음과 같다.
+
+```text
+[session_bootstrap]
+  -> [input_normalize]
+  -> [decision]
+    -> [no_tool_response]
+    -> [search]
+    -> [search_then_draft]
+    -> [ask_back]
+    -> [fallback]
+  -> [synthesis]
+  -> [stream_response]
+  -> [persist]
+  -> [idle]
+```
+
+각 주요 node 이후에는 checkpoint를 저장한다.
+
+## Workflow Steps
+
+### STEP 0: Session Bootstrap
+
+**Actor**: GovOn Shell Client + Persistence Layer
+
+**Action**:
+- 새 세션을 만들거나 기존 세션을 재개한다.
+- 최근 transcript, draft 후보, checkpoint 메타데이터를 로드한다.
+
+**Output**:
+- `session_id`
+- `session_context`
+- `last_checkpoint` (있다면)
+
+### STEP 1: Input Normalize and Policy Precheck
+
+**Actor**: FastAPI Runtime Adapter
+
+**Action**:
+- 빈 입력, 과도한 길이, 기본 금지 패턴을 검증한다.
+- slash command 여부를 해석한다.
+- 일반 질의인 경우 graph runtime에 넘길 `normalized_input`을 만든다.
+
+**Failure / Recovery**:
+- validation error면 shell에 구조화된 오류를 반환한다.
+- slash command면 해당 제어 흐름으로 바로 전환한다.
+
+### STEP 2: Decision Node
+
+**Actor**: LangGraph Decision Runtime
+
+**Action**:
+- 현재 세션 상태와 사용자 입력을 바탕으로 다음 route 중 하나를 선택한다.
+
+**Available routes**:
+- `no-tool`: 일반 설명, 정책 안내, 간단한 재작성
+- `search-first`: 사실 근거 또는 유사 사례가 먼저 필요한 요청
+- `search-then-draft`: 검색 근거를 바탕으로 민원 답변/공문 초안까지 필요한 요청
+- `ask-back`: 입력이 부족하거나 범위가 불명확한 요청
+- `fallback`: tool 또는 모델 실패 이후 최소 안전 응답
+
+**Guardrails**:
+- 입력이 불충분하면 tool을 부르지 않고 `ask-back`
+- 동일 turn에서 중복 tool 반복 호출 금지
+- 빈 검색 결과에서는 근거 없는 draft 생성 금지
+- 외부 API 입력 스키마가 불완전하면 실행 차단
+
+### STEP 3A: No-Tool Response
+
+**Actor**: LangGraph Decision Runtime + Model Adapter
+
+**Action**:
+- tool 없이 직접 응답을 생성한다.
+- 정책 설명, 요약, 문체 수정, 간단한 후속 질문에 사용한다.
+
+**Output**:
+- `final_response`
+- `route = no-tool`
+
+### STEP 3B: Search-First
+
+**Actor**: Tool Nodes
+
+**Action**:
+- RAG 검색 또는 민원분석 API를 실행한다.
+- 결과를 `tool_results`, `citations` 필드에 정규화한다.
+
+**Failure / Recovery**:
+- 타임아웃이면 1회 재시도 후 실패 정보를 state에 저장한다.
+- 외부 API 실패 시 검색 가능한 내부 근거가 있으면 내부 근거만으로 계속 진행한다.
+- 둘 다 실패하면 `fallback`으로 전환한다.
+
+### STEP 3C: Search-Then-Draft
+
+**Actor**: Tool Nodes + Model Adapter
+
+**Action**:
+- 먼저 검색/분석 tool을 실행한다.
+- 검색 결과와 citations를 바탕으로 답변 초안 또는 공문 초안을 생성한다.
+- draft 결과를 `draft_candidates`에 저장한다.
+
+**Policy**:
+- draft는 검색 근거가 없으면 생성하지 않는다.
+- 근거 부족 시 `ask-back` 또는 `fallback`으로 내린다.
+
+### STEP 4: Synthesis
+
+**Actor**: LangGraph Decision Runtime
+
+**Action**:
+- tool 결과, citations, draft 후보를 하나의 사용자 응답으로 합성한다.
+- shell에서 바로 복사 가능한 최종본과 참고 근거를 분리한다.
+
+**Output shape**:
+- `final_response`
+- `sources`
+- `next_actions` (예: `/sources`, `/retry`, `/session resume`)
+
+### STEP 5: Stream Response
+
+**Actor**: FastAPI Runtime Adapter + GovOn Shell Client
+
+**Action**:
+- 응답을 스트리밍하거나 블록 단위로 출력한다.
+- shell은 최소한 다음 상태를 사용자에게 보여준다.
+  - `thinking`
+  - `searching`
+  - `drafting`
+  - `recovering`
+  - `done`
+
+### STEP 6: Persist and Checkpoint
+
+**Actor**: Persistence Layer
+
+**Action**:
+- transcript 저장
+- audit trace 저장
+- 현재 node 실행 결과 checkpoint 저장
+
+**Saved fields**:
+- `session_id`
+- `messages`
+- `selected_route`
+- `tool_results`
+- `citations`
+- `draft_candidates`
+- `final_response`
+- `checkpoint_id`
+- `error_state`
+
+### STEP 7: Recovery and Human-in-the-loop
+
+**Actor**: GovOn Shell Client + LangGraph Decision Runtime
+
+**Action**:
+- 실패한 node부터 재시도할 수 있다.
+- 사용자는 `/retry`, `/sources`, `/session resume` 같은 제어 명령을 사용할 수 있다.
+- 필요 시 사용자의 확인을 받아 다음 단계로 진행한다.
+
+**Typical cases**:
+- 외부 API 타임아웃 후 재시도
+- 검색 결과 부족으로 질문 보강 요청
+- 이전 checkpoint에서 세션 재개
+
+## Decision Table
+
+| User request pattern | Route | Notes |
+|---|---|---|
+| 간단한 설명, 요약, 문체 수정 | `no-tool` | 직접 응답 |
+| 근거가 필요한 사실성 질문 | `search-first` | citations 우선 |
+| 민원 답변/공문 초안 요청 | `search-then-draft` | 검색 후 초안 생성 |
+| 입력이 짧거나 모호함 | `ask-back` | 재질문 후 진행 |
+| tool 실패 또는 근거 부족 | `fallback` | 안전 응답 + 재시도 경로 제시 |
+
+## Shell Control Surface
+
+R1 셸은 최소한 다음 제어 흐름을 제공한다.
+
+- `/help`
+- `/sources`
+- `/retry`
+- `/session resume`
+- `/copy`
+- `/exit`
+
+이 명령은 별도의 제품 기능이 아니라 graph runtime의 상태 전이와 연결된 제어면이다.
 
 ## Test Cases
-| Test | Trigger | Expected behavior |
+
+| TC | Trigger | Expected behavior |
 |---|---|---|
-| TC-01: Direct Chat | "안녕" | Step 2 chooses No Tool. Step 5 returns greeting. |
-| TC-02: Public Doc Generation | "국토부 도로 공사 보도자료 초안 써줘" | Step 2 chooses No Tool. LLM drafts the document natively using its fine-tuned knowledge. Step 5 streams the draft. |
-| TC-03: Similar Case Search | "소음 민원 유사 사례 찾아봐" | Step 2 chooses `search_civil_complaints`. Step 3B calls API. Step 4 summarizes cases. |
-| TC-04: API Timeout Fallback | Step 3 external API takes >10s | LLM receives error context and tells user "현재 민원분석 API 연동 지연으로 조회할 수 없습니다." |
-| TC-05: Multi-tool 연쇄 호출 | "RAG로 유사 사례 찾은 후 민원분석 API로 통계 확인" | STEP 2에서 다중 Tool 의도 인식, STEP 3에서 순차 또는 병렬 실행, STEP 4에서 결과 통합 후 응답 |
-| TC-06: Tool 실패 후 Agent 대체 | STEP 3에서 Tool 타임아웃 (예: API 응답 10초 초과) | Smolagents가 Tool 실패 컨텍스트를 수신 -> STEP 4에서 "현재 조회 불가" 메시지 생성 (graceful degradation) |
-| TC-07: LoRA 스위칭 성능 | adapter_brain -> adapter_civil 전환 시 레이턴시 측정 | vLLM Multi-LoRA 동적 스위칭 < 1초 (GPU 벤치마크 기준) |
+| TC-01 | `govon` 실행 | 새 세션 또는 재개 가능한 세션 선택 |
+| TC-02 | 일반 설명 요청 | `no-tool` route로 직접 응답 |
+| TC-03 | 유사 민원 검색 요청 | `search-first` route로 citations 포함 응답 |
+| TC-04 | 답변 초안 요청 | `search-then-draft` route로 근거 + 초안 제공 |
+| TC-05 | 입력 부족 | `ask-back` route로 보강 질문 |
+| TC-06 | 외부 API 타임아웃 | retry 또는 fallback 후 세션 유지 |
+| TC-07 | 세션 재개 | checkpoint와 transcript를 불러와 후속 대화 가능 |


### PR DESCRIPTION
## 관련 이슈
- Closes #407
- Refs #402
- Refs #406

## 작업 배경
첫 릴리즈 정의가 `GovOn Agentic Shell + graph-based decision framework`로 정리된 이후에도, `ADR-006`과 workflow 문서는 여전히 기존 `웹 UI/사이드바 + Smolagents phase` 중심 설명이 남아 있었습니다.

이 PR은 `README`, `ADR-006`, `workflow` 문서를 shell-first + agentic-first 기준으로 다시 정렬해 `#407`의 남은 범위를 마무리합니다.

## 주요 변경 사항
- `ADR-006`을 shell-first release decision 기준으로 재작성했습니다.
- LangGraph 기반 decision runtime, state graph, tool guardrail, checkpoint, recovery 개념을 ADR에 명시했습니다.
- workflow 문서를 `decision -> no-tool/search-first/search-then-draft/ask-back/fallback -> persist` 흐름으로 재정리했습니다.
- shell session, slash command, checkpoint/recovery 흐름을 workflow에 연결했습니다.
- `README` 아키텍처 다이어그램과 기술 스택 설명을 interactive shell + runtime orchestration 기준으로 동기화했습니다.

## 테스트 결과
- [ ] 로컬 테스트 완료
- [ ] 기존 기능 정상 동작 확인
- `git diff --check` 통과
- 문서 용어 정합성 수동 확인

## 기타 사항
- 이번 PR은 문서 변경만 포함하며 런타임 코드 동작은 수정하지 않습니다.
- `docs/GovOn-orchestrator-tasklist.md`는 이미 shell-first 기준으로 정리되어 있어, 이번 PR은 `ADR-006`과 workflow 문서의 남은 불일치를 해소하는 데 집중했습니다.

---

## 머지 조건 체크리스트
- [ ] 2명 이상의 코드리뷰 승인 완료
- [ ] CODEOWNERS(팀장) 최종 승인 완료
- [ ] 모든 리뷰 코멘트 해결(resolved) 완료

## 리뷰어 가이드
| 태그 | 의미 | 예시 |
|------|------|------|
| `[MUST]` | 반드시 수정 (보안·버그·성능 이슈) | `[MUST] API 키가 로그에 노출됩니다.` |
| `[SHOULD]` | 수정 강권 (코드 품질·유지보수성) | `[SHOULD] 이 로직은 별도 함수로 분리하는 것이 좋습니다.` |
| `[NITS]` | 사소한 개선 (스타일·네이밍) | `[NITS] 변수명을 `result`보다 `parsed_output`이 명확합니다.` |
| `[QUESTION]` | 이해를 위한 질문 | `[QUESTION] 이 조건이 항상 True일 수 있지 않나요?` |
