### PR TITLE
fix: DORA 워크플로우 Deploy Key 인증 전환

### DIFF
--- a/.github/workflows/dora-metrics.yml
+++ b/.github/workflows/dora-metrics.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Collect DORA 4 Metrics
         id: dora


### PR DESCRIPTION
## 관련 이슈

Refs #231

## 작업 배경

DORA 워크플로우가 정상 실행되었으나, Branch ruleset이 `GITHUB_TOKEN`의 main 직접 push를 차단하여 배지/보고서 커밋이 실패함.

## 수정 내용

- `actions/checkout@v6`의 인증을 `token: GITHUB_TOKEN` → `ssh-key: DEPLOY_KEY`로 전환

## 설정 변경 사항 (이미 적용됨)

- Org: `deploy_keys_enabled_for_repositories: true`
- Repo: "DORA Metrics Deploy Key" (ed25519, write access) 등록
- Repo secret: `DEPLOY_KEY` 등록
- Ruleset: DeployKey를 bypass actor로 추가

## 머지 조건 체크리스트

- [ ] 1명 이상의 코드리뷰 승인 완료
- [ ] CODEOWNERS(팀장) 최종 승인 완료
- [ ] 모든 리뷰 코멘트 해결(resolved) 완료