### PR TITLE
feat(cli): production-level CLI gaps — version flag, signals, stderr, persistent history

### DIFF
--- a/src/cli/daemon.py
+++ b/src/cli/daemon.py
@@ -1,16 +1,16 @@
-"""GovOn daemon lifecycle 관리.
+"""GovOn daemon lifecycle management.
 
-Issue #144: CLI-daemon/LangGraph runtime 연동 및 session resume.
+Issue #144: CLI-daemon/LangGraph runtime integration and session resume.
 
-uvicorn으로 백그라운드에서 GovOn API 서버를 기동하고,
-PID 파일로 프로세스 상태를 추적한다.
+Starts the GovOn API server in the background via uvicorn and tracks
+the process state via a PID file.
 
 .. note::
-   이 모듈은 **로컬 daemon 전용**입니다.
-   원격 서버에 연결할 때는 ``GOVON_RUNTIME_URL`` 환경변수를 설정하면
-   ``shell.py``의 ``main()``이 이 모듈을 완전히 건너뛰고 지정된 URL에
-   직접 연결합니다. Docker, 클라우드 배포, CI 환경에서는 해당 방식을
-   사용하는 것을 권장합니다.
+   This module is for **local daemon use only**.
+   When connecting to a remote server, set the ``GOVON_RUNTIME_URL``
+   environment variable and ``shell.py``'s ``main()`` will skip this
+   module entirely and connect directly to the specified URL.
+   This approach is recommended for Docker, cloud deployments, and CI.
 """
 
 from __future__ import annotations
@@ -28,17 +28,19 @@ from loguru import logger
 
 
 class DaemonManager:
-    """GovOn API 서버 daemon lifecycle 관리자.
+    """GovOn API server daemon lifecycle manager.
 
-    PID 파일과 /health 엔드포인트를 결합하여 daemon 상태를 확인하고,
-    필요 시 uvicorn으로 백그라운드 기동한다.
+    Combines PID file tracking with /health endpoint polling to verify
+    daemon state, and starts it via uvicorn as a background process when
+    needed.
 
-    환경변수 ``GOVON_PORT``로 포트를 오버라이드할 수 있다 (기본: 8000).
+    Override the default port (8000) via the ``GOVON_PORT`` environment
+    variable.
     """
 
     GOVON_HOME = Path.home() / ".govon"
-    _HEALTH_CHECK_TIMEOUT = 120  # 최대 대기 초
-    _HEALTH_CHECK_INTERVAL = 1  # 재시도 간격 (초)
+    _HEALTH_CHECK_TIMEOUT = 120  # seconds
+    _HEALTH_CHECK_INTERVAL = 1  # seconds between retries
 
     def __init__(self) -> None:
         self.GOVON_HOME.mkdir(parents=True, exist_ok=True)
@@ -47,44 +49,44 @@ class DaemonManager:
         self.log_path: Path = self.GOVON_HOME / "daemon.log"
 
     def get_base_url(self) -> str:
-        """daemon base URL을 반환한다."""
+        """Return the daemon base URL."""
         return f"http://127.0.0.1:{self.port}"
 
     def is_running(self) -> bool:
-        """daemon이 실행 중인지 확인한다.
+        """Check whether the daemon is running.
 
-        PID 파일이 존재하고 해당 프로세스가 살아 있으며,
-        /health 엔드포인트가 응답할 때 True를 반환한다.
+        Returns True when the PID file exists, the process is alive, and
+        the /health endpoint responds with HTTP 200.
         """
         pid = self._read_pid()
         if pid is None:
             return False
 
-        # PID 프로세스 생존 확인
+        # Verify the process is still alive
         if not self._pid_alive(pid):
-            logger.debug(f"[daemon] PID {pid} 프로세스가 없음. PID 파일 제거.")
+            logger.debug(f"[daemon] PID {pid} not found; removing PID file.")
             self._remove_pid()
             return False
 
-        # /health HTTP 확인
+        # Verify /health HTTP endpoint
         try:
             with httpx.Client(timeout=5.0) as client:
                 resp = client.get(f"{self.get_base_url()}/health")
                 return resp.status_code == 200
-        except (httpx.ConnectError, httpx.TimeoutException, Exception):
+        except (httpx.ConnectError, httpx.TimeoutException, httpx.RequestError, OSError):
             return False
 
     def start(self) -> bool:
-        """uvicorn을 백그라운드로 기동하고 PID를 기록한다.
+        """Start uvicorn in the background and record its PID.
 
         Returns
         -------
         bool
-            기동 성공 여부 (health check 통과 시 True).
+            True if the daemon started successfully (health check passed).
         """
