### PR TITLE
feat: 터미널 너비 기반 CLI 반응형 레이아웃 적용

### DIFF
--- a/src/cli/approval_ui.py
+++ b/src/cli/approval_ui.py
@@ -7,7 +7,6 @@ Falls back to a plain input() prompt if prompt_toolkit is not installed.
 from __future__ import annotations
 
 import unicodedata
-from typing import Optional
 
 from src.cli.terminal import (
     get_approval_box_width,
@@ -39,16 +38,15 @@ def _display_width(s: str) -> int:
     return w
 
 
-def _box_line(content: str = "", width: Optional[int] = None) -> str:
+def _box_line(content: str = "", *, width: int) -> str:
     """Return a single box line padded to *width* display columns."""
-    line_width = get_approval_box_width(get_terminal_columns()) if width is None else width
-    pad = line_width - _display_width(content)
+    pad = width - _display_width(content)
     inner = content + " " * max(pad, 0)
     return f"│ {inner} │"
 
 
 def _build_box_lines(
-    approval_request: dict, selected: int, box_width: Optional[int] = None
+    approval_request: dict, selected: int, box_width: int | None = None
 ) -> list[str]:
     """Build the raw text lines of the approval box (no ANSI needed here)."""
     goal: str = approval_request.get("goal", "")
@@ -153,15 +151,17 @@ def show_approval_prompt(approval_request: dict) -> bool:
     if not _PT_AVAILABLE:
         return _fallback_prompt(approval_request, columns=terminal_columns)
 
-    return _pt_prompt(approval_request)
+    return _pt_prompt(approval_request, columns=terminal_columns)
 
 
-def _pt_prompt(approval_request: dict) -> bool:
+def _pt_prompt(approval_request: dict, *, columns: int) -> bool:
     """prompt_toolkit–based arrow-key selection UI."""
     state = {"selected": 0, "result": None}
+    box_width = get_approval_box_width(columns)
 
     def get_text():
-        lines = _build_box_lines(approval_request, state["selected"])
+        # Keep a stable width for a single prompt interaction.
+        lines = _build_box_lines(approval_request, state["selected"], box_width=box_width)
         return "\n".join(lines) + "\n\n↑↓ 방향키로 선택, Enter로 확정"
 
     kb = KeyBindings()
@@ -203,16 +203,24 @@ def _pt_prompt(approval_request: dict) -> bool:
     return bool(state["result"])
 
 
-def _fallback_prompt(approval_request: dict, columns: Optional[int] = None) -> bool:
+def _fallback_prompt(approval_request: dict, columns: int | None = None) -> bool:
     """Plain input() fallback when prompt_toolkit is unavailable."""
     goal: str = approval_request.get("goal", "")
     reason: str = approval_request.get("reason", "")
     tool_summaries: list[str] = approval_request.get("tool_summaries") or []
     terminal_columns = get_terminal_columns() if columns is None else columns
     separator = "─" * max(terminal_columns - 2, 12)
+    title = " 작업 승인 요청 "
+    title_width = _display_width(title)
+    if terminal_columns > title_width:
+        fill_width = terminal_columns - title_width
+        left_fill = fill_width // 2
+        right_fill = fill_width - left_fill
+        title_line = f"{'─' * left_fill}{title}{'─' * right_fill}"
+    else:
+        title_line = title
 
-    print(f"\n{separator}")
-    print("작업 승인 요청")
+    print(f"\n{title_line}")
     if goal:
         print(f"  목표: {goal}")
     if reason:

--- a/src/cli/renderer.py
+++ b/src/cli/renderer.py
@@ -5,10 +5,7 @@ Uses `rich` when available; falls back to plain print() otherwise.
 
 from __future__ import annotations
 
-import contextlib
-import sys
-from contextlib import contextmanager
-from typing import Generator, Optional
+from threading import Lock
 
 from src.cli.terminal import (
     get_narrow_terminal_warning,
@@ -29,7 +26,8 @@ except ImportError:  # pragma: no cover
     _console = None  # type: ignore[assignment]
     _RICH_AVAILABLE = False
 
-_LAST_NARROW_WARNING_COLUMNS: int | None = None
+_HAS_WARNED_NARROW_TERMINAL = False
+_NARROW_WARNING_LOCK = Lock()
 
 # ---------------------------------------------------------------------------
 # Node status message mapping
@@ -63,7 +61,7 @@ class StreamingStatusDisplay:
 
     def __init__(self, initial_message: str = "처리 중…") -> None:
         self._initial_message = initial_message
-        self._status: Optional["Status"] = None  # type: ignore[name-defined]
+        self._status: Status | None = None  # type: ignore[name-defined]
         self._use_rich = False
 
     def __enter__(self) -> "StreamingStatusDisplay":
@@ -89,14 +87,23 @@ class StreamingStatusDisplay:
 
 
 def _warn_narrow_terminal_once(columns: int) -> None:
-    """Emit the narrow-terminal fallback warning only once per width."""
-    global _LAST_NARROW_WARNING_COLUMNS
+    """Emit the narrow-terminal fallback warning once per narrow-state entry."""
+    global _HAS_WARNED_NARROW_TERMINAL
 
-    if _LAST_NARROW_WARNING_COLUMNS == columns:
-        return
+    with _NARROW_WARNING_LOCK:
+        if _HAS_WARNED_NARROW_TERMINAL:
+            return
+        _HAS_WARNED_NARROW_TERMINAL = True
 
     print(get_narrow_terminal_warning(columns), flush=True)
-    _LAST_NARROW_WARNING_COLUMNS = columns
+
+
+def _reset_narrow_warning() -> None:
+    """Reset narrow-terminal warning state for tests and wide-terminal recovery."""
+    global _HAS_WARNED_NARROW_TERMINAL
+
+    with _NARROW_WARNING_LOCK:
+        _HAS_WARNED_NARROW_TERMINAL = False
 
 
 def _resolve_render_mode() -> tuple[bool, int]:
@@ -105,6 +112,7 @@ def _resolve_render_mode() -> tuple[bool, int]:
     if not is_layout_supported(columns):
         _warn_narrow_terminal_once(columns)
         return False, columns
+    _reset_narrow_warning()
     return _RICH_AVAILABLE, columns
 
 

--- a/src/cli/terminal.py
+++ b/src/cli/terminal.py
@@ -11,35 +11,45 @@ APPROVAL_BOX_MAX_WIDTH = 55
 APPROVAL_BOX_MARGIN = 4
 PANEL_MARGIN = 2
 
+assert MIN_CONTENT_WIDTH < MIN_TERMINAL_COLUMNS
+
 
 def get_terminal_columns(default: int = DEFAULT_TERMINAL_COLUMNS) -> int:
     """Return the current terminal width in columns."""
     return max(shutil.get_terminal_size(fallback=(default, 24)).columns, 1)
 
 
+def _cols(columns: int | None) -> int:
+    """Resolve an explicit column override or read the current terminal width."""
+    return get_terminal_columns() if columns is None else columns
+
+
 def is_layout_supported(columns: int | None = None) -> bool:
     """Return True when the terminal is wide enough for full rich layouts."""
-    current_columns = get_terminal_columns() if columns is None else columns
-    return current_columns >= MIN_TERMINAL_COLUMNS
+    return _cols(columns) >= MIN_TERMINAL_COLUMNS
 
 
 def get_approval_box_width(columns: int | None = None) -> int:
-    """Return the inner width for the approval box."""
-    current_columns = get_terminal_columns() if columns is None else columns
+    """Return the inner width for the approval box.
+
+    Callers should gate rich box rendering with `is_layout_supported()` first.
+    For very narrow terminals, plain fallback is the supported rendering path.
+    """
+    current_columns = _cols(columns)
     return max(
-        MIN_CONTENT_WIDTH, min(APPROVAL_BOX_MAX_WIDTH, current_columns - APPROVAL_BOX_MARGIN)
+        MIN_CONTENT_WIDTH,
+        min(APPROVAL_BOX_MAX_WIDTH, current_columns - APPROVAL_BOX_MARGIN),
     )
 
 
 def get_panel_width(columns: int | None = None) -> int:
     """Return the rich panel width for result rendering."""
-    current_columns = get_terminal_columns() if columns is None else columns
-    return max(MIN_CONTENT_WIDTH, current_columns - PANEL_MARGIN)
+    return max(MIN_CONTENT_WIDTH, _cols(columns) - PANEL_MARGIN)
 
 
 def get_narrow_terminal_warning(columns: int | None = None) -> str:
     """Return the warning shown when the terminal is too narrow."""
-    current_columns = get_terminal_columns() if columns is None else columns
+    current_columns = _cols(columns)
     return (
         f"터미널 너비가 {current_columns}열로 좁아 plain mode로 전환합니다. "
         f"최소 {MIN_TERMINAL_COLUMNS}열 이상에서 전체 레이아웃이 보장됩니다."

--- a/tests/test_inference/conftest.py
+++ b/tests/test_inference/conftest.py
@@ -155,6 +155,16 @@ def db_engine():
     engine.dispose()
 
 
+@pytest.fixture(autouse=True)
+def reset_renderer_narrow_warning_state():
+    """Ensure renderer module state does not leak between tests."""
+    from src.cli import renderer
+
+    renderer._reset_narrow_warning()
+    yield
+    renderer._reset_narrow_warning()
+
+
 @pytest.fixture
 def db_session(db_engine):
     """테스트용 세션. 각 테스트 후 롤백."""

--- a/tests/test_inference/test_approval_ui.py
+++ b/tests/test_inference/test_approval_ui.py
@@ -62,13 +62,26 @@ def test_show_approval_prompt_warns_and_falls_back_on_narrow_terminal(capsys):
     mock_pt_prompt.assert_not_called()
 
 
+def test_show_approval_prompt_reuses_resolved_columns_for_pt_prompt():
+    """prompt_toolkit 경로는 이미 구한 터미널 폭을 다시 전달한다."""
+    with patch("src.cli.approval_ui._PT_AVAILABLE", True):
+        with patch("src.cli.approval_ui.get_terminal_columns", return_value=80):
+            with patch("src.cli.approval_ui._pt_prompt", return_value=True) as mock_pt_prompt:
+                assert approval_ui.show_approval_prompt(_sample_request()) is True
+
+    mock_pt_prompt.assert_called_once_with(_sample_request(), columns=80)
+
+
 def test_fallback_prompt_uses_terminal_width_for_separator(capsys):
     """plain fallback separator도 현재 터미널 폭을 넘지 않는다."""
     with patch("builtins.input", return_value="n"):
         approval_ui._fallback_prompt(_sample_request(), columns=32)
 
     lines = [line for line in capsys.readouterr().out.splitlines() if line]
+    title_line = lines[0]
     separator_lines = [line for line in lines if set(line) == {"─"}]
+
+    assert "작업 승인 요청" in title_line
     assert separator_lines
-    max_width = max(approval_ui._display_width(line) for line in separator_lines)
+    max_width = max(approval_ui._display_width(line) for line in [title_line, *separator_lines])
     assert max_width <= 32

--- a/tests/test_inference/test_cli_streaming.py
+++ b/tests/test_inference/test_cli_streaming.py
@@ -400,14 +400,29 @@ class TestStreamingStatusDisplay:
         with patch.object(renderer, "_RICH_AVAILABLE", True):
             with patch.object(renderer, "_console", mock_console):
                 with patch.object(renderer, "get_terminal_columns", return_value=30):
-                    with patch.object(renderer, "_LAST_NARROW_WARNING_COLUMNS", None):
-                        with renderer.StreamingStatusDisplay("초기") as display:
-                            display.update("planner 처리 중")
+                    with renderer.StreamingStatusDisplay("초기") as display:
+                        display.update("planner 처리 중")
 
         out = capsys.readouterr().out
         assert "plain mode" in out
         assert "planner 처리 중" in out
         mock_console.status.assert_not_called()
+
+    def test_narrow_terminal_warning_is_emitted_once_per_narrow_state(self, capsys):
+        """좁은 상태가 지속되는 동안 경고는 한 번만 출력되고, wide 후 다시 좁아지면 재출력된다."""
+        from src.cli import renderer
+
+        with patch.object(renderer, "_RICH_AVAILABLE", False):
+            with patch.object(renderer, "get_terminal_columns", side_effect=[30, 35, 80, 30]):
+                renderer.render_status("첫 상태")
+                renderer.render_status("둘째 상태")
+                renderer.render_status("셋째 상태")
+                renderer.render_status("넷째 상태")
+
+        out = capsys.readouterr().out
+        assert out.count("plain mode") == 2
+        assert "첫 상태" in out
+        assert "넷째 상태" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_inference/test_follow_up_evidence.py
+++ b/tests/test_inference/test_follow_up_evidence.py
@@ -389,8 +389,7 @@ def test_render_result_rich_panel_uses_explicit_terminal_width():
     with patch.object(renderer, "_RICH_AVAILABLE", True):
         with patch.object(renderer, "_console", mock_console):
             with patch.object(renderer, "get_terminal_columns", return_value=80):
-                with patch.object(renderer, "_LAST_NARROW_WARNING_COLUMNS", None):
-                    renderer.render_result({"text": "답변 텍스트"})
+                renderer.render_result({"text": "답변 텍스트"})
 
     panel = mock_console.print.call_args.args[0]
     assert panel.width == 78
@@ -404,8 +403,7 @@ def test_render_result_rich_panel_scales_at_120_columns():
     with patch.object(renderer, "_RICH_AVAILABLE", True):
         with patch.object(renderer, "_console", mock_console):
             with patch.object(renderer, "get_terminal_columns", return_value=120):
-                with patch.object(renderer, "_LAST_NARROW_WARNING_COLUMNS", None):
-                    renderer.render_result({"text": "넓은 터미널 응답"})
+                renderer.render_result({"text": "넓은 터미널 응답"})
 
     panel = mock_console.print.call_args.args[0]
     assert panel.width == 118
@@ -419,8 +417,7 @@ def test_render_result_rich_panel_scales_at_40_columns():
     with patch.object(renderer, "_RICH_AVAILABLE", True):
         with patch.object(renderer, "_console", mock_console):
             with patch.object(renderer, "get_terminal_columns", return_value=40):
-                with patch.object(renderer, "_LAST_NARROW_WARNING_COLUMNS", None):
-                    renderer.render_result({"text": "40열 응답"})
+                renderer.render_result({"text": "40열 응답"})
 
     panel = mock_console.print.call_args.args[0]
     assert panel.width == 38
@@ -434,8 +431,7 @@ def test_render_result_falls_back_to_plain_on_narrow_terminal(capsys):
     with patch.object(renderer, "_RICH_AVAILABLE", True):
         with patch.object(renderer, "_console", mock_console):
             with patch.object(renderer, "get_terminal_columns", return_value=30):
-                with patch.object(renderer, "_LAST_NARROW_WARNING_COLUMNS", None):
-                    renderer.render_result({"text": "좁은 터미널 응답"})
+                renderer.render_result({"text": "좁은 터미널 응답"})
 
     captured = capsys.readouterr()
     assert "plain mode" in captured.out

--- a/tests/test_inference/test_terminal.py
+++ b/tests/test_inference/test_terminal.py
@@ -1,0 +1,32 @@
+"""Terminal helper tests for CLI responsive layout logic."""
+
+from __future__ import annotations
+
+from src.cli import terminal
+
+
+def test_is_layout_supported_respects_minimum_columns():
+    """40열 이상부터 full layout을 허용한다."""
+    assert terminal.is_layout_supported(39) is False
+    assert terminal.is_layout_supported(40) is True
+
+
+def test_get_approval_box_width_clamps_to_minimum_and_maximum():
+    """approval box width는 최소/최대 범위를 유지한다."""
+    assert terminal.get_approval_box_width(1) == terminal.MIN_CONTENT_WIDTH
+    assert terminal.get_approval_box_width(40) == 36
+    assert terminal.get_approval_box_width(200) == terminal.APPROVAL_BOX_MAX_WIDTH
+
+
+def test_get_panel_width_tracks_terminal_minus_margin():
+    """result panel width는 terminal margin만 차감한다."""
+    assert terminal.get_panel_width(40) == 38
+    assert terminal.get_panel_width(200) == 198
+
+
+def test_get_narrow_terminal_warning_includes_current_width():
+    """narrow warning은 현재 width와 최소 요구 width를 함께 안내한다."""
+    warning = terminal.get_narrow_terminal_warning(30)
+
+    assert "30열" in warning
+    assert str(terminal.MIN_TERMINAL_COLUMNS) in warning


### PR DESCRIPTION
## 관련 이슈
- Closes #504
- Refs #369

## 작업 배경
CLI 출력이 터미널 너비를 고려하지 않아 승인 박스와 결과 패널이 좁은 환경에서 깨질 수 있었습니다. `#504` 범위에서는 터미널 너비를 공통 유틸리티로 계산하고, approval UI와 renderer가 같은 기준으로 반응형 폭과 fallback 정책을 따르도록 정리하는 것이 목적입니다.

## 주요 변경 사항
- `src/cli/terminal.py`
  - 터미널 너비 감지, 최소 지원 폭, approval box width, panel width 계산 유틸리티를 추가했습니다.
- `src/cli/approval_ui.py`
  - `_BOX_WIDTH = 55` 하드코딩을 제거하고 현재 터미널 폭 기준으로 approval box width를 계산하도록 변경했습니다.
  - `40`열 미만에서는 경고 메시지를 출력한 뒤 plain fallback으로 전환하도록 했습니다.
- `src/cli/renderer.py`
  - Rich `Panel` width를 현재 터미널 폭 기준으로 명시적으로 설정했습니다.
  - 좁은 터미널에서는 spinner/Panel 대신 plain mode로 전환하도록 정리했습니다.
- 테스트 보강
  - `tests/test_inference/test_approval_ui.py`를 추가했습니다.
  - `tests/test_inference/test_cli_streaming.py`, `tests/test_inference/test_follow_up_evidence.py`에 narrow terminal fallback과 `40`/`80`/`120`열 시나리오를 검증하는 테스트를 추가했습니다.

## 테스트 결과
- [x] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인

실행한 검증:
- `PYTHONPATH=/tmp/govon-504 /Users/yujeong/Desktop/AIOSS_GovOn/GovOn/.venv/bin/black --target-version py310 --check src/cli/terminal.py src/cli/approval_ui.py src/cli/renderer.py tests/test_inference/test_approval_ui.py tests/test_inference/test_cli_streaming.py tests/test_inference/test_follow_up_evidence.py`
- `SKIP_MODEL_LOAD=true /Users/yujeong/Desktop/AIOSS_GovOn/GovOn/.venv/bin/python -m pytest tests/test_inference/test_approval_ui.py tests/test_inference/test_cli_streaming.py tests/test_inference/test_follow_up_evidence.py -q`

## 기타 사항
- 브랜치는 최신 `origin/main` 위에서 시작해 별도 rebase 없이 작업했습니다.
- 현재 반영 범위는 issue `#504`의 acceptance criteria에 대응하는 너비 감지, 최소 폭 경고, plain fallback, approval box/Panel width 제어까지입니다.

---

## 머지 조건 체크리스트
- [ ] 1명 이상의 코드리뷰 승인 완료
- [ ] CODEOWNERS(팀장) 최종 승인 완료
- [ ] 모든 리뷰 코멘트 해결(resolved) 완료

## 리뷰어 가이드

| 태그 | 의미 | 예시 |
|------|------|------|
| `[MUST]` | 반드시 수정 (보안·버그·성능 이슈) | `[MUST] API 키가 로그에 노출됩니다.` |
| `[SHOULD]` | 수정 강권 (코드 품질·유지보수성) | `[SHOULD] 이 로직은 별도 함수로 분리하는 것이 좋습니다.` |
| `[NITS]` | 사소한 개선 (스타일·네이밍) | `[NITS] 변수명을 \`result\`보다 \`parsed_output\`이 명확합니다.` |
| `[QUESTION]` | 이해를 위한 질문 | `[QUESTION] 이 조건이 항상 True일 수 있지 않나요?` |
