### PR TITLE
feat(tui): Textual TUI — Claude Code-style terminal interface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,10 @@ test = [
     "pytest-asyncio>=0.21.0",
 ]
 
+tui = [
+    "textual>=0.89.0",
+]
+
 # Full server-side runtime (inference engine, ML models, etc.)
 server = [
     "torch>=2.8.0",

--- a/src/cli/shell.py
+++ b/src/cli/shell.py
@@ -106,6 +106,20 @@ except ImportError:  # pragma: no cover
 _PROMPT_TEXT = "\u276f "  # ❯ (Claude Code-style prompt)
 
 
+def _should_use_tui() -> bool:
+    """Return True if the Textual TUI should be used instead of the legacy REPL."""
+    if os.environ.get("GOVON_PLAIN") == "1":
+        return False
+    if not sys.stdin.isatty():
+        return False
+    try:
+        from src.cli.tui import HAS_TEXTUAL
+
+        return HAS_TEXTUAL
+    except ImportError:
+        return False
+
+
 def _get_input(session: "PromptSession | None") -> str:  # type: ignore[name-defined]
     """Read one line of user input (prompt_toolkit or plain input())."""
     if _PT_AVAILABLE and session is not None:
@@ -657,8 +671,14 @@ def main() -> None:
         # Single-shot mode: must ensure server is ready before sending
         _ensure_server_ready(client, is_remote=bool(runtime_url))
         _run_once(client, args.query, args.session)
+    elif _should_use_tui():
+        # Textual TUI mode — full terminal UI
+        from src.cli.tui.app import GovOnApp
+
+        app = GovOnApp(client=client, session_id=args.session)
+        app.run(inline=True)
     else:
-        # Interactive REPL mode: show banner first, check server on first query
+        # Legacy REPL mode — rich + prompt_toolkit fallback
         if not args.no_banner:
             mode = "remote" if runtime_url else "local"
             render_banner(version=ver, mode=mode, runtime_url=runtime_url)

--- a/src/cli/tui/__init__.py
+++ b/src/cli/tui/__init__.py
@@ -1,0 +1,13 @@
+"""Textual TUI package for GovOn CLI.
+
+Provides a full terminal UI when Textual is installed. Falls back to the
+legacy rich+prompt_toolkit REPL when Textual is not available.
+"""
+
+HAS_TEXTUAL = False
+try:
+    import textual  # noqa: F401
+
+    HAS_TEXTUAL = True
+except ImportError:
+    pass

--- a/src/cli/tui/app.py
+++ b/src/cli/tui/app.py
@@ -1,0 +1,252 @@
+"""GovOn Textual TUI application.
+
+Provides a Claude Code-style terminal interface with scrollable message
+history, streaming markdown, collapsible tool panels, and an input bar.
+Runs in inline mode so output stays in terminal scrollback.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from textual.app import App, ComposeResult
+from textual.containers import VerticalScroll
+from textual.widgets import Footer, Input, Rule, Static
+
+if TYPE_CHECKING:
+    from src.cli.http_client import GovOnClient
+
+CSS_PATH = Path(__file__).parent / "govon_app.tcss"
+
+
+class GovOnApp(App):
+    """Main Textual application for GovOn CLI."""
+
+    CSS_PATH = "govon_app.tcss"
+
+    BINDINGS = [
+        ("escape", "cancel_query", "취소"),
+        ("ctrl+d", "quit", "종료"),
+    ]
+
+    def __init__(
+        self,
+        client: GovOnClient,
+        session_id: str | None = None,
+        query: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.client = client
+        self.session_id = session_id
+        self._initial_query = query
+
+    def compose(self) -> ComposeResult:
+        """Build the widget tree."""
+        yield VerticalScroll(id="message-history")
+        yield Rule(id="separator")
+        yield Input(placeholder="\u276f ", id="input-bar")
+        yield Footer(id="status-footer")
+
+    def on_mount(self) -> None:
+        """Focus the input bar on startup."""
+        self.query_one("#input-bar", Input).focus()
+        if self._initial_query:
+            self._submit_query(self._initial_query)
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Handle Enter key in the input bar."""
+        query = event.value.strip()
+        if not query:
+            return
+        event.input.clear()
+        self._submit_query(query)
+
+    def _submit_query(self, query: str) -> None:
+        """Process a user query — route to command handler or SSE worker."""
+        from src.cli.commands import handle_command, is_command
+
+        if is_command(query):
+            try:
+                result = handle_command(query)
+            except SystemExit:
+                self.exit()
+                return
+            if result is not None:
+                history = self.query_one("#message-history", VerticalScroll)
+                history.mount(Static(result))
+            return
+
+        # Mount user message bubble
+        history = self.query_one("#message-history", VerticalScroll)
+        history.mount(Static(f"[bold]❯[/bold] {query}"))
+
+        # Start SSE streaming in background thread
+        self.run_worker(
+            self._consume_sse(query),
+            thread=True,
+            exclusive=True,
+            group="sse",
+        )
+
+    async def _consume_sse(self, query: str) -> None:
+        """Worker: consume SSE events from the sync httpx client."""
+        from src.cli.tui.messages import (
+            SSEComplete,
+            SSEError,
+            SSEResponseDelta,
+            SSEThinkingDelta,
+            SSEToolEnd,
+            SSEToolStart,
+        )
+
+        try:
+            for event in self.client.stream_v3(query, self.session_id):
+                event_type = event.get("type", "")
+
+                if event_type == "error":
+                    self.call_from_thread(
+                        self.post_message,
+                        SSEError(event.get("error", "unknown error")),
+                    )
+                    return
+
+                if event_type == "thinking_delta":
+                    content = event.get("content", "")
+                    if content:
+                        self.call_from_thread(
+                            self.post_message,
+                            SSEThinkingDelta(content),
+                        )
+
+                elif event_type == "response_delta":
+                    content = event.get("content", "")
+                    if content:
+                        self.call_from_thread(
+                            self.post_message,
+                            SSEResponseDelta(content),
+                        )
+
+                elif event_type == "tool_start":
+                    tool_name = event.get("tool", "")
+                    if tool_name:
+                        self.call_from_thread(
+                            self.post_message,
+                            SSEToolStart(tool_name),
+                        )
+
+                elif event_type == "tool_end":
+                    tool_name = event.get("tool", "")
+                    self.call_from_thread(
+                        self.post_message,
+                        SSEToolEnd(tool_name),
+                    )
+
+                elif event_type == "run_complete":
+                    sid = event.get("session_id") or event.get("thread_id")
+                    if sid:
+                        self.session_id = sid
+                    self.call_from_thread(
+                        self.post_message,
+                        SSEComplete(event),
+                    )
+
+        except Exception as exc:
+            self.call_from_thread(
+                self.post_message,
+                SSEError(str(exc)),
+            )
+
+    # -- SSE event handlers --------------------------------------------------
+
+    def on_sse_thinking_delta(self, event: object) -> None:
+        """Append thinking text to the message history."""
+        from src.cli.tui.messages import SSEThinkingDelta
+
+        msg = event if isinstance(event, SSEThinkingDelta) else None
+        if msg is None:
+            return
+        history = self.query_one("#message-history", VerticalScroll)
+        history.mount(Static(f"[dim italic]{msg.content}[/dim italic]"))
+
+    def on_sse_response_delta(self, event: object) -> None:
+        """Append response token to the message history."""
+        from src.cli.tui.messages import SSEResponseDelta
+
+        msg = event if isinstance(event, SSEResponseDelta) else None
+        if msg is None:
+            return
+        history = self.query_one("#message-history", VerticalScroll)
+        history.mount(Static(msg.content))
+
+    def on_sse_tool_start(self, event: object) -> None:
+        """Show tool execution start."""
+        from src.cli.tui.messages import SSEToolStart
+
+        msg = event if isinstance(event, SSEToolStart) else None
+        if msg is None:
+            return
+        history = self.query_one("#message-history", VerticalScroll)
+        history.mount(Static(f"[cyan]\u250c\u2500 \u2699 {msg.tool_name}[/cyan]"))
+
+    def on_sse_tool_end(self, event: object) -> None:
+        """Show tool execution end."""
+        from src.cli.tui.messages import SSEToolEnd
+
+        msg = event if isinstance(event, SSEToolEnd) else None
+        if msg is None:
+            return
+        history = self.query_one("#message-history", VerticalScroll)
+        latency = f" ({msg.latency_ms:.0f}ms)" if msg.latency_ms else ""
+        history.mount(
+            Static(f"[green]\u2514\u2500 \u2726 {msg.tool_name} \uc644\ub8cc{latency}[/green]")
+        )
+
+    def on_sse_error(self, event: object) -> None:
+        """Show error message."""
+        from src.cli.tui.messages import SSEError
+
+        msg = event if isinstance(event, SSEError) else None
+        if msg is None:
+            return
+        history = self.query_one("#message-history", VerticalScroll)
+        history.mount(Static(f"[red bold]\uc624\ub958:[/red bold] {msg.error}"))
+
+    def on_sse_complete(self, event: object) -> None:
+        """Finalize response rendering."""
+        from src.cli.tui.messages import SSEComplete
+
+        msg = event if isinstance(event, SSEComplete) else None
+        if msg is None:
+            return
+
+        # Render final text if present and not already streamed via deltas
+        text = msg.result.get("text") or msg.result.get("response") or ""
+        if text:
+            history = self.query_one("#message-history", VerticalScroll)
+            from textual.widgets import Markdown
+
+            history.mount(Markdown(text))
+
+        # Show metadata
+        metadata = msg.result.get("metadata", {})
+        if metadata:
+            iterations = metadata.get("total_iterations", 0)
+            tool_calls = metadata.get("total_tool_calls", 0)
+            latency = metadata.get("total_latency_ms", 0)
+            history = self.query_one("#message-history", VerticalScroll)
+            history.mount(
+                Static(
+                    f"[dim]\u23af iterations={iterations}  "
+                    f"tools={tool_calls}  "
+                    f"latency={latency:.0f}ms[/dim]"
+                )
+            )
+
+    def action_cancel_query(self) -> None:
+        """Cancel the active SSE worker on Esc."""
+        self.workers.cancel_group(self, "sse")
+
+    def action_quit(self) -> None:
+        """Quit the application."""
+        self.exit()

--- a/src/cli/tui/app.py
+++ b/src/cli/tui/app.py
@@ -7,17 +7,30 @@ Runs in inline mode so output stays in terminal scrollback.
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from textual.app import App, ComposeResult
 from textual.containers import VerticalScroll
-from textual.widgets import Footer, Input, Rule, Static
+from textual.widgets import Footer, Rule, Static
+
+from src.cli.tui.messages import (
+    SSEComplete,
+    SSEError,
+    SSEResponseDelta,
+    SSEThinkingDelta,
+    SSEToolEnd,
+    SSEToolStart,
+)
+from src.cli.tui.widgets.input_bar import InputBar
+from src.cli.tui.widgets.markdown_view import MarkdownView
+from src.cli.tui.widgets.message_bubble import MessageBubble
+from src.cli.tui.widgets.metadata_bar import MetadataBar
+from src.cli.tui.widgets.spinner import SpinnerWidget
+from src.cli.tui.widgets.thinking_block import ThinkingBlock
+from src.cli.tui.widgets.tool_panel import ToolCallPanel
 
 if TYPE_CHECKING:
     from src.cli.http_client import GovOnClient
-
-CSS_PATH = Path(__file__).parent / "govon_app.tcss"
 
 
 class GovOnApp(App):
@@ -26,8 +39,8 @@ class GovOnApp(App):
     CSS_PATH = "govon_app.tcss"
 
     BINDINGS = [
-        ("escape", "cancel_query", "취소"),
-        ("ctrl+d", "quit", "종료"),
+        ("escape", "cancel_query", "\ucde8\uc18c"),
+        ("ctrl+d", "quit", "\uc885\ub8cc"),
     ]
 
     def __init__(
@@ -40,21 +53,25 @@ class GovOnApp(App):
         self.client = client
         self.session_id = session_id
         self._initial_query = query
+        self._current_bubble: MessageBubble | None = None
+        self._current_spinner: SpinnerWidget | None = None
+        self._current_thinking: ThinkingBlock | None = None
+        self._current_markdown: MarkdownView | None = None
 
     def compose(self) -> ComposeResult:
         """Build the widget tree."""
         yield VerticalScroll(id="message-history")
         yield Rule(id="separator")
-        yield Input(placeholder="\u276f ", id="input-bar")
+        yield InputBar(id="input-bar")
         yield Footer(id="status-footer")
 
     def on_mount(self) -> None:
         """Focus the input bar on startup."""
-        self.query_one("#input-bar", Input).focus()
+        self.query_one("#input-bar", InputBar).focus()
         if self._initial_query:
             self._submit_query(self._initial_query)
 
-    def on_input_submitted(self, event: Input.Submitted) -> None:
+    def on_input_submitted(self, event: InputBar.Submitted) -> None:
         """Handle Enter key in the input bar."""
         query = event.value.strip()
         if not query:
@@ -66,6 +83,8 @@ class GovOnApp(App):
         """Process a user query — route to command handler or SSE worker."""
         from src.cli.commands import handle_command, is_command
 
+        history = self.query_one("#message-history", VerticalScroll)
+
         if is_command(query):
             try:
                 result = handle_command(query)
@@ -73,13 +92,21 @@ class GovOnApp(App):
                 self.exit()
                 return
             if result is not None:
-                history = self.query_one("#message-history", VerticalScroll)
                 history.mount(Static(result))
             return
 
         # Mount user message bubble
-        history = self.query_one("#message-history", VerticalScroll)
-        history.mount(Static(f"[bold]❯[/bold] {query}"))
+        user_bubble = MessageBubble(role="user")
+        history.mount(user_bubble)
+        user_bubble.mount(Static(f"[bold]\u276f[/bold] {query}"))
+
+        # Mount assistant bubble with spinner
+        self._current_bubble = MessageBubble(role="assistant")
+        history.mount(self._current_bubble)
+        self._current_spinner = SpinnerWidget()
+        self._current_bubble.mount(self._current_spinner)
+        self._current_thinking = None
+        self._current_markdown = None
 
         # Start SSE streaming in background thread
         self.run_worker(
@@ -89,163 +116,141 @@ class GovOnApp(App):
             group="sse",
         )
 
+    def _stop_spinner(self) -> None:
+        """Remove the spinner widget when first content arrives."""
+        if self._current_spinner is not None:
+            self._current_spinner.stop()
+            self._current_spinner.remove()
+            self._current_spinner = None
+
     async def _consume_sse(self, query: str) -> None:
         """Worker: consume SSE events from the sync httpx client."""
-        from src.cli.tui.messages import (
-            SSEComplete,
-            SSEError,
-            SSEResponseDelta,
-            SSEThinkingDelta,
-            SSEToolEnd,
-            SSEToolStart,
-        )
-
         try:
             for event in self.client.stream_v3(query, self.session_id):
                 event_type = event.get("type", "")
 
                 if event_type == "error":
                     self.call_from_thread(
-                        self.post_message,
-                        SSEError(event.get("error", "unknown error")),
+                        self.post_message, SSEError(event.get("error", "unknown error"))
                     )
                     return
 
-                if event_type == "thinking_delta":
+                elif event_type == "thinking_delta":
                     content = event.get("content", "")
                     if content:
-                        self.call_from_thread(
-                            self.post_message,
-                            SSEThinkingDelta(content),
-                        )
+                        self.call_from_thread(self.post_message, SSEThinkingDelta(content))
 
                 elif event_type == "response_delta":
                     content = event.get("content", "")
                     if content:
-                        self.call_from_thread(
-                            self.post_message,
-                            SSEResponseDelta(content),
-                        )
+                        self.call_from_thread(self.post_message, SSEResponseDelta(content))
 
                 elif event_type == "tool_start":
                     tool_name = event.get("tool", "")
                     if tool_name:
-                        self.call_from_thread(
-                            self.post_message,
-                            SSEToolStart(tool_name),
-                        )
+                        self.call_from_thread(self.post_message, SSEToolStart(tool_name))
 
                 elif event_type == "tool_end":
                     tool_name = event.get("tool", "")
-                    self.call_from_thread(
-                        self.post_message,
-                        SSEToolEnd(tool_name),
-                    )
+                    latency = event.get("latency_ms", 0)
+                    self.call_from_thread(self.post_message, SSEToolEnd(tool_name, latency))
 
                 elif event_type == "run_complete":
                     sid = event.get("session_id") or event.get("thread_id")
                     if sid:
                         self.session_id = sid
-                    self.call_from_thread(
-                        self.post_message,
-                        SSEComplete(event),
-                    )
+                    self.call_from_thread(self.post_message, SSEComplete(event))
 
         except Exception as exc:
-            self.call_from_thread(
-                self.post_message,
-                SSEError(str(exc)),
-            )
+            self.call_from_thread(self.post_message, SSEError(str(exc)))
 
     # -- SSE event handlers --------------------------------------------------
 
-    def on_sse_thinking_delta(self, event: object) -> None:
-        """Append thinking text to the message history."""
-        from src.cli.tui.messages import SSEThinkingDelta
-
-        msg = event if isinstance(event, SSEThinkingDelta) else None
-        if msg is None:
+    def on_sse_thinking_delta(self, message: SSEThinkingDelta) -> None:
+        """Append thinking text — spinner disappears on first token."""
+        self._stop_spinner()
+        if self._current_bubble is None:
             return
-        history = self.query_one("#message-history", VerticalScroll)
-        history.mount(Static(f"[dim italic]{msg.content}[/dim italic]"))
+        if self._current_thinking is None:
+            self._current_thinking = ThinkingBlock()
+            self._current_bubble.mount(self._current_thinking)
+        self._current_thinking.append(message.content)
 
-    def on_sse_response_delta(self, event: object) -> None:
-        """Append response token to the message history."""
-        from src.cli.tui.messages import SSEResponseDelta
-
-        msg = event if isinstance(event, SSEResponseDelta) else None
-        if msg is None:
+    def on_sse_response_delta(self, message: SSEResponseDelta) -> None:
+        """Stream response tokens into markdown view."""
+        self._stop_spinner()
+        if self._current_bubble is None:
             return
-        history = self.query_one("#message-history", VerticalScroll)
-        history.mount(Static(msg.content))
+        if self._current_markdown is None:
+            self._current_markdown = MarkdownView()
+            self._current_bubble.mount(self._current_markdown)
+        self._current_markdown.append_delta(message.content)
 
-    def on_sse_tool_start(self, event: object) -> None:
-        """Show tool execution start."""
-        from src.cli.tui.messages import SSEToolStart
-
-        msg = event if isinstance(event, SSEToolStart) else None
-        if msg is None:
+    def on_sse_tool_start(self, message: SSEToolStart) -> None:
+        """Mount a tool call panel."""
+        self._stop_spinner()
+        if self._current_bubble is None:
             return
-        history = self.query_one("#message-history", VerticalScroll)
-        history.mount(Static(f"[cyan]\u250c\u2500 \u2699 {msg.tool_name}[/cyan]"))
+        panel = ToolCallPanel(tool_name=message.tool_name, id=f"tool-{message.tool_name}")
+        self._current_bubble.mount(panel)
 
-    def on_sse_tool_end(self, event: object) -> None:
-        """Show tool execution end."""
-        from src.cli.tui.messages import SSEToolEnd
-
-        msg = event if isinstance(event, SSEToolEnd) else None
-        if msg is None:
+    def on_sse_tool_end(self, message: SSEToolEnd) -> None:
+        """Update tool call panel to completed state."""
+        if self._current_bubble is None:
             return
-        history = self.query_one("#message-history", VerticalScroll)
-        latency = f" ({msg.latency_ms:.0f}ms)" if msg.latency_ms else ""
-        history.mount(
-            Static(f"[green]\u2514\u2500 \u2726 {msg.tool_name} \uc644\ub8cc{latency}[/green]")
-        )
-
-    def on_sse_error(self, event: object) -> None:
-        """Show error message."""
-        from src.cli.tui.messages import SSEError
-
-        msg = event if isinstance(event, SSEError) else None
-        if msg is None:
-            return
-        history = self.query_one("#message-history", VerticalScroll)
-        history.mount(Static(f"[red bold]\uc624\ub958:[/red bold] {msg.error}"))
-
-    def on_sse_complete(self, event: object) -> None:
-        """Finalize response rendering."""
-        from src.cli.tui.messages import SSEComplete
-
-        msg = event if isinstance(event, SSEComplete) else None
-        if msg is None:
-            return
-
-        # Render final text if present and not already streamed via deltas
-        text = msg.result.get("text") or msg.result.get("response") or ""
-        if text:
-            history = self.query_one("#message-history", VerticalScroll)
-            from textual.widgets import Markdown
-
-            history.mount(Markdown(text))
-
-        # Show metadata
-        metadata = msg.result.get("metadata", {})
-        if metadata:
-            iterations = metadata.get("total_iterations", 0)
-            tool_calls = metadata.get("total_tool_calls", 0)
-            latency = metadata.get("total_latency_ms", 0)
-            history = self.query_one("#message-history", VerticalScroll)
-            history.mount(
+        try:
+            panel = self._current_bubble.query_one(f"#tool-{message.tool_name}", ToolCallPanel)
+            panel.complete(message.latency_ms)
+        except Exception:
+            # Panel not found — render inline fallback
+            latency = f" ({message.latency_ms:.0f}ms)" if message.latency_ms else ""
+            self._current_bubble.mount(
                 Static(
-                    f"[dim]\u23af iterations={iterations}  "
-                    f"tools={tool_calls}  "
-                    f"latency={latency:.0f}ms[/dim]"
+                    f"[green]\u2514\u2500 \u2726 {message.tool_name} \uc644\ub8cc{latency}[/green]"
                 )
             )
+
+    def on_sse_error(self, message: SSEError) -> None:
+        """Show error in the current bubble or history."""
+        self._stop_spinner()
+        target = self._current_bubble or self.query_one("#message-history", VerticalScroll)
+        target.mount(Static(f"[red bold]\uc624\ub958:[/red bold] {message.error}"))
+
+    def on_sse_complete(self, message: SSEComplete) -> None:
+        """Finalize response rendering."""
+        self._stop_spinner()
+
+        if self._current_bubble is None:
+            return
+
+        # Render final text if not already streamed via response_delta
+        text = message.result.get("text") or message.result.get("response") or ""
+        if text and self._current_markdown is None:
+            md = MarkdownView()
+            self._current_bubble.mount(md)
+            md.set_content(text)
+
+        # Show metadata
+        metadata = message.result.get("metadata", {})
+        if metadata:
+            bar = MetadataBar()
+            self._current_bubble.mount(bar)
+            bar.set_metadata(metadata)
+
+        # Scroll to bottom
+        history = self.query_one("#message-history", VerticalScroll)
+        history.scroll_end()
+
+        # Reset current state for next query
+        self._current_bubble = None
+        self._current_spinner = None
+        self._current_thinking = None
+        self._current_markdown = None
 
     def action_cancel_query(self) -> None:
         """Cancel the active SSE worker on Esc."""
         self.workers.cancel_group(self, "sse")
+        self._stop_spinner()
 
     def action_quit(self) -> None:
         """Quit the application."""

--- a/src/cli/tui/app.py
+++ b/src/cli/tui/app.py
@@ -14,6 +14,8 @@ from textual.containers import VerticalScroll
 from textual.widgets import Footer, Rule, Static
 
 from src.cli.tui.messages import (
+    ApprovalResult,
+    SSEApproval,
     SSEComplete,
     SSEError,
     SSEResponseDelta,
@@ -21,6 +23,7 @@ from src.cli.tui.messages import (
     SSEToolEnd,
     SSEToolStart,
 )
+from src.cli.tui.widgets.approval_modal import ApprovalModal
 from src.cli.tui.widgets.input_bar import InputBar
 from src.cli.tui.widgets.markdown_view import MarkdownView
 from src.cli.tui.widgets.message_bubble import MessageBubble
@@ -155,6 +158,12 @@ class GovOnApp(App):
                     latency = event.get("latency_ms", 0)
                     self.call_from_thread(self.post_message, SSEToolEnd(tool_name, latency))
 
+                elif event_type == "awaiting_approval":
+                    request = event.get("approval_request") or {}
+                    thread_id = event.get("thread_id", "")
+                    self.call_from_thread(self.post_message, SSEApproval(request, thread_id))
+                    return  # pause SSE consumption until approval resolves
+
                 elif event_type == "run_complete":
                     sid = event.get("session_id") or event.get("thread_id")
                     if sid:
@@ -246,6 +255,59 @@ class GovOnApp(App):
         self._current_spinner = None
         self._current_thinking = None
         self._current_markdown = None
+
+    def on_sse_approval(self, message: SSEApproval) -> None:
+        """Mount an approval modal for human-in-the-loop tool approval."""
+        self._stop_spinner()
+        if self._current_bubble is None:
+            return
+        modal = ApprovalModal(
+            approval_request=message.request,
+            thread_id=message.thread_id,
+        )
+        self._current_bubble.mount(modal)
+
+    def on_approval_result(self, message: ApprovalResult) -> None:
+        """Handle user approval/rejection and resume SSE if approved."""
+        try:
+            self.client.approve(message.thread_id, approved=message.approved)
+        except Exception:
+            pass
+
+        if message.approved:
+            # Resume SSE streaming after approval
+            self.run_worker(
+                self._consume_sse_resume(message.thread_id),
+                thread=True,
+                exclusive=True,
+                group="sse",
+            )
+
+    async def _consume_sse_resume(self, thread_id: str) -> None:
+        """Resume SSE streaming after approval by re-streaming from the server."""
+        # The server continues the agent execution after approve().
+        # We need to stream the remaining events.
+        # Use stream() (v2) which handles post-approval continuation.
+        try:
+            for event in self.client.stream(None, self.session_id):
+                event_type = event.get("type", event.get("status", ""))
+
+                if event_type == "error" or event.get("node") == "error":
+                    self.call_from_thread(
+                        self.post_message,
+                        SSEError(event.get("error", "unknown error")),
+                    )
+                    return
+
+                if event_type in ("completed", "done", "success") or event.get("text"):
+                    self.call_from_thread(
+                        self.post_message,
+                        SSEComplete(event),
+                    )
+                    return
+
+        except Exception as exc:
+            self.call_from_thread(self.post_message, SSEError(str(exc)))
 
     def action_cancel_query(self) -> None:
         """Cancel the active SSE worker on Esc."""

--- a/src/cli/tui/govon_app.tcss
+++ b/src/cli/tui/govon_app.tcss
@@ -1,0 +1,81 @@
+/* GovOn TUI layout — Claude Code-style inline terminal UI */
+
+GovOnApp {
+    layout: vertical;
+}
+
+#message-history {
+    height: 1fr;
+    overflow-y: auto;
+    padding: 0 1;
+}
+
+MessageBubble {
+    margin: 1 0 0 0;
+    width: 100%;
+}
+
+MessageBubble.user {
+    color: $text;
+}
+
+MessageBubble.assistant {
+    margin: 0 0 0 0;
+}
+
+SpinnerWidget {
+    height: 1;
+    color: $text-muted;
+}
+
+ThinkingBlock {
+    color: $text-muted;
+    text-style: italic;
+    margin: 0 2;
+}
+
+MarkdownView {
+    margin: 0 0;
+}
+
+ToolCallPanel {
+    margin: 0 2;
+    height: auto;
+}
+
+MetadataBar {
+    color: $text-muted;
+    height: 1;
+    margin: 0 0;
+}
+
+#separator {
+    height: 1;
+    color: $text-muted;
+}
+
+#input-bar {
+    height: 3;
+    dock: bottom;
+    padding: 0 1;
+}
+
+#input-bar Input {
+    width: 100%;
+}
+
+#status-footer {
+    height: 1;
+    dock: bottom;
+    color: $text-muted;
+    text-align: center;
+    padding: 0 1;
+}
+
+ApprovalModal {
+    width: 60;
+    height: auto;
+    margin: 1 4;
+    border: thick $warning;
+    padding: 1 2;
+}

