### PR TITLE
fix: GitHub Pages index.html → TO-BE 아키텍처 SVG로 전환

### DIFF
--- a/site/static/index.html
+++ b/site/static/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>GovOn Pipeline Architecture</title>
+  <title>GovOn TO-BE Architecture</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
@@ -24,6 +24,6 @@
   </style>
 </head>
 <body>
-  <img src="govon_pipeline_architecture.svg" alt="GovOn Pipeline Architecture">
+  <img src="govon-tobe-architecture.svg" alt="GovOn TO-BE Architecture">
 </body>
 </html>


### PR DESCRIPTION
## Summary
- `site/static/index.html`이 이전 `govon_pipeline_architecture.svg`를 참조하고 있어 TO-BE SVG로 교체

## Test plan
- [ ] https://govon-org.github.io/GovOn/ 접속 시 TO-BE 아키텍처 SVG 렌더링 확인