### PR TITLE
fix: WS8 코드 감사 결과 반영

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,7 @@ LOG_DIR=/var/log/govon
 CACHE_DIR=/app/.cache
 
 # --- 보안 ---
-API_KEY=your_secret_api_key_here
+API_KEY=CHANGE_ME_TO_SECURE_RANDOM_KEY
 CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 
 # --- Rate Limiting / 타임아웃 ---

--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -41,14 +41,14 @@ jobs:
             .cache
 
           cat > /tmp/govon-offline.env <<'EOF'
-          API_KEY=offline-ci-key
-          BM25_INDEX_HMAC_KEY=offline-ci-hmac-key
-          CORS_ORIGINS=http://127.0.0.1:3000
-          EOF
+API_KEY=offline-ci-key
+BM25_INDEX_HMAC_KEY=offline-ci-hmac-key
+CORS_ORIGINS=http://127.0.0.1:3000
+EOF
 
           cat > /tmp/govon-prod.env <<'EOF'
-          API_KEY=prod-ci-key
-          EOF
+API_KEY=prod-ci-key
+EOF
 
       - name: Compose 설정 검증
         run: |
@@ -126,16 +126,16 @@ jobs:
             .cache
 
           cat > /tmp/govon-gpu.env <<'EOF'
-          API_KEY=gpu-smoke-key
-          BM25_INDEX_HMAC_KEY=gpu-smoke-hmac-key
-          CORS_ORIGINS=http://127.0.0.1:3000
-          HOST_PORT=18001
-          USE_RAG_PIPELINE=false
-          SKIP_MODEL_LOAD=false
-          GPU_UTILIZATION=0.5
-          MAX_MODEL_LEN=2048
-          MODEL_PATH=umyunsang/GovOn-EXAONE-AWQ-v2
-          EOF
+API_KEY=gpu-smoke-key
+BM25_INDEX_HMAC_KEY=gpu-smoke-hmac-key
+CORS_ORIGINS=http://127.0.0.1:3000
+HOST_PORT=18001
+USE_RAG_PIPELINE=false
+SKIP_MODEL_LOAD=false
+GPU_UTILIZATION=0.5
+MAX_MODEL_LEN=2048
+MODEL_PATH=umyunsang/GovOn-EXAONE-AWQ-v2
+EOF
 
       - name: 호스트 GPU 인식 확인
         run: nvidia-smi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for GovOn Backend
 
 # Use NVIDIA CUDA base image with Python 3.10
-FROM nvidia/cuda:13.2.0-devel-ubuntu22.04
+FROM nvidia/cuda:12.1.1-runtime-ubuntu22.04
 
 LABEL org.opencontainers.image.source="https://github.com/GovOn-Org/GovOn"
 LABEL org.opencontainers.image.description="GovOn AI Civil Complaint Analysis System"
@@ -45,6 +45,11 @@ RUN mkdir -p models/faiss_index data/processed
 
 # Expose port
 EXPOSE 8000
