### PR TITLE
docs: #494 .env.example 누락 환경변수 6개 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,7 +97,7 @@ HEALTH_TIMEOUT_SEC=10
 # uvicorn worker 수 (성능 튜닝, 기본값: 1)
 WORKERS=1
 
-# planner 전용 모델 별도 지정 (미설정 시 LANGGRAPH_MODEL_BASE_URL 사용)
+# planner 전용 모델 별도 지정 (미설정 시 runtime_config.model.model_path 값 사용)
 # LANGGRAPH_PLANNER_MODEL=gpt-4o
 
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -88,7 +88,7 @@ HEALTH_TIMEOUT_SEC=10
 # DATABASE_URL=sqlite:////home/yourname/.govon/metadata.sqlite3
 
 # 세션 DB 경로 오버라이드 — sqlite3.connect()에 직접 전달되므로 파일 경로로 지정
-# GOVON_SESSION_DB=/home/yourname/.govon/session.sqlite3
+# GOVON_SESSION_DB=/home/yourname/.govon/sessions.sqlite3
 
 # =============================================================================
 # 런타임 설정

--- a/.env.example
+++ b/.env.example
@@ -74,3 +74,33 @@ LANGGRAPH_MODEL_API_KEY=EMPTY
 # --- 헬스체크 ---
 HEALTH_INTERVAL_SEC=30
 HEALTH_TIMEOUT_SEC=10
+
+# =============================================================================
+# DB 설정
+# =============================================================================
+
+# GovOn 홈 디렉토리 (메타데이터 DB, 캐시 등 기본 저장 위치)
+GOVON_HOME=~/.govon
+
+# SQLAlchemy DB URL — 기본값은 GOVON_HOME 아래 sqlite3 파일
+DATABASE_URL=sqlite:///${GOVON_HOME}/metadata.sqlite3
+
+# 세션 DB 경로 오버라이드 (미설정 시 DATABASE_URL 사용)
+# GOVON_SESSION_DB=sqlite:///~/.govon/session.sqlite3
+
+# =============================================================================
+# 런타임 설정
+# =============================================================================
+
+# uvicorn worker 수 (성능 튜닝, 기본값: 1)
+WORKERS=1
+
+# planner 전용 모델 별도 지정 (미설정 시 LANGGRAPH_MODEL_BASE_URL 사용)
+# LANGGRAPH_PLANNER_MODEL=gpt-4o
+
+# =============================================================================
+# 디버그
+# =============================================================================
+
+# SQLAlchemy 쿼리 로깅 활성화 (true/false, 기본값: false)
+SQL_ECHO=false

--- a/.env.example
+++ b/.env.example
@@ -80,13 +80,15 @@ HEALTH_TIMEOUT_SEC=10
 # =============================================================================
 
 # GovOn 홈 디렉토리 (메타데이터 DB, 캐시 등 기본 저장 위치)
-GOVON_HOME=~/.govon
+# 미설정 시 코드에서 $HOME/.govon 으로 자동 설정됨 (python-dotenv는 ~ 미확장)
+# GOVON_HOME=/home/yourname/.govon
 
-# SQLAlchemy DB URL — 기본값은 GOVON_HOME 아래 sqlite3 파일
-DATABASE_URL=sqlite:///${GOVON_HOME}/metadata.sqlite3
+# SQLAlchemy DB URL — 미설정 시 GOVON_HOME 아래 metadata.sqlite3 사용
+# python-dotenv는 ${VAR} 미확장이므로 절대경로로 직접 지정하거나 주석 유지
+# DATABASE_URL=sqlite:////home/yourname/.govon/metadata.sqlite3
 
 # 세션 DB 경로 오버라이드 (미설정 시 DATABASE_URL 사용)
-# GOVON_SESSION_DB=sqlite:///~/.govon/session.sqlite3
+# GOVON_SESSION_DB=sqlite:////home/yourname/.govon/session.sqlite3
 
 # =============================================================================
 # 런타임 설정

--- a/.env.example
+++ b/.env.example
@@ -87,8 +87,8 @@ HEALTH_TIMEOUT_SEC=10
 # python-dotenv는 ${VAR} 미확장이므로 절대경로로 직접 지정하거나 주석 유지
 # DATABASE_URL=sqlite:////home/yourname/.govon/metadata.sqlite3
 
-# 세션 DB 경로 오버라이드 (미설정 시 DATABASE_URL 사용)
-# GOVON_SESSION_DB=sqlite:////home/yourname/.govon/session.sqlite3
+# 세션 DB 경로 오버라이드 — sqlite3.connect()에 직접 전달되므로 파일 경로로 지정
+# GOVON_SESSION_DB=/home/yourname/.govon/session.sqlite3
 
 # =============================================================================
 # 런타임 설정


### PR DESCRIPTION
## 관련 이슈
- Closes #494

## 작업 배경
`.env.example`에 실제 코드에서 사용하는 환경변수 6개가 누락되어 있어 새로 세팅하는 개발자가 코드를 직접 뒤져야 알 수 있는 상태였음.

## 주요 변경 사항
- `GOVON_HOME` — GovOn 홈 디렉토리 (미설정 시 코드에서 `$HOME/.govon` 자동 설정)
- `DATABASE_URL` — SQLAlchemy DB URL (미설정 시 `GOVON_HOME/metadata.sqlite3` 자동 설정)
- `GOVON_SESSION_DB` — 세션 DB 경로 오버라이드 (선택)
- `LANGGRAPH_PLANNER_MODEL` — planner 전용 모델 별도 지정 (선택)
- `WORKERS` — uvicorn worker 수 (기본: `1`)
- `SQL_ECHO` — SQLAlchemy 쿼리 로깅 (기본: `false`)
- `GOVON_HOME` / `DATABASE_URL`은 python-dotenv가 `~`, `${VAR}` 미확장 → 주석 처리 후 절대경로 예시로 안내

## 테스트 결과
- [x] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인

## 기타 사항
`database.py`의 기본값 로직(`Path.home() / ".govon"`)이 `GOVON_HOME` 미설정 시 자동으로 처리하므로, 주석 유지가 올바른 기본 동작임.

---

## 머지 조건 체크리스트
- [ ] 1명 이상의 코드리뷰 승인 완료
- [ ] CODEOWNERS(팀장) 최종 승인 완료
- [ ] 모든 리뷰 코멘트 해결(resolved) 완료

## 리뷰어 가이드

| 태그 | 의미 | 예시 |
|------|------|------|
| `[MUST]` | 반드시 수정 (보안·버그·성능 이슈) | `[MUST] API 키가 로그에 노출됩니다.` |
| `[SHOULD]` | 수정 강권 (코드 품질·유지보수성) | `[SHOULD] 이 로직은 별도 함수로 분리하는 것이 좋습니다.` |
| `[NITS]` | 사소한 개선 (스타일·네이밍) | `[NITS] 변수명을 \`result\`보다 \`parsed_output\`이 명확합니다.` |
| `[QUESTION]` | 이해를 위한 질문 | `[QUESTION] 이 조건이 항상 True일 수 있지 않나요?` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 런타임 및 데이터베이스 관련 환경 변수 추가 및 문서화: WORKERS(기본 1), SQL_ECHO(기본 false) 포함
  * 선택적 설정 설명 추가: 메타데이터 저장소 기본 위치(GOVON_HOME), 데이터베이스 URL(DATABASE_URL), 세션 DB 경로(GOVON_SESSION_DB) 문서화
  * 플래너 모델 오버라이드용 선택적 설정(LANGGRAPH_PLANNER_MODEL) 주석으로 안내 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->