### PR TITLE
fix: README SVG 상대경로로 변경 (렌더링 수정)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ GovOn은 행정 업무를 보조하는 **에이전틱 CLI 셸**이다. 사용자
 
 <p align="center">
   <a href="https://govon-org.github.io/GovOn/govon-tobe-architecture.svg">
-    <img src="https://govon-org.github.io/GovOn/govon-tobe-architecture.svg" alt="GovOn TO-BE Architecture" width="100%"/>
+    <img src="docs/architecture/govon-tobe-architecture.svg" alt="GovOn TO-BE Architecture" width="100%"/>
   </a>
 </p>
 


### PR DESCRIPTION
## Summary
- GitHub Pages 외부 URL 대신 레포 내 상대경로(`docs/architecture/govon-tobe-architecture.svg`)로 변경
- GitHub README에서 외부 URL SVG는 camo 프록시 캐시/지연 문제로 렌더링이 불안정

## Test plan
- [ ] README에서 SVG 이미지 즉시 렌더링 확인