### PR TITLE
fix: SVG 렌더링 오류 수정 (XML 이스케이프)

### DIFF
--- a/docs/architecture/govon-tobe-architecture.svg
+++ b/docs/architecture/govon-tobe-architecture.svg
@@ -189,7 +189,7 @@
 
   <!-- Arrow types -->
   <line x1="460" y1="1420" x2="510" y2="1420" stroke="#534AB7" stroke-width="2" stroke-dasharray="8,4"/>
-  <text x="520" y="1425" font-size="12" fill="#3C3489">ReAct loop (agent <-> ToolNode cycle)</text>
+  <text x="520" y="1425" font-size="12" fill="#3C3489">ReAct loop (agent ↔ ToolNode cycle)</text>
 
   <line x1="460" y1="1448" x2="510" y2="1448" stroke="#534AB7" stroke-width="1" stroke-dasharray="5,3"/>
   <text x="520" y="1453" font-size="12" fill="#534AB7">Conditional routing</text>

--- a/site/static/govon-tobe-architecture.svg
+++ b/site/static/govon-tobe-architecture.svg
@@ -189,7 +189,7 @@
 
   <!-- Arrow types -->
   <line x1="460" y1="1420" x2="510" y2="1420" stroke="#534AB7" stroke-width="2" stroke-dasharray="8,4"/>
-  <text x="520" y="1425" font-size="12" fill="#3C3489">ReAct loop (agent <-> ToolNode cycle)</text>
+  <text x="520" y="1425" font-size="12" fill="#3C3489">ReAct loop (agent ↔ ToolNode cycle)</text>
 
   <line x1="460" y1="1448" x2="510" y2="1448" stroke="#534AB7" stroke-width="1" stroke-dasharray="5,3"/>
   <text x="520" y="1453" font-size="12" fill="#534AB7">Conditional routing</text>


### PR DESCRIPTION
## Summary
- SVG line 192의 `<->` 가 XML 파서에서 태그로 해석되어 렌더링 실패
- Unicode 화살표 `↔`로 교체하여 해결

## Test plan
- [ ] SVG 브라우저 렌더링 정상 확인