### PR TITLE
feat: E2E tool calling 검증 스크립트 + API 관측성 보강

### DIFF
--- a/scripts/verify_e2e_tool_calling.py
+++ b/scripts/verify_e2e_tool_calling.py
@@ -422,7 +422,7 @@ async def _call_agent_with_approval(
                 return True, final_text, meta, None
             if final_text:
                 return True, final_text, meta, None
-            return False, "", meta, f"approve 200 but text 없음"
+            return False, "", meta, "approve 200 but text 없음"
 
         if resp.get("status") == "error":
             return False, "", meta, resp.get("error", "agent run error")

--- a/src/inference/api_server.py
+++ b/src/inference/api_server.py
@@ -164,6 +164,18 @@ def _extract_approval_request(graph_state: Any) -> Any:
     return task.interrupts[0].value
 
 
+def _safe_state_field(vals: Any, key: str, default: Any = "") -> Any:
+    """graph state에서 JSON 직렬화 가능한 값을 안전하게 추출한다."""
+    if not isinstance(vals, dict):
+        return default
+    v = vals.get(key, default)
+    if isinstance(v, (str, int, float, bool, type(None))):
+        return v
+    if isinstance(v, (dict, list)):
+        return v
+    return default
+
+
 class vLLMEngineManager:
     """GovOn Shell MVP용 로컬 런타임 매니저."""
 
@@ -1759,8 +1771,8 @@ async def v2_agent_stream(
                                     "approval_request": _extract_approval_request(graph_state),
                                     "thread_id": thread_id,
                                     "session_id": session_id,
-                                    "adapter_mode": _vals.get("adapter_mode", ""),
-                                    "tool_args": _vals.get("tool_args", {}),
+                                    "adapter_mode": _safe_state_field(_vals, "adapter_mode", ""),
+                                    "tool_args": _safe_state_field(_vals, "tool_args", {}),
                                 }
                         except Exception as exc:
                             logger.warning(f"[v2/agent/stream] aget_state 실패: {exc}")
@@ -1875,8 +1887,8 @@ async def v2_agent_run(
             "text": final_state.get("final_text", ""),
             "evidence_items": final_state.get("evidence_items", []),
             "task_type": final_state.get("task_type", ""),
-            "adapter_mode": final_state.get("adapter_mode", ""),
-            "tool_args": final_state.get("tool_args", {}),
+            "adapter_mode": _safe_state_field(final_state, "adapter_mode", ""),
+            "tool_args": _safe_state_field(final_state, "tool_args", {}),
         }
     except Exception as exc:
         logger.error(f"[v2/agent/run] 예외 발생: {exc}")
@@ -1954,8 +1966,8 @@ async def v2_agent_approve(
             "task_type": result.get("task_type", ""),
             "tool_results": result.get("tool_results", {}),
             "approval_status": approval_status,
-            "adapter_mode": result.get("adapter_mode", ""),
-            "tool_args": result.get("tool_args", {}),
+            "adapter_mode": _safe_state_field(result, "adapter_mode", ""),
+            "tool_args": _safe_state_field(result, "tool_args", {}),
         }
     except Exception as exc:
         logger.error(f"[v2/agent/approve] 예외 발생: {exc}")


### PR DESCRIPTION
## Summary

- HuggingFace Spaces A100 GPU 환경에서 네이티브 tool calling + AdapterRegistry 동적 LoRA 선택을 검증하는 E2E 스크립트
- API 응답에 `adapter_mode`, `tool_args` 필드 노출 (planner 메타데이터 관측성)

## 변경 사항

### 신규: `scripts/verify_e2e_tool_calling.py`

13개 시나리오, 5 Phase 구성:

| Phase | 시나리오 | 검증 대상 |
|-------|---------|----------|
| 1 (하드 게이트) | 1-3 | Health, Base Model, Adapter Registry |
| 2 (파이프라인) | 4-7 | Planner 계획, Civil LoRA, Legal LoRA, Task Type |
| 3 (외부 API) | 8 (4 서브) | issue_detector, stats_lookup, keyword_analyzer, demographics |
| 4 (어댑터) | 9-10 | 순차 전환 civil→legal→civil, LoRA ID 일관성 |
| 5 (견고성) | 11-13 | 빈 쿼리 422, 거절 흐름, 동시 요청 격리 |

사용법:
```bash
GOVON_RUNTIME_URL=https://<space>.hf.space python3 scripts/verify_e2e_tool_calling.py
```

### 수정: `src/inference/api_server.py`

4개 API 응답에 `adapter_mode`, `tool_args` 필드 추가:
- SSE stream awaiting_approval 이벤트
- /v2/agent/run awaiting_approval 응답
- /v2/agent/run completed 응답
- /v2/agent/approve 응답

## Test plan

- [ ] lint (black) 통과
- [ ] 기존 테스트 회귀 없음
- [ ] HF Spaces A100 배포 후 `verify_e2e_tool_calling.py` 13/13 통과

Closes #560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 에이전트 API 응답에 어댑터 모드 및 도구 인자 정보 추가 — 승인 대기·실행·완료 시 반환 페이로드에 노출

* **Tests**
  * 엔드투엔드 자동 검증 스크립트 추가 — 다양한 시나리오로 서버 상태, 에이전트 플로우, 도구 호출 및 동시성 검증 및 보고서 생성
<!-- end of auto-generated comment: release notes by coderabbit.ai -->