### PR TITLE
test: #397 draft_civil_response / append_evidence capability 단위·통합 테스트 추가

### DIFF
--- a/tests/test_inference/test_civil_response_capabilities.py
+++ b/tests/test_inference/test_civil_response_capabilities.py
@@ -103,9 +103,7 @@ def mock_registry_fns():
     """build_mvp_registry에 주입할 mock 함수 모음."""
     return {
         "rag_search_fn": _make_async_fn({"text": "rag_result", "results": []}),
-        "draft_civil_response_fn": _make_async_fn(
-            {"text": "민원 답변 초안입니다.", "results": []}
-        ),
+        "draft_civil_response_fn": _make_async_fn({"text": "민원 답변 초안입니다.", "results": []}),
         "append_evidence_fn": _make_async_fn(
             {
                 "text": "근거 보강 결과입니다.",
@@ -843,7 +841,9 @@ class TestExecutorAdapterIntegration:
         error_fns = {
             "rag_search_fn": _make_async_fn({"results": []}),
             "draft_civil_response_fn": _make_async_fn({"error": "LLM 오류 발생"}),
-            "append_evidence_fn": _make_async_fn({"text": "", "api_citations": [], "rag_results": []}),
+            "append_evidence_fn": _make_async_fn(
+                {"text": "", "api_citations": [], "rag_results": []}
+            ),
         }
         registry = build_mvp_registry(
             rag_search_fn=error_fns["rag_search_fn"],


### PR DESCRIPTION
## 관련 이슈

Closes #397

## 작업 배경

draft_civil_response / append_evidence capability가 구현 완료되었으나, 단위·통합 테스트가 부재하여 회귀 방지가 불가능했다. 두 capability의 LookupResult 변환 로직, metadata 값, registry 등록, RegistryExecutorAdapter 실행 흐름을 검증하는 테스트를 추가한다.

## 주요 변경 사항

- `DraftCivilResponseCapability` 단위 테스트: 정상/에러 응답 LookupResult 변환, `timeout_sec=30.0`, `provider="local_llm"` 검증
- `AppendEvidenceCapability` 단위 테스트: 정상/에러/rag+api 혼합/빈 결과 처리, `timeout_sec=15.0`, `provider="local_vectordb+data.go.kr"` 검증
- 경로 분리 통합 테스트: registry 등록 확인, `RegistryExecutorAdapter`를 통한 두 capability 독립 실행 검증
- 총 66개 테스트, 외부 서비스(vLLM/API)는 모두 AsyncMock 처리

## 테스트 결과

- [x] CI lint (Black/Flake8) 통과
- [x] CI test (3.10, 3.11) 통과
- [x] CI security 통과
- [x] 기존 기능 정상 동작 확인

## 기타 사항

- `langgraph`/`langchain_core` 미설치 환경에서도 실행 가능하도록 모듈 수준 mock 처리 포함
- 실제 외부 서비스(vLLM, 벡터DB, data.go.kr API)와의 연동은 mock 처리

---

## 머지 조건 체크리스트

- [ ] 1명 이상의 코드리뷰 승인 완료
- [ ] CODEOWNERS(팀장) 최종 승인 완료
- [ ] 모든 리뷰 코멘트 해결(resolved) 완료