+
+# Non-root user for security
+RUN groupadd -r govon && useradd -r -g govon -d /app govon
+RUN chown -R govon:govon /app
+USER govon
 
 # Command to run the application
 CMD ["python3.10", "-m", "src.inference.api_server"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
+    "Operating System :: POSIX",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/scripts/govon-bootstrap.sh
+++ b/scripts/govon-bootstrap.sh
@@ -9,6 +9,8 @@
 
 set -euo pipefail
 
+PYTHON_CMD=""
+
 # ---------------------------------------------------------------------------
 # 설정
 # ---------------------------------------------------------------------------
@@ -142,9 +144,9 @@ cmd_start() {
         exit 1
     fi
 
-    # health check 대기 (최대 30초)
+    # health check 대기 (최대 120초)
     local elapsed=0
-    local max_wait=30
+    local max_wait=120
     _info "health check 대기 중..."
     while [ $elapsed -lt $max_wait ]; do
         if _health_check; then
@@ -155,7 +157,7 @@ cmd_start() {
         elapsed=$((elapsed + 1))
     done
 
-    _error "health check timeout (${max_wait}초). 로그를 확인하세요: $LOG_FILE"
+    _error "health check timeout (${max_wait}s). 로그를 확인하세요: $LOG_FILE"
     exit 1
 }
 

--- a/src/cli/daemon.py
+++ b/src/cli/daemon.py
@@ -37,7 +37,7 @@ class DaemonManager:
     """
 
     GOVON_HOME = Path.home() / ".govon"
-    _HEALTH_CHECK_TIMEOUT = 30  # 최대 대기 초
+    _HEALTH_CHECK_TIMEOUT = 120  # 최대 대기 초
     _HEALTH_CHECK_INTERVAL = 1  # 재시도 간격 (초)
 
     def __init__(self) -> None:
@@ -87,8 +87,6 @@ class DaemonManager:
             logger.info("[daemon] 이미 실행 중입니다.")
             return True
 
-        log_file = open(self.log_path, "a")  # noqa: WPS515
-
         cmd = [
             sys.executable,
             "-m",
@@ -102,13 +100,13 @@ class DaemonManager:
 
         logger.info(f"[daemon] 기동 명령: {' '.join(cmd)}")
 
-        proc = subprocess.Popen(
-            cmd,
-            stdout=log_file,
-            stderr=log_file,
-            start_new_session=True,
-        )
-        log_file.close()
+        with open(self.log_path, "a") as log_file:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=log_file,
+                stderr=log_file,
+                start_new_session=True,
+            )
 
         self._write_pid(proc.pid)
         logger.info(f"[daemon] 프로세스 기동 완료. PID={proc.pid}")
@@ -207,7 +205,7 @@ class DaemonManager:
             return True
 
     def _wait_until_healthy(self) -> bool:
-        """health check가 통과할 때까지 최대 30초 대기한다."""
+        """health check가 통과할 때까지 최대 120초 대기한다."""
         deadline = time.monotonic() + self._HEALTH_CHECK_TIMEOUT
         while time.monotonic() < deadline:
             try:
@@ -220,5 +218,5 @@ class DaemonManager:
                 pass
             time.sleep(self._HEALTH_CHECK_INTERVAL)
 
-        logger.error("[daemon] health check timeout (30초).")
+        logger.error("[daemon] health check timeout (120초).")
         return False


### PR DESCRIPTION
## 관련 이슈
- WS8 (#372) 코드 감사 결과 반영

## 작업 배경
WS8 코드 감사에서 발견된 보안 취약점 및 버그를 수정합니다.

## 주요 변경 사항
- Dockerfile: CUDA 12.1.1-runtime + non-root user 적용
- daemon.py: 파일 디스크립터 누수 수정 (with 문)
- daemon/bootstrap: health check timeout 30s → 120s
- CI workflow: heredoc 들여쓰기 오류 수정
- .env.example: 플레이스홀더 통일
- pyproject.toml: OS classifier 수정

## 테스트 결과
- [ ] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인

## 기타 사항
- M1 (MUST): Dockerfile CUDA 13.2.0(존재하지 않는 버전) → 12.1.1, devel → runtime, non-root user 추가
- M2 (MUST): daemon.py open() file descriptor leak → with 문으로 수정
- S1~S5 (SHOULD): CI heredoc 들여쓰기, health timeout, PYTHON_CMD 초기화, .env.example 플레이스홀더, OS classifier

---

## 머지 조건 체크리스트
- [ ] 1명 이상의 코드리뷰 승인 완료
- [ ] CODEOWNERS(팀장) 최종 승인 완료
- [ ] 모든 리뷰 코멘트 해결(resolved) 완료

## 리뷰어 가이드
<!-- 리뷰어는 아래 태그를 사용해 구조화된 피드백을 남겨주세요. -->

| 태그 | 의미 | 예시 |
|------|------|------|
| `[MUST]` | 반드시 수정 (보안·버그·성능 이슈) | `[MUST] API 키가 로그에 노출됩니다.` |
| `[SHOULD]` | 수정 강권 (코드 품질·유지보수성) | `[SHOULD] 이 로직은 별도 함수로 분리하는 것이 좋습니다.` |
| `[NITS]` | 사소한 개선 (스타일·네이밍) | `[NITS] 변수명을 \`result\`보다 \`parsed_output\`이 명확합니다.` |
| `[QUESTION]` | 이해를 위한 질문 | `[QUESTION] 이 조건이 항상 True일 수 있지 않나요?` |