### PR TITLE
fix: security-scan uv tools 캐시 키 갱신 — bandit PATH 복구

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -49,7 +49,7 @@ jobs:
           path: |
             ~/.local/share/uv/tools
             ~/.local/bin
-          key: uv-tools-${{ runner.os }}-bandit-pip-audit
+          key: uv-tools-${{ runner.os }}-bandit-pip-audit-v2
 
       - name: Install security tools
         run: |


### PR DESCRIPTION
## Summary
- 이전 캐시가 `~/.local/bin` 없이 저장되어 캐시 히트 시 `bandit: command not found` 발생
- 캐시 키를 `v2`로 변경하여 불완전한 캐시 무효화
- `GITHUB_PATH` 등록이 이미 있지만 캐시가 bin symlink를 포함하지 않아 무의미했음

## Test plan
- [ ] security-scan에서 bandit 정상 실행 확인