### PR TITLE
test: #162 LangGraph tooling E2E 통합 테스트 구현

### DIFF
--- a/tests/test_inference/test_tooling_e2e.py
+++ b/tests/test_inference/test_tooling_e2e.py
@@ -318,9 +318,9 @@ class TestDraftResponsePipeline:
 
         # api_action=None이면 유의미한 결과가 없으므로 fallback 메시지여야 한다
         final_text = result.get("final_text", "")
-        assert final_text == "요청을 처리할 수 없습니다.", (
-            f"api_action=None일 때 유의미한 결과가 없으므로 fallback이어야 합니다. 실제: {final_text!r}"
-        )
+        assert (
+            final_text == "요청을 처리할 수 없습니다."
+        ), f"api_action=None일 때 유의미한 결과가 없으므로 fallback이어야 합니다. 실제: {final_text!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -428,18 +428,18 @@ class TestEvidenceAugmentationPipeline:
         _approve(graph, config)
 
         # append_evidence execute_fn이 호출될 때 rag_search 결과가 누적 컨텍스트에 있어야 한다
-        assert "rag_search" in received_context, (
-            "append_evidence 호출 시 context에 rag_search 결과가 있어야 합니다"
-        )
-        assert isinstance(received_context["rag_search"], dict), (
-            "rag_search 결과는 dict이어야 합니다"
-        )
-        assert "api_lookup" in received_context, (
-            "append_evidence 호출 시 context에 api_lookup 결과가 있어야 합니다"
-        )
-        assert isinstance(received_context["api_lookup"], dict), (
-            "api_lookup 결과는 dict이어야 합니다"
-        )
+        assert (
+            "rag_search" in received_context
+        ), "append_evidence 호출 시 context에 rag_search 결과가 있어야 합니다"
+        assert isinstance(
+            received_context["rag_search"], dict
+        ), "rag_search 결과는 dict이어야 합니다"
+        assert (
+            "api_lookup" in received_context
+        ), "append_evidence 호출 시 context에 api_lookup 결과가 있어야 합니다"
+        assert isinstance(
+            received_context["api_lookup"], dict
+        ), "api_lookup 결과는 dict이어야 합니다"
 
     def test_evidence_with_empty_rag(self, make_tooling_graph):
         """rag 결과가 없을 때도 append_evidence 파이프라인이 완료된다.
@@ -852,12 +852,12 @@ class TestEmptyResultScenarios:
         final_text = result.get("final_text", "")
         # rag 결과가 있고 draft가 실패했으므로 rag 기반 출력이 있어야 한다
         # _extract_final_text는 evidence/draft가 없으면 [로컬 문서 근거] 포맷 사용
-        assert "[로컬 문서 근거]" in final_text, (
-            f"rag만 성공 시 '[로컬 문서 근거]' 포맷이어야 합니다. 실제: {final_text!r}"
-        )
-        assert "도로법" in final_text, (
-            f"rag 결과의 제목이 final_text에 포함되어야 합니다. 실제: {final_text!r}"
-        )
+        assert (
+            "[로컬 문서 근거]" in final_text
+        ), f"rag만 성공 시 '[로컬 문서 근거]' 포맷이어야 합니다. 실제: {final_text!r}"
+        assert (
+            "도로법" in final_text
+        ), f"rag 결과의 제목이 final_text에 포함되어야 합니다. 실제: {final_text!r}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 관련 이슈
<!-- 반드시 관련 이슈를 연결해 주세요. 이슈 연결 없는 PR은 리뷰가 진행되지 않습니다. -->
- Closes #162

## 작업 배경

LangGraph tooling layer가 PR #448(api_lookup), PR #449(rag_search), PR #447(planner 검증) 등 핵심 capability 구현 및 통합 완료됨에 따라, capability→adapter→node 전체 파이프라인을 실제 인스턴스로 검증하는 E2E 통합 테스트가 필요했다.

기존 `test_graph_smoke.py`와 `test_orchestration_e2e.py`는 `StubExecutorAdapter`를 사용하여 capability 내부 로직을 건너뛰었으나, 이번 테스트는 **실제 capability 인스턴스 + mock execute_fn** 조합으로 진짜 파이프라인을 검증한다.

## 주요 변경 사항

- `tests/test_inference/test_tooling_e2e.py` 신규 추가 (16개 테스트)
  - `_make_registry()`: 실제 capability 인스턴스(RagSearchCapability, ApiLookupCapability, DraftCivilResponseCapability, AppendEvidenceCapability)를 injectable mock execute_fn으로 구성하는 헬퍼
  - **TestDraftResponsePipeline** (3개): rag+api+draft 3-tool 콤보, synthesis 우선순위, api_only lookup
  - **TestEvidenceAugmentationPipeline** (3개): append_evidence 병합, context chaining 검증, empty rag 시나리오
  - **TestPartialFailureE2E** (4개): rag timeout, api 예외, draft 예외, 전체 실패 fallback
  - **TestEmptyResultScenarios** (3개): no_match, low_confidence, rag 단독 fallback 포맷
  - **TestPersistToolRunAccuracy** (3개): 부분 실패 tool_runs 기록, total_latency_ms, executed_capabilities 정확도

## 테스트 결과
- [ ] 로컬 테스트 완료 (macOS 환경에서 triton 의존성 이슈로 로컬 실행 불가, CI로 검증)
- [ ] 기존 기능 정상 동작 확인

## 기타 사항

- `test_tooling_e2e.py`는 CI의 `run_inference_ci.sh` 내 `*e2e*` 제외 패턴에 의해 단위 테스트 레인에서는 실행되지 않음 (기존 `test_orchestration_e2e.py`와 동일한 정책)
- `asyncio.TimeoutError`를 직접 raise하여 rag timeout 시나리오를 빠르게 시뮬레이션 (16초 대기 불필요)
- `test_api_failure_draft_still_runs`는 `make_tooling_graph` 픽스처 대신 `session_store` 픽스처만 사용하여 `FailingApiAction`을 직접 주입하는 방식으로 구현

---

## 머지 조건 체크리스트
- [ ] 1명 이상의 코드리뷰 승인 완료
- [ ] CODEOWNERS(팀장) 최종 승인 완료
- [ ] 모든 리뷰 코멘트 해결(resolved) 완료

## 리뷰어 가이드

| 태그 | 의미 | 예시 |
|------|------|------|
| `[MUST]` | 반드시 수정 (보안·버그·성능 이슈) | `[MUST] API 키가 로그에 노출됩니다.` |
| `[SHOULD]` | 수정 강권 (코드 품질·유지보수성) | `[SHOULD] 이 로직은 별도 함수로 분리하는 것이 좋습니다.` |
| `[NITS]` | 사소한 개선 (스타일·네이밍) | `[NITS] 변수명을 \`result\`보다 \`parsed_output\`이 명확합니다.` |
| `[QUESTION]` | 이해를 위한 질문 | `[QUESTION] 이 조건이 항상 True일 수 있지 않나요?` |

**리뷰 포인트:**
- `_make_registry()` 헬퍼가 실제 capability 인스턴스를 올바르게 구성하는지
- 각 테스트가 capability 내부 로직(타임아웃, fallback, evidence 정규화)을 적절히 커버하는지
- `ConfigurableStubPlanner` 재사용 패턴이 기존 E2E 테스트와 일관성 있는지