-        # 레이스 컨디션 방지: 기동 전 한 번 더 health check
+        # Guard against race conditions: re-check before starting
         if self.is_running():
-            logger.info("[daemon] 이미 실행 중입니다.")
+            logger.info("[daemon] Already running.")
             return True
 
         cmd = [
@@ -99,10 +101,10 @@ class DaemonManager:
         ]
 
         if self._port_in_use():
-            logger.error(f"[daemon] 포트 {self.port}이 이미 사용 중입니다.")
+            logger.error(f"[daemon] Port {self.port} is already in use.")
             return False
 
-        logger.info(f"[daemon] 기동 명령: {' '.join(cmd)}")
+        logger.info(f"[daemon] Starting: {' '.join(cmd)}")
 
         with open(self.log_path, "a") as log_file:
             proc = subprocess.Popen(
@@ -113,40 +115,40 @@ class DaemonManager:
             )
 
         self._write_pid(proc.pid)
-        logger.info(f"[daemon] 프로세스 기동 완료. PID={proc.pid}")
+        logger.info(f"[daemon] Process started. PID={proc.pid}")
 
-        # health check 대기
+        # Wait for the health check to pass
         healthy = self._wait_until_healthy()
         if not healthy:
-            logger.error("[daemon] health check 실패. 프로세스를 정리합니다.")
+            logger.error("[daemon] Health check failed; cleaning up.")
             self.stop()
             return False
         return True
 
     def stop(self) -> None:
-        """daemon을 정상 종료한다 (SIGTERM → timeout 후 SIGKILL)."""
+        """Gracefully stop the daemon (SIGTERM, then SIGKILL after timeout)."""
         pid = self._read_pid()
         if pid is None:
-            logger.info("[daemon] PID 파일이 없습니다. 실행 중이 아닌 것으로 간주합니다.")
+            logger.info("[daemon] No PID file found; assuming not running.")
             return
 
         if not self._pid_alive(pid):
-            logger.info(f"[daemon] PID {pid} 프로세스가 없습니다.")
+            logger.info(f"[daemon] PID {pid} not found.")
             self._remove_pid()
             return
 
-        logger.info(f"[daemon] SIGTERM 전송: PID={pid}")
+        logger.info(f"[daemon] Sending SIGTERM: PID={pid}")
         os.kill(pid, signal.SIGTERM)
 
-        # 최대 10초 대기
+        # Wait up to 10 seconds for graceful shutdown
         for _ in range(10):
             time.sleep(1)
             if not self._pid_alive(pid):
-                logger.info(f"[daemon] PID {pid} 정상 종료됨.")
+                logger.info(f"[daemon] PID {pid} terminated gracefully.")
                 self._remove_pid()
                 return
 
-        logger.warning(f"[daemon] SIGKILL 전송: PID={pid}")
+        logger.warning(f"[daemon] Sending SIGKILL: PID={pid}")
         try:
             os.kill(pid, signal.SIGKILL)
         except ProcessLookupError:
@@ -154,41 +156,39 @@ class DaemonManager:
         self._remove_pid()
 
     def ensure_running(self) -> str:
-        """daemon이 실행 중임을 보장하고 base URL을 반환한다.
+        """Ensure the daemon is running and return its base URL.
 
-        실행 중이 아니면 start()를 호출한다.
+        Calls start() if the daemon is not already running.
 
         Returns
         -------
         str
-            daemon base URL (예: "http://127.0.0.1:8000").
+            Daemon base URL, e.g. "http://127.0.0.1:8000".
 
         Raises
         ------
         RuntimeError
