### PR TITLE
fix: bandit-severity shell injection 방어

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -61,7 +61,11 @@ jobs:
           BANDIT_TARGET: ${{ inputs.bandit-target }}
           BANDIT_SEVERITY: ${{ inputs.bandit-severity }}
         run: |
-          uvx bandit -r "$BANDIT_TARGET" $BANDIT_SEVERITY -x tests
+          case "$BANDIT_SEVERITY" in
+            -l|-ll|-lll) ;;
+            *) echo "Invalid bandit-severity: $BANDIT_SEVERITY" && exit 1 ;;
+          esac
+          uvx bandit -r "$BANDIT_TARGET" "$BANDIT_SEVERITY" -x tests
 
       - name: Compile dependency lockfile
         if: inputs.pip-audit-enabled
@@ -87,7 +91,7 @@ jobs:
           BANDIT_TARGET: ${{ inputs.bandit-target }}
           BANDIT_SEVERITY: ${{ inputs.bandit-severity }}
         run: |
-          uvx bandit -r "$BANDIT_TARGET" $BANDIT_SEVERITY -x tests -f sarif -o bandit-results.sarif 2>/dev/null || true
+          uvx bandit -r "$BANDIT_TARGET" "$BANDIT_SEVERITY" -x tests -f sarif -o bandit-results.sarif 2>/dev/null || true
 
       - name: Upload Bandit SARIF to Code Scanning
         if: inputs.upload-sarif && hashFiles('bandit-results.sarif') != ''


### PR DESCRIPTION
## Summary
- `reusable-security-scan.yml`: `BANDIT_SEVERITY` 입력값을 화이트리스트(`-l`, `-ll`, `-lll`)로 검증 후 따옴표 처리
- CodeRabbit ASSERTIVE 리뷰 지적 사항 반영

## Root Cause
`$BANDIT_SEVERITY`가 unquoted으로 shell 명령에 삽입되어 shell injection 취약점 존재

## Test plan
- [ ] security-scan job 통과 확인
- [ ] 잘못된 severity 값 입력 시 exit 1 동작 확인