--- a/src/cli/tui/messages.py
+++ b/src/cli/tui/messages.py
@@ -1,0 +1,95 @@
+"""Custom Textual Message types for SSE event bridging.
+
+These messages are posted from the SSE worker thread to the main Textual
+event loop, allowing async widget updates from synchronous httpx streams.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from textual.message import Message
+
+
+class SSENodeUpdate(Message):
+    """Agent node status changed (e.g. session_load, agent, tools)."""
+
+    def __init__(self, node: str, status: str) -> None:
+        super().__init__()
+        self.node = node
+        self.status = status
+
+
+class SSEThinkingDelta(Message):
+    """Incremental thinking text from the LLM."""
+
+    def __init__(self, content: str) -> None:
+        super().__init__()
+        self.content = content
+
+
+class SSEResponseDelta(Message):
+    """Incremental response token from the LLM final answer."""
+
+    def __init__(self, content: str) -> None:
+        super().__init__()
+        self.content = content
+
+
+class SSEToolStart(Message):
+    """A tool execution has started."""
+
+    def __init__(self, tool_name: str) -> None:
+        super().__init__()
+        self.tool_name = tool_name
+
+
+class SSEToolEnd(Message):
+    """A tool execution has completed."""
+
+    def __init__(self, tool_name: str, latency_ms: float = 0) -> None:
+        super().__init__()
+        self.tool_name = tool_name
+        self.latency_ms = latency_ms
+
+
+class SSEApproval(Message):
+    """Server is requesting human approval for a tool execution plan."""
+
+    def __init__(self, request: dict[str, Any], thread_id: str) -> None:
+        super().__init__()
+        self.request = request
+        self.thread_id = thread_id
+
+
+class SSEComplete(Message):
+    """SSE stream finished. Carries the final result payload."""
+
+    def __init__(self, result: dict[str, Any]) -> None:
+        super().__init__()
+        self.result = result
+
+
+class SSEError(Message):
+    """An error occurred during SSE streaming."""
+
+    def __init__(self, error: str) -> None:
+        super().__init__()
+        self.error = error
+
+
+class ApprovalResult(Message):
+    """User responded to an approval request."""
+
+    def __init__(self, approved: bool, thread_id: str) -> None:
+        super().__init__()
+        self.approved = approved
+        self.thread_id = thread_id
+
+
+class QuerySubmitted(Message):
+    """User submitted a query from the input bar."""
+
+    def __init__(self, query: str) -> None:
+        super().__init__()
+        self.query = query

--- a/src/cli/tui/widgets/__init__.py
+++ b/src/cli/tui/widgets/__init__.py
@@ -1,0 +1,1 @@
+"""TUI widget re-exports for GovOn."""

--- a/src/cli/tui/widgets/approval_modal.py
+++ b/src/cli/tui/widgets/approval_modal.py
@@ -1,0 +1,135 @@
+"""Textual approval modal for human-in-the-loop tool execution approval.
+
+Reuses constants and normalization logic from the legacy approval_ui module.
+"""
+
+from __future__ import annotations
+
+from textual.binding import Binding
+from textual.reactive import reactive
+from textual.widget import Widget
+from textual.widgets import Static
+
+from src.cli.approval_ui import (
+    _get_task_type_label,
+    _get_task_type_style,
+    _normalize_approval_request,
+)
+from src.cli.tui.messages import ApprovalResult
+
+
+class ApprovalModal(Widget):
+    """Inline approval widget with keyboard navigation.
+
+    Displays the approval request details and lets the user choose
+    approve or reject using arrow keys / j/k and Enter.
+    """
+
+    DEFAULT_CSS = """
+    ApprovalModal {
+        width: 100%;
+        height: auto;
+        margin: 1 0;
+        padding: 1 2;
+        border: thick $warning;
+    }
+
+    ApprovalModal .choice {
+        height: 1;
+        padding: 0 1;
+    }
+
+    ApprovalModal .choice-selected {
+        text-style: bold;
+    }
+
+    ApprovalModal .hint {
+        color: $text-muted;
+        margin: 1 0 0 0;
+    }
+    """
+
+    BINDINGS = [
+        Binding("up", "select_prev", "위로", show=False),
+        Binding("down", "select_next", "아래로", show=False),
+        Binding("k", "select_prev", "위로", show=False),
+        Binding("j", "select_next", "아래로", show=False),
+        Binding("enter", "confirm", "확정", show=False),
+        Binding("q", "cancel", "취소", show=False),
+    ]
+
+    selected: reactive[int] = reactive(0)
+
+    def __init__(self, approval_request: dict, thread_id: str, **kwargs) -> None:  # noqa: ANN003
+        super().__init__(**kwargs)
+        self._request = _normalize_approval_request(approval_request)
+        self._thread_id = thread_id
+        self.can_focus = True
+
+    def compose(self):  # noqa: ANN201
+        """Build the approval UI content."""
+        task_type = self._request.get("task_type")
+        accent = _get_task_type_style(task_type)
+        label = _get_task_type_label(task_type)
+        goal = self._request.get("goal", "")
+        reason = self._request.get("reason", "")
+        tool_summaries = self._request.get("tool_summaries") or []
+
+        yield Static(f"[bold {accent}]\uc791\uc5c5 \uc2b9\uc778 \uc694\uccad[/bold {accent}]")
+        yield Static(f"[bold]\uc720\ud615:[/bold] [{accent}]{label}[/{accent}]")
+        if goal:
+            yield Static(f"[bold]\ubaa9\ud45c:[/bold] {goal}")
+        if reason:
+            yield Static(f"[dim]\uc774\uc720: {reason}[/dim]")
+        if tool_summaries:
+            for idx, summary in enumerate(tool_summaries, 1):
+                yield Static(f"  [{accent}]{idx}.[/{accent}] {summary}")
+
+        yield Static("")
+        yield Static(self._choice_text(0), id="choice-approve", classes="choice")
+        yield Static(self._choice_text(1), id="choice-reject", classes="choice")
+        yield Static(
+            "[dim]\u2191\u2193 \ubc29\ud5a5\ud0a4 / j k \uc120\ud0dd, Enter \ud655\uc815, q \ucde8\uc18c[/dim]",
+            classes="hint",
+        )
+
+    def on_mount(self) -> None:
+        """Focus this widget for keyboard input."""
+        self.focus()
+
+    def watch_selected(self, value: int) -> None:
+        """Update choice display when selection changes."""
+        try:
+            self.query_one("#choice-approve", Static).update(self._choice_text(0))
+            self.query_one("#choice-reject", Static).update(self._choice_text(1))
+        except Exception:
+            pass
+
+    def _choice_text(self, index: int) -> str:
+        """Render a choice line with selection indicator."""
+        if index == 0:
+            bullet = "\u25cf" if self.selected == 0 else "\u25cb"
+            style = "bold green" if self.selected == 0 else "dim"
+            return f"[{style}]{bullet} \uc2b9\uc778[/{style}]"
+        bullet = "\u25cf" if self.selected == 1 else "\u25cb"
+        style = "bold red" if self.selected == 1 else "dim"
+        return f"[{style}]{bullet} \uac70\uc808[/{style}]"
+
+    def action_select_prev(self) -> None:
+        """Move selection up."""
+        self.selected = max(0, self.selected - 1)
+
+    def action_select_next(self) -> None:
+        """Move selection down."""
+        self.selected = min(1, self.selected + 1)
+
+    def action_confirm(self) -> None:
+        """Confirm the current selection."""
+        approved = self.selected == 0
+        self.post_message(ApprovalResult(approved=approved, thread_id=self._thread_id))
+        self.remove()
+
+    def action_cancel(self) -> None:
+        """Cancel (reject) the approval request."""
+        self.post_message(ApprovalResult(approved=False, thread_id=self._thread_id))
+        self.remove()

--- a/src/cli/tui/widgets/input_bar.py
+++ b/src/cli/tui/widgets/input_bar.py
@@ -1,0 +1,54 @@
+"""Input bar widget with history support for the GovOn TUI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from textual.widgets import Input
+
+
+class InputBar(Input):
+    """Input field with ❯ prompt and persistent command history.
+
+    History is stored in ~/.govon/history (same as the legacy REPL).
+    """
+
+    DEFAULT_CSS = """
+    InputBar {
+        width: 100%;
+        dock: bottom;
+    }
+    """
+
+    HISTORY_PATH = Path.home() / ".govon" / "history"
+
+    def __init__(self, **kwargs) -> None:  # noqa: ANN003
+        super().__init__(placeholder="\u276f ", **kwargs)
+        self._history: list[str] = []
+        self._history_index: int = -1
+        self._load_history()
+
+    def _load_history(self) -> None:
+        """Load command history from file."""
+        try:
+            if self.HISTORY_PATH.exists():
+                self._history = self.HISTORY_PATH.read_text().strip().splitlines()[-500:]
+        except OSError:
+            pass
+
+    def _save_entry(self, text: str) -> None:
+        """Append a single entry to the history file."""
+        try:
+            self.HISTORY_PATH.parent.mkdir(parents=True, exist_ok=True)
+            with open(self.HISTORY_PATH, "a") as f:
+                f.write(f"{text}\n")
+            self._history.append(text)
+        except OSError:
+            pass
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Save submitted text to history."""
+        text = event.value.strip()
+        if text:
+            self._save_entry(text)
+            self._history_index = -1

--- a/src/cli/tui/widgets/markdown_view.py
+++ b/src/cli/tui/widgets/markdown_view.py
@@ -1,0 +1,34 @@
+"""Streaming markdown view widget for LLM response rendering."""
+
+from __future__ import annotations
+
+from textual.widgets import Markdown
+
+
+class MarkdownView(Markdown):
+    """Markdown widget that supports incremental content via append_delta().
+
+    Accumulates text deltas and re-renders the full markdown on each update.
+    Uses Textual's built-in Markdown widget which supports syntax highlighting.
+    """
+
+    DEFAULT_CSS = """
+    MarkdownView {
+        width: 100%;
+        margin: 0 0;
+    }
+    """
+
+    def __init__(self, **kwargs) -> None:  # noqa: ANN003
+        super().__init__("", **kwargs)
+        self._accumulated = ""
+
+    def append_delta(self, text: str) -> None:
+        """Append a text chunk and re-render the markdown."""
+        self._accumulated += text
+        self.update(self._accumulated)
+
+    def set_content(self, text: str) -> None:
+        """Replace the entire content at once."""
+        self._accumulated = text
+        self.update(text)

--- a/src/cli/tui/widgets/message_bubble.py
+++ b/src/cli/tui/widgets/message_bubble.py
@@ -1,0 +1,31 @@
+"""Message bubble container for user and assistant messages."""
+
+from __future__ import annotations
+
+from textual.containers import Vertical
+
+
+class MessageBubble(Vertical):
+    """Container for a single conversation turn (user or assistant).
+
+    Usage::
+
+        bubble = MessageBubble(role="user")
+        bubble.mount(Static("user query text"))
+
+        bubble = MessageBubble(role="assistant")
+        bubble.mount(SpinnerWidget())  # later replaced by MarkdownView
+    """
+
+    DEFAULT_CSS = """
+    MessageBubble {
+        width: 100%;
+        margin: 1 0 0 0;
+        padding: 0 0;
+    }
+    """
+
+    def __init__(self, role: str = "assistant", **kwargs) -> None:  # noqa: ANN003
+        super().__init__(**kwargs)
+        self.role = role
+        self.add_class(role)

--- a/src/cli/tui/widgets/metadata_bar.py
+++ b/src/cli/tui/widgets/metadata_bar.py
@@ -1,0 +1,27 @@
+"""Metadata bar showing execution statistics."""
+
+from __future__ import annotations
+
+from textual.widgets import Static
+
+
+class MetadataBar(Static):
+    """Single-line display of execution metadata (iterations, tools, latency)."""
+
+    DEFAULT_CSS = """
+    MetadataBar {
+        width: 100%;
+        height: 1;
+        color: $text-muted;
+        margin: 0 0;
+    }
+    """
+
+    def set_metadata(self, metadata: dict) -> None:
+        """Update the metadata display from a result metadata dict."""
+        iterations = metadata.get("total_iterations", 0)
+        tool_calls = metadata.get("total_tool_calls", 0)
+        latency = metadata.get("total_latency_ms", 0)
+        self.update(
+            f"\u23af iterations={iterations}  " f"tools={tool_calls}  " f"latency={latency:.0f}ms"
+        )

--- a/src/cli/tui/widgets/spinner.py
+++ b/src/cli/tui/widgets/spinner.py
@@ -1,0 +1,63 @@
+"""Textual spinner widget with Korean proverbs and elapsed time.
+
+Uses Textual's built-in timer system instead of a background thread.
+Reuses spinner characters and verbs from src.cli.spinner.
+"""
+
+from __future__ import annotations
+
+import random
+import time
+
+from textual.reactive import reactive
+from textual.widget import Widget
+
+from src.cli.spinner import SPINNER_CHARS, STATUS_VERBS, _format_elapsed, _format_tokens
+
+
+class SpinnerWidget(Widget):
+    """Animated spinner showing a Korean proverb, elapsed time, and token count."""
+
+    DEFAULT_CSS = """
+    SpinnerWidget {
+        height: 1;
+        width: 100%;
+    }
+    """
+
+    tokens: reactive[int] = reactive(0)
+
+    def __init__(self, **kwargs) -> None:  # noqa: ANN003
+        super().__init__(**kwargs)
+        self._verb = random.choice(STATUS_VERBS)  # noqa: S311
+        self._start_time = time.monotonic()
+        self._frame = 0
+        self._timer = None
+
+    def on_mount(self) -> None:
+        """Start the animation timer at ~30fps."""
+        self._timer = self.set_interval(1 / 30, self._tick)
+
+    def _tick(self) -> None:
+        """Advance one animation frame."""
+        self._frame += 1
+        # Change verb every ~90 frames (~3 seconds)
+        if self._frame % 90 == 0:
+            self._verb = random.choice(STATUS_VERBS)  # noqa: S311
+        self.refresh()
+
+    def render(self) -> str:
+        """Render the current spinner frame."""
+        char = SPINNER_CHARS[self._frame % len(SPINNER_CHARS)]
+        elapsed = _format_elapsed(time.monotonic() - self._start_time)
+        parts = f"{char} {self._verb}\u2026 ({elapsed}"
+        if self.tokens > 0:
+            parts += f" \u00b7 \u2193 {_format_tokens(self.tokens)} tokens"
+        parts += ")"
+        return parts
+
+    def stop(self) -> None:
+        """Stop the animation timer."""
+        if self._timer is not None:
+            self._timer.stop()
+            self._timer = None

--- a/src/cli/tui/widgets/thinking_block.py
+++ b/src/cli/tui/widgets/thinking_block.py
@@ -1,0 +1,30 @@
+"""Dim thinking text block for LLM reasoning display."""
+
+from __future__ import annotations
+
+from textual.widgets import Static
+
+
+class ThinkingBlock(Static):
+    """Displays LLM thinking/reasoning text in dim italic style.
+
+    Supports incremental updates as thinking tokens stream in.
+    """
+
+    DEFAULT_CSS = """
+    ThinkingBlock {
+        width: 100%;
+        color: $text-muted;
+        text-style: italic;
+        margin: 0 2;
+    }
+    """
+
+    def __init__(self, **kwargs) -> None:  # noqa: ANN003
+        super().__init__("", **kwargs)
+        self._accumulated = ""
+
+    def append(self, text: str) -> None:
+        """Append thinking text and re-render."""
+        self._accumulated += text
+        self.update(self._accumulated)

--- a/src/cli/tui/widgets/tool_panel.py
+++ b/src/cli/tui/widgets/tool_panel.py
@@ -1,0 +1,37 @@
+"""Collapsible tool call panel for displaying tool execution status."""
+
+from __future__ import annotations
+
+from textual.widgets import Static
+
+
+class ToolCallPanel(Static):
+    """Displays a tool call with bordered header and optional result.
+
+    Shows tool name, execution status, and timing information.
+    Collapsed by default — shows only the header line.
+    """
+
+    DEFAULT_CSS = """
+    ToolCallPanel {
+        width: 100%;
+        height: auto;
+        margin: 0 2;
+    }
+    """
+
+    def __init__(self, tool_name: str, **kwargs) -> None:  # noqa: ANN003
+        super().__init__(**kwargs)
+        self.tool_name = tool_name
+        self._completed = False
+        self._latency_ms: float = 0
+        self.update(f"[cyan]\u250c\u2500 \u2699 {tool_name} \uc2e4\ud589 \uc911\u2026[/cyan]")
+
+    def complete(self, latency_ms: float = 0) -> None:
+        """Mark the tool call as completed with timing info."""
+        self._completed = True
+        self._latency_ms = latency_ms
+        latency_str = f" ({latency_ms:.0f}ms)" if latency_ms else ""
+        self.update(
+            f"[green]\u2514\u2500 \u2726 {self.tool_name} " f"\uc644\ub8cc{latency_str}[/green]"
+        )


### PR DESCRIPTION
## Summary
- Textual 기반 풀 TUI 구현 (Phase 0~2)
- Claude Code 스타일: 스크롤 히스토리, 스트리밍 마크다운, 접이식 도구 패널, ❯ 프롬프트
- SSE → Textual Message 브릿지 (thread worker + call_from_thread)
- 스피너 → 첫 토큰 도착 시 사라지고 마크다운 스트리밍 시작
- `GOVON_PLAIN=1` 또는 textual 미설치 시 레거시 REPL 자동 폴백

## Widgets
- `SpinnerWidget` — 한국어 사자성어/속담 30fps 애니메이션
- `MessageBubble` — user/assistant 메시지 컨테이너
- `InputBar` — ❯ 프롬프트 + 히스토리
- `MarkdownView` — 스트리밍 마크다운 (.append_delta())
- `ThinkingBlock` — dim 추론 텍스트
- `ToolCallPanel` — 접이식 도구 호출 상태
- `MetadataBar` — 실행 통계

## Test plan
- [ ] `pip install -e ".[tui]"` → Textual TUI 실행
- [ ] `GOVON_PLAIN=1 govon` → 레거시 REPL
- [ ] 기존 pytest 전체 통과