### PR TITLE
fix: reusable-security-scan permissions 동적 표현식 제거

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -30,8 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      security-events: ${{ inputs.upload-sarif && 'write' || 'read' }}
-      issues: ${{ inputs.create-issue-on-vuln && 'write' || 'read' }}
+      security-events: write
+      issues: write
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- `reusable-security-scan.yml`의 permissions에 `${{ }}` 동적 표현식 사용으로 워크플로우 파싱 실패
- GitHub Actions는 permissions 블록에 표현식을 지원하지 않음
- `security-events`, `issues`를 정적 `write`로 교체
- Phase 2 머지 후 main push 트리거 5개 워크플로우 연쇄 실패 원인

## Test plan
- [ ] main 머지 후 ci.yml, security.yml, reusable-security-scan.yml 정상 실행 확인
- [ ] compose-smoke.yml, dora-metrics.yml 연쇄 실패 해소 확인