-            daemon 기동에 실패한 경우.
+            If the daemon fails to start.
         """
         if not self.is_running():
             success = self.start()
             if not success:
-                raise RuntimeError(
-                    "GovOn daemon 기동에 실패했습니다. " f"로그를 확인하세요: {self.log_path}"
-                )
+                raise RuntimeError(f"GovOn daemon failed to start. Check logs: {self.log_path}")
         return self.get_base_url()
 
     def _port_in_use(self) -> bool:
-        """포트가 이미 사용 중인지 확인한다."""
+        """Return True if the target port is already bound."""
         import socket
 
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             return s.connect_ex(("127.0.0.1", self.port)) == 0
 
     # ------------------------------------------------------------------
-    # 내부 헬퍼
+    # Internal helpers
     # ------------------------------------------------------------------
 
     def _read_pid(self) -> Optional[int]:
-        """PID 파일에서 PID를 읽는다. 파일이 없으면 None."""
+        """Read the PID from the PID file; return None if absent or invalid."""
         if not self.pid_path.exists():
             return None
         try:
@@ -198,11 +198,11 @@ class DaemonManager:
             return None
 
     def _write_pid(self, pid: int) -> None:
-        """PID와 기동 시각(epoch timestamp)을 파일에 기록한다."""
+        """Write PID and start timestamp (epoch) to the PID file."""
         self.pid_path.write_text(f"{pid} {int(time.time())}")
 
     def _remove_pid(self) -> None:
-        """PID 파일을 제거한다."""
+        """Remove the PID file, ignoring missing-file errors."""
         try:
             self.pid_path.unlink()
         except FileNotFoundError:
@@ -210,29 +210,29 @@ class DaemonManager:
 
     @staticmethod
     def _pid_alive(pid: int) -> bool:
-        """프로세스가 살아 있는지 확인한다."""
+        """Return True if the process with *pid* is alive."""
         try:
             os.kill(pid, 0)
             return True
         except ProcessLookupError:
             return False
         except PermissionError:
-            # 프로세스가 존재하지만 권한이 없는 경우 → 살아 있음으로 간주
+            # Process exists but we lack permissions — treat as alive
             return True
 
     def _wait_until_healthy(self) -> bool:
-        """health check가 통과할 때까지 최대 120초 대기한다."""
+        """Poll /health until it returns 200 or the timeout (120 s) expires."""
         deadline = time.monotonic() + self._HEALTH_CHECK_TIMEOUT
         while time.monotonic() < deadline:
             try:
                 with httpx.Client(timeout=3.0) as client:
                     resp = client.get(f"{self.get_base_url()}/health")
                     if resp.status_code == 200:
-                        logger.info("[daemon] health check 통과.")
+                        logger.info("[daemon] Health check passed.")
                         return True
-            except (httpx.ConnectError, httpx.TimeoutException, Exception):
+            except (httpx.ConnectError, httpx.TimeoutException, httpx.RequestError, OSError):
                 pass
             time.sleep(self._HEALTH_CHECK_INTERVAL)
 
-        logger.error("[daemon] health check timeout (120초).")
+        logger.error("[daemon] Health check timed out (120 s).")
         return False

--- a/src/cli/renderer.py
+++ b/src/cli/renderer.py
@@ -5,6 +5,7 @@ Uses `rich` when available; falls back to plain print() otherwise.
 
 from __future__ import annotations
 
+import sys
 from threading import Lock
 from typing import Any
 
@@ -133,10 +134,10 @@ class StreamingStatusDisplay:
     def __enter__(self) -> "StreamingStatusDisplay":
         self._use_rich, _ = _resolve_render_mode()
         if self._use_rich:
-            self._status = _console.status(self._initial_message, spinner="dots")
+            self._status = _stderr_console.status(self._initial_message, spinner="dots")
             self._status.__enter__()
         else:
-            print(f"→ {self._initial_message}", flush=True)
+            print(f"→ {self._initial_message}", file=sys.stderr, flush=True)
         return self
 
     def update(self, message: str) -> None:
@@ -144,7 +145,7 @@ class StreamingStatusDisplay:
         if self._use_rich and self._status is not None:
             self._status.update(message)
         else:
-            print(f"→ {message}", flush=True)
+            print(f"→ {message}", file=sys.stderr, flush=True)
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         if self._use_rich and self._status is not None:
@@ -161,7 +162,7 @@ def _warn_narrow_terminal_once(columns: int) -> None:
             return
         _HAS_WARNED_NARROW_TERMINAL = True
 
-    print(get_narrow_terminal_warning(columns), flush=True)
+    print(get_narrow_terminal_warning(columns), file=sys.stderr, flush=True)
 
 
 def _reset_narrow_warning() -> None:

--- a/src/cli/renderer.py
+++ b/src/cli/renderer.py
@@ -25,9 +25,11 @@ try:
     from rich.text import Text
 
     _console = Console()
+    _stderr_console = Console(stderr=True)
     _RICH_AVAILABLE = True
 except ImportError:  # pragma: no cover
     _console = None  # type: ignore[assignment]
+    _stderr_console = None  # type: ignore[assignment]
     _RICH_AVAILABLE = False
 
 _HAS_WARNED_NARROW_TERMINAL = False
@@ -498,23 +500,27 @@ def render_result(result: dict) -> None:
 
 
 def render_status(message: str) -> None:
-    """Render a transient status / progress message."""
+    """Render a transient status / progress message to stderr."""
+    import sys
+
     use_rich, _ = _resolve_render_mode()
     if use_rich:
         theme = get_theme()
-        _console.print(f"[{theme.text_secondary}]→ {message}[/{theme.text_secondary}]")
+        _stderr_console.print(f"[{theme.text_secondary}]→ {message}[/{theme.text_secondary}]")
     else:
-        print(f"→ {message}")
+        print(f"→ {message}", file=sys.stderr)
 
 
 def render_error(message: str) -> None:
-    """Render an error message in red."""
+    """Render an error message in red to stderr."""
+    import sys
+
     use_rich, _ = _resolve_render_mode()
     if use_rich:
         theme = get_theme()
-        _console.print(f"[{theme.status_error}]오류:[/{theme.status_error}] {message}")
+        _stderr_console.print(f"[{theme.status_error}]오류:[/{theme.status_error}] {message}")
     else:
-        print(f"오류: {message}")
+        print(f"오류: {message}", file=sys.stderr)
 
 
 def render_thinking(content: str) -> None:

--- a/src/cli/shell.py
+++ b/src/cli/shell.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import argparse
 import os
+import signal
 import sys
+from pathlib import Path
 
 import httpx
 
@@ -26,7 +28,7 @@ from src.cli.log_config import setup_logging  # noqa: E402  (import order intent
 _PT_AVAILABLE = False
 try:
     from prompt_toolkit import PromptSession
-    from prompt_toolkit.history import InMemoryHistory
+    from prompt_toolkit.history import FileHistory
 
     _PT_AVAILABLE = True
 except ImportError:  # pragma: no cover
@@ -426,7 +428,9 @@ def _run_repl(
 ) -> None:
     """Run the interactive REPL until EOF or /exit."""
     session_id: str | None = initial_session_id
-    pt_session = PromptSession(history=InMemoryHistory()) if _PT_AVAILABLE else None
+    history_path = Path.home() / ".govon" / "history"
+    history_path.parent.mkdir(parents=True, exist_ok=True)
+    pt_session = PromptSession(history=FileHistory(str(history_path))) if _PT_AVAILABLE else None
     server_checked = False
 
     while True:
@@ -492,6 +496,31 @@ def _run_once(client: GovOnClient, query: str, session_id: str | None) -> None:
 
 def main() -> None:
     """CLI entry point for the `govon` command."""
+    # ── resolve package version early (needed for --version flag) ────────
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _pkg_version
+
+    try:
+        ver = _pkg_version("govon")
+    except PackageNotFoundError:
+        ver = "dev"
+
+    # ── SIGPIPE: restore default so that `govon … | head` works cleanly ──
+    try:
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+    except AttributeError:
+        pass  # Windows does not have SIGPIPE
+
+    # ── graceful shutdown on SIGTERM / SIGHUP ─────────────────────────────
+    def _graceful_exit(signum, frame):  # noqa: ANN001
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, _graceful_exit)
+    try:
+        signal.signal(signal.SIGHUP, _graceful_exit)
+    except AttributeError:
+        pass  # Windows does not have SIGHUP
+
     # ── early dispatch for server subcommand ──────────────────────────────
     # argparse handles positional + subparser mixing poorly,
     # so intercept 'server' first and delegate to a separate handler.
@@ -515,6 +544,7 @@ def main() -> None:
         formatter_class=argparse.RawTextHelpFormatter,
         epilog="Subcommands:\n  govon server <command>   Docker backend management (pull/start/stop/status/logs)",
     )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {ver}")
     parser.add_argument(
         "query",
         nargs="?",
@@ -605,13 +635,6 @@ def main() -> None:
     else:
         # Interactive REPL mode: show banner first, check server on first query
         if not args.no_banner:
-            from importlib.metadata import PackageNotFoundError
-            from importlib.metadata import version as pkg_version
-
-            try:
-                ver = pkg_version("govon")
-            except PackageNotFoundError:
-                ver = "dev"
             mode = "remote" if runtime_url else "local"
             render_banner(version=ver, mode=mode, runtime_url=runtime_url)
 

--- a/tests/test_inference/test_cli_streaming.py
+++ b/tests/test_inference/test_cli_streaming.py
@@ -384,8 +384,8 @@ class TestStreamingStatusDisplay:
                 d.update("업데이트 메시지")
 
         captured = capsys.readouterr()
-        assert "테스트 시작" in captured.out
-        assert "업데이트 메시지" in captured.out
+        assert "테스트 시작" in captured.err
+        assert "업데이트 메시지" in captured.err
 
     def test_streaming_status_display_update_plain(self, capsys):
         """update() 호출 시 plain mode에서 새 메시지가 출력된다."""

--- a/tests/test_inference/test_cli_streaming.py
+++ b/tests/test_inference/test_cli_streaming.py
@@ -396,9 +396,9 @@ class TestStreamingStatusDisplay:
                 d.update("planner 처리 중")
                 d.update("synthesis 처리 중")
 
-        out = capsys.readouterr().out
-        assert "planner 처리 중" in out
-        assert "synthesis 처리 중" in out
+        captured = capsys.readouterr()
+        assert "planner 처리 중" in captured.err
+        assert "synthesis 처리 중" in captured.err
 
     def test_streaming_status_display_falls_back_on_narrow_terminal(self, capsys):
         """좁은 터미널에서는 rich가 있어도 plain mode로 전환된다."""
@@ -411,9 +411,9 @@ class TestStreamingStatusDisplay:
                     with renderer.StreamingStatusDisplay("초기") as display:
                         display.update("planner 처리 중")
 
-        out = capsys.readouterr().out
-        assert "plain mode" in out
-        assert "planner 처리 중" in out
+        captured = capsys.readouterr()
+        assert "plain mode" in captured.err
+        assert "planner 처리 중" in captured.err
         mock_console.status.assert_not_called()
 
     def test_narrow_terminal_warning_is_emitted_once_per_narrow_state(self, capsys):
@@ -427,10 +427,10 @@ class TestStreamingStatusDisplay:
                 renderer.render_status("셋째 상태")
                 renderer.render_status("넷째 상태")
 
-        out = capsys.readouterr().out
-        assert out.count("plain mode") == 2
-        assert "첫 상태" in out
-        assert "넷째 상태" in out
+        captured = capsys.readouterr()
+        assert captured.err.count("plain mode") == 2
+        assert "첫 상태" in captured.err
+        assert "넷째 상태" in captured.err
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Related Issue
-

## Background
The CLI was missing several production-standard features that affect reliability and usability:
- No `--version` flag
- No SIGPIPE handler (pipe to `head` caused BrokenPipeError noise)
- No SIGTERM/SIGHUP handlers (unclean shutdown in container/service deployments)
- Error and status output mixed with stdout (broke pipe-based scripting)
- Input history lost on every session restart
- Overly broad `except Exception` in daemon health checks hid real errors

## Key Changes
- **shell.py** — resolve package version via `importlib.metadata` at `main()` entry; expose `--version` argparse flag
- **shell.py** — install `SIGPIPE → SIG_DFL` so `govon … | head` exits cleanly; install `SIGTERM`/`SIGHUP` graceful-exit handlers
- **shell.py** — replace `InMemoryHistory` with `FileHistory(~/.govon/history)` for persistent readline-style history
- **renderer.py** — add `_stderr_console = Console(stderr=True)`; route `render_error()` and `render_status()` to stderr so answer text on stdout is uncontaminated
- **daemon.py** — narrow `except (httpx.ConnectError, httpx.TimeoutException, Exception)` to `(httpx.ConnectError, httpx.TimeoutException, httpx.RequestError, OSError)` in both `is_running()` and `_wait_until_healthy()`
- **daemon.py** — convert all Korean docstrings, inline comments, and log messages to English per source code language rule

## Test Results
- [ ] Local test complete
- [ ] Existing functionality verified
- `ruff check`, `black --check`, `isort --check` all pass on all three modified files

## Additional Notes
SIGPIPE and SIGHUP handlers are wrapped in `try/except AttributeError` so the code stays Windows-compatible.

---

## Merge Checklist
- [ ] At least one code review approval
- [ ] CODEOWNERS (team lead) final approval
- [ ] All review comments resolved

## Reviewer Guide

| Tag | Meaning | Example |
|-----|---------|---------|
| `[MUST]` | Must fix (security, bug, performance issue) | `[MUST] API key is exposed in logs.` |
| `[SHOULD]` | Strongly recommended (code quality, maintainability) | `[SHOULD] This logic should be extracted into a separate function.` |
| `[NITS]` | Minor improvement (style, naming) | `[NITS] \`parsed_output\` is clearer than \`result\` as a variable name.` |
| `[QUESTION]` | Question for understanding | `[QUESTION] Can this condition ever be always True?` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * REPL history is now saved and restored across sessions
  * Added `--version` flag to display application version

* **Bug Fixes**
  * Improved error messages and narrower exception handling for reliability
  * Better daemon health checks and simpler failure reporting
  * Graceful signal handling for clean shutdowns
  * Status, error and warning output now go to stderr

* **Documentation**
  * System messages and logs updated to clearer English wording
<!-- end of auto-generated comment: release notes by coderabbit.ai -->