### PR TITLE
fix: ci.yml startup_failure — workflow-level env를 job-level로 이동

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,9 +94,30 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       needs.detect-changes.outputs.runtime == 'true' ||
       needs.detect-changes.outputs.packaging == 'true'
-    uses: ./.github/workflows/reusable-lint.yml
-    with:
-      python-version: '3.12'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Python with uv
+        uses: ./.github/actions/setup-python-uv
+        with:
+          python-version: '3.12'
+          extras: '--extra dev'
+
+      - name: Black
+        run: uv run black --check .
+
+      - name: isort
+        run: uv run isort --check .
+
+      - name: Flake8
+        run: |
+          uv run flake8 . \
+            --count \
+            --select=E9,F63,F7,F82 \
+            --show-source \
+            --statistics \
+            --exclude=.venv,.git,__pycache__,build,dist
 
   test:
     needs: detect-changes
@@ -118,14 +139,17 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       needs.detect-changes.outputs.runtime == 'true' ||
       needs.detect-changes.outputs.packaging == 'true'
-    uses: ./.github/workflows/reusable-security-scan.yml
-    with:
-      bandit-target: src/inference
-      bandit-severity: '-lll'
-      pip-audit-enabled: false
-      upload-sarif: false
-      create-issue-on-vuln: false
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Python with uv
+        uses: ./.github/actions/setup-python-uv
+        with:
+          extras: '--extra dev'
+
+      - name: Run Bandit on runtime code
+        run: uv run bandit -r src/inference -lll -x tests
 
   runtime-contract:
     needs: [detect-changes, test]
@@ -164,21 +188,17 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
 
       - name: Install Node dependencies
         run: npm ci
 
       - name: Install Playwright browsers
-        run: |
-          if ls ~/.cache/ms-playwright/chromium-*/chrome-linux/chrome 2>/dev/null; then
-            echo "Playwright chromium found in cache — installing OS deps only"
-            npx playwright install-deps chromium
-          else
-            echo "Playwright cache miss or partial — running full install"
-            npx playwright install --with-deps chromium
-          fi
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright deps (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: Run shell-first runtime contract tests
         env:
@@ -228,14 +248,34 @@ jobs:
           retention-days: 7
 
   docs-build:
+    needs: detect-changes
     if: |
       github.event_name == 'workflow_dispatch' ||
       needs.detect-changes.outputs.docs == 'true'
-    needs: [detect-changes]
-    uses: ./.github/workflows/reusable-docs-build.yml
-    with:
-      strict: true
-      upload_pages_artifact: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: 'site/requirements-docs.txt'
+
+      - name: Install MkDocs dependencies
+        run: pip install -r site/requirements-docs.txt
+
+      - name: Build docs with strict mode
+        run: cd site && mkdocs build --strict
+
+      - name: Upload docs artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: docs-site-preview
+          path: site/site
+          retention-days: 7
 
   build:
     needs: [detect-changes, lint, test]


### PR DESCRIPTION
## Summary
- PR Gate가 모든 실행에서 `startup_failure`로 즉시 실패 (Phase 2 머지 이후)
- 원인 추정: workflow-level `env:` 블록이 reusable workflow `uses:` job과 공존 시 GitHub 내부 validator 거부
- `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env를 workflow-level에서 각 `runs-on:` job-level로 이동

## Test plan
- [ ] PR Gate가 startup_failure 없이 정상 시작되는지 확인