### PR TITLE
fix: CI 반복 실패 수정 — Black 포맷, bandit PATH, HF_TOKEN

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Install security tools
         run: |
-          uv tool install bandit && uv tool install pip-audit
+          uv tool install pip-audit
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Run Bandit (Static Analysis)
@@ -61,7 +61,7 @@ jobs:
           BANDIT_TARGET: ${{ inputs.bandit-target }}
           BANDIT_SEVERITY: ${{ inputs.bandit-severity }}
         run: |
-          bandit -r "$BANDIT_TARGET" $BANDIT_SEVERITY -x tests
+          uvx bandit -r "$BANDIT_TARGET" $BANDIT_SEVERITY -x tests
 
       - name: Compile dependency lockfile
         if: inputs.pip-audit-enabled
@@ -87,7 +87,7 @@ jobs:
           BANDIT_TARGET: ${{ inputs.bandit-target }}
           BANDIT_SEVERITY: ${{ inputs.bandit-severity }}
         run: |
-          bandit -r "$BANDIT_TARGET" $BANDIT_SEVERITY -x tests -f sarif -o bandit-results.sarif 2>/dev/null || true
+          uvx bandit -r "$BANDIT_TARGET" $BANDIT_SEVERITY -x tests -f sarif -o bandit-results.sarif 2>/dev/null || true
 
       - name: Upload Bandit SARIF to Code Scanning
         if: inputs.upload-sarif && hashFiles('bandit-results.sarif') != ''

--- a/src/cli/renderer.py
+++ b/src/cli/renderer.py
@@ -192,7 +192,9 @@ def _build_citations_text(citations: list[str]) -> Text:
     return content
 
 
-def _build_rich_result_content(text_body: str, evidence_items: list, citations: list) -> Text | Markdown | Group:
+def _build_rich_result_content(
+    text_body: str, evidence_items: list, citations: list
+) -> Text | Markdown | Group:
     """Build the rich renderable used inside the result panel."""
     renderables = []
 

--- a/src/inference/api_server.py
+++ b/src/inference/api_server.py
@@ -1430,7 +1430,9 @@ async def chat_completions(
         raise HTTPException(status_code=503, detail="Model engine not initialized.")
 
     request_id = str(uuid.uuid4())
-    logger.info(f"chat_completions request_id={request_id} messages={len(messages)} max_tokens={max_tokens}")
+    logger.info(
+        f"chat_completions request_id={request_id} messages={len(messages)} max_tokens={max_tokens}"
+    )
     sampling_params = SamplingParams(
         max_tokens=max_tokens,
         temperature=temperature,


### PR DESCRIPTION
## Summary
- `src/cli/renderer.py`, `src/inference/api_server.py`: Black 포맷 적용 → PR Gate lint 차단 해결
- `reusable-security-scan.yml`: `bandit` → `uvx bandit` 교체 → command not found 해결
- `HF_TOKEN` GitHub Secret 등록 필요 (별도 진행)

## Root Cause
- Black: 포맷 미적용 상태로 커밋 반복
- bandit: `uv tool install` 후 `$GITHUB_PATH` 추가가 동일 step에서 이뤄지나, 실제 bandit 바이너리 경로와 PATH 불일치
- HF_TOKEN: GitHub Secrets에 미등록 → HF API 404

## Test plan
- [ ] PR Gate lint 통과 확인
- [ ] Security Scan bandit 통과 확인
- [ ] HF_TOKEN 등록 후 Deploy HF Space 재실행 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 함수 선언부 및 로깅 문 포맷팅 개선으로 코드 가독성 향상

* **유지보수**
  * 보안 검사 워크플로우 도구 실행 방식 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->