### PR TITLE
fix(npm-tui): harden useHistory — async writes, navigate bug, useReducer, symlink guard

### DIFF
--- a/packages/npm/esbuild.config.mjs
+++ b/packages/npm/esbuild.config.mjs
@@ -1,0 +1,25 @@
+import { build } from 'esbuild';
+
+const shared = {
+  entryPoints: ['src/index.tsx'],
+  platform: 'node',
+  target: 'node20',
+  jsx: 'automatic',
+  logLevel: 'info',
+};
+
+// ESM build for `npm install -g govon` / `npx govon`
+// Dependencies are external — resolved via node_modules at runtime
+await build({
+  ...shared,
+  outfile: 'dist/index.js',
+  format: 'esm',
+  bundle: true,
+  packages: 'external',
+});
+
+// NOTE: CJS/SEA bundle (dist/govon.cjs) will be added in Phase 5
+// when the Node SEA build pipeline is implemented. Ink uses top-level
+// await which is incompatible with CJS format — SEA will use ESM blob.
+
+console.log('Build complete: dist/index.js (ESM)');

--- a/packages/npm/src/App.tsx
+++ b/packages/npm/src/App.tsx
@@ -1,0 +1,411 @@
+/**
+ * App.tsx — main application component.
+ *
+ * Port of src/cli/tui/app.py GovOnApp class.
+ * Composes all UI widgets into a full-screen Ink layout and wires state
+ * management, server polling, SSE streaming, and input history together.
+ *
+ * Layout (top → bottom):
+ *   1. Banner           (welcome screen, rendered once into scrollback)
+ *   2. Message history  (Ink <Static> — completed messages go to scrollback)
+ *   3. Streaming area   (current thinking + tools + streaming content)
+ *   4. Approval prompt  (shown when pendingApproval is set)
+ *   5. Separator line
+ *   6. InputBar
+ *   7. Status footer
+ */
+
+import React, { useReducer, useCallback, useMemo } from 'react';
+import { Box, Text, Static, useApp, useInput } from 'ink';
+import { GovOnClient } from './client.js';
+import { getBaseUrl, THEME_COLORS } from './config.js';
+import type { AppState, Action, Message } from './types.js';
+import { useDaemon } from './hooks/useDaemon.js';
+import { useSSE } from './hooks/useSSE.js';
+import { useHistory } from './hooks/useHistory.js';
+import { Banner } from './components/Banner.js';
+import { InputBar } from './components/InputBar.js';
+import { Spinner } from './components/Spinner.js';
+import { ThinkingBlock } from './components/ThinkingBlock.js';
+import { MarkdownView } from './components/MarkdownView.js';
+import { MessageBubble } from './components/MessageBubble.js';
+import { ToolPanel } from './components/ToolPanel.js';
+import { ApprovalPrompt } from './components/ApprovalPrompt.js';
+import { MetadataBar } from './components/MetadataBar.js';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface AppProps {
+  version: string;
+  initialQuery?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
+
+const initialState: AppState = {
+  messages: [],
+  isLoading: false,
+  streamingContent: '',
+  streamingThinking: '',
+  pendingThinking: [],
+  activeTools: [],
+  sessionId: null,
+  threadId: null,
+  pendingApproval: null,
+  statusLabel: null,
+  error: null,
+  theme: 'dark',
+  apiBase: getBaseUrl(),
+  apiVersion: 'v3',
+};
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+function reducer(state: AppState, action: Action): AppState {
+  switch (action.type) {
+    case 'SET_LOADING':
+      return { ...state, isLoading: action.payload };
+
+    case 'ADD_USER_MESSAGE': {
+      const msg: Message = {
+        ...action.payload,
+        role: 'user',
+        content: action.payload.content,
+      };
+      return { ...state, messages: [...state.messages, msg] };
+    }
+
+    case 'START_ASSISTANT_MESSAGE': {
+      const msg: Message = {
+        id: action.payload.id,
+        role: 'assistant',
+        content: '',
+        timestamp: action.payload.timestamp,
+        streaming: true,
+      };
+      return {
+        ...state,
+        messages: [...state.messages, msg],
+        streamingContent: '',
+        streamingThinking: '',
+        pendingThinking: [],
+        activeTools: [],
+      };
+    }
+
+    case 'APPEND_STREAMING_CONTENT':
+      return {
+        ...state,
+        streamingContent: state.streamingContent + action.payload,
+      };
+
+    case 'APPEND_STREAMING_THINKING':
+      return {
+        ...state,
+        streamingThinking: state.streamingThinking + action.payload,
+      };
+
+    case 'START_THINKING_STEP': {
+      const { iteration } = action.payload;
+      // Only add if we don't already have an entry for this iteration
+      const already = state.pendingThinking.some((s) => s.iteration === iteration);
+      if (already) return state;
+      return {
+        ...state,
+        pendingThinking: [
+          ...state.pendingThinking,
+          { iteration, content: state.streamingThinking },
+        ],
+        streamingThinking: '',
+      };
+    }
+
+    case 'END_THINKING_STEP': {
+      const { iteration, tool_calls } = action.payload;
+      const updated = state.pendingThinking.map((step) =>
+        step.iteration === iteration
+          ? { ...step, content: step.content + state.streamingThinking, tool_calls }
+          : step,
+      );
+      return {
+        ...state,
+        pendingThinking: updated,
+        streamingThinking: '',
+      };
+    }
+
+    case 'MARK_TOOL_START':
+      return {
+        ...state,
+        activeTools: [
+          ...state.activeTools,
+          { tool: action.payload.tool, pending: true },
+        ],
+      };
+
+    case 'MARK_TOOL_END': {
+      const { tool, success } = action.payload;
+      const updated = state.activeTools.map((t) =>
+        t.tool === tool && t.pending ? { ...t, pending: false, success } : t,
+      );
+      return { ...state, activeTools: updated };
+    }
+
+    case 'FINALIZE_ASSISTANT_MESSAGE': {
+      const {
+        messageId,
+        content,
+        evidence,
+        metadata,
+        sessionId,
+        threadId,
+      } = action.payload;
+
+      const messages = state.messages.map((msg) =>
+        msg.id === messageId
+          ? {
+              ...msg,
+              content,
+              streaming: false,
+              thinking: state.pendingThinking,
+              tools: state.activeTools,
+              evidence,
+              metadata,
+            }
+          : msg,
+      );
+
+      return {
+        ...state,
+        messages,
+        streamingContent: '',
+        streamingThinking: '',
+        pendingThinking: [],
+        activeTools: [],
+        sessionId,
+        threadId,
+        isLoading: false,
+        statusLabel: null,
+        error: null,
+      };
+    }
+
+    case 'SET_PENDING_APPROVAL':
+      return { ...state, pendingApproval: action.payload };
+
+    case 'SET_STATUS_LABEL':
+      return { ...state, statusLabel: action.payload };
+
+    case 'SET_ERROR':
+      return { ...state, error: action.payload, isLoading: false };
+
+    case 'SET_THEME':
+      return { ...state, theme: action.payload };
+
+    case 'SET_API_BASE':
+      return { ...state, apiBase: action.payload };
+
+    case 'SET_API_VERSION':
+      return { ...state, apiVersion: action.payload };
+
+    case 'RESET_SESSION':
+      return { ...initialState, apiBase: state.apiBase, theme: state.theme };
+
+    default:
+      return state;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// App component
+// ---------------------------------------------------------------------------
+
+export function App({ version, initialQuery }: AppProps) {
+  const { exit } = useApp();
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  // GovOnClient is stable for the lifetime of the app
+  const client = useMemo(() => new GovOnClient(state.apiBase), [state.apiBase]);
+
+  // Wait for server readiness
+  const daemon = useDaemon(client);
+
+  // SSE streaming
+  const { submit, cancel } = useSSE({
+    client,
+    dispatch,
+    sessionId: state.sessionId,
+  });
+
+  // Input history (up/down arrow navigation)
+  const { push: pushHistory } = useHistory();
+
+  // Handle query submission from InputBar
+  const handleSubmit = useCallback(
+    (query: string) => {
+      // Guard: do not allow submission while a request is in flight
+      if (state.isLoading) return;
+
+      const userMsgId = crypto.randomUUID();
+      const timestamp = new Date().toISOString();
+
+      dispatch({
+        type: 'ADD_USER_MESSAGE',
+        payload: { id: userMsgId, content: query, timestamp },
+      });
+
+      pushHistory(query);
+      submit(query);
+    },
+    [state.isLoading, dispatch, pushHistory, submit],
+  );
+
+  // Approval handling
+  const handleApproval = useCallback(
+    async (approved: boolean) => {
+      if (!state.threadId || !state.pendingApproval) return;
+      dispatch({ type: 'SET_PENDING_APPROVAL', payload: null });
+      try {
+        await client.approve(state.threadId, approved);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        dispatch({ type: 'SET_ERROR', payload: msg });
+      }
+    },
+    [client, state.threadId, state.pendingApproval, dispatch],
+  );
+
+  // Submit initial query on first render once daemon is ready
+  const initialSubmittedRef = React.useRef(false);
+  React.useEffect(() => {
+    if (daemon.ready && initialQuery && !initialSubmittedRef.current) {
+      initialSubmittedRef.current = true;
+      handleSubmit(initialQuery);
+    }
+  }, [daemon.ready, initialQuery, handleSubmit]);
+
+  // Keyboard shortcut: Ctrl+D / Ctrl+C exits
+  useInput((input: string, key: { ctrl: boolean }) => {
+    if (key.ctrl && input === 'd') exit();
+    if (key.ctrl && input === 'c') exit();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  // Server not yet ready
+  if (daemon.waiting) {
+    return (
+      <Box flexDirection="column">
+        <Banner version={version} />
+        <Box marginTop={1}>
+          <Text color={THEME_COLORS.muted}>{'서버 연결 중…'}</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (daemon.error) {
+    return (
+      <Box flexDirection="column">
+        <Banner version={version} />
+        <Box marginTop={1}>
+          <Text color={THEME_COLORS.error}>{'서버 오류: '}{daemon.error}</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  // Completed messages (go to terminal scrollback via <Static>)
+  // Banner is the first "static" element, followed by the message history.
+  const completedMessages = state.messages.filter((m) => !m.streaming);
+
+  return (
+    <Box flexDirection="column">
+      {/* ── 1. Banner + completed messages in scrollback ── */}
+      <Static items={[{ _banner: true }, ...completedMessages]}>
+        {(item: { _banner?: boolean } | Message) => {
+          if ('_banner' in item && item._banner) {
+            return <Banner key="__banner__" version={version} />;
+          }
+          const msg = item as Message;
+          return <MessageBubble key={msg.id} message={msg} />;
+        }}
+      </Static>
+
+      {/* ── 2. Streaming area (live, below scrollback) ── */}
+      {state.isLoading && (
+        <Box flexDirection="column" marginTop={1}>
+          {/* Thinking in progress */}
+          {state.streamingThinking.length > 0 && (
+            <ThinkingBlock content={state.streamingThinking} streaming />
+          )}
+
+          {/* Active tool invocations */}
+          {state.activeTools.length > 0 && (
+            <ToolPanel tools={state.activeTools} />
+          )}
+
+          {/* Streaming response text */}
+          {state.streamingContent.length > 0 ? (
+            <Box marginLeft={2}>
+              <MarkdownView content={state.streamingContent} streaming />
+            </Box>
+          ) : (
+            <Box marginLeft={2}>
+              <Spinner />
+            </Box>
+          )}
+
+          {/* Status label from v2 node events */}
+          {state.statusLabel && (
+            <Box marginLeft={2}>
+              <Text color={THEME_COLORS.muted} dimColor>
+                {state.statusLabel}
+              </Text>
+            </Box>
+          )}
+        </Box>
+      )}
+
+      {/* ── 3. Error display ── */}
+      {state.error && !state.isLoading && (
+        <Box marginTop={1} marginLeft={2}>
+          <Text color={THEME_COLORS.error}>{'오류: '}{state.error}</Text>
+        </Box>
+      )}
+
+      {/* ── 4. Approval prompt ── */}
+      {state.pendingApproval && (
+        <ApprovalPrompt
+          request={state.pendingApproval}
+          onApprove={handleApproval}
+        />
+      )}
+
+      {/* ── 5. Separator ── */}
+      <Box marginTop={1}>
+        <Text color={THEME_COLORS.muted} dimColor>
+          {'─'.repeat(process.stdout.columns > 0 ? process.stdout.columns - 1 : 79)}
+        </Text>
+      </Box>
+
+      {/* ── 6. Input bar ── */}
+      <InputBar onSubmit={handleSubmit} disabled={state.isLoading} />
+
+      {/* ── 7. Status footer ── */}
+      <Box marginTop={1}>
+        <Text dimColor color={THEME_COLORS.dimmed}>
+          {'esc 취소 · Ctrl+D 종료 · /help 도움말'}
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/npm/src/components/ApprovalPrompt.tsx
+++ b/packages/npm/src/components/ApprovalPrompt.tsx
@@ -1,0 +1,83 @@
+/**
+ * ApprovalPrompt — renders a human-approval gate dialog.
+ *
+ * Shown when the backend emits an `awaiting_approval` event.
+ * The user presses 'y' to approve or 'n' to reject.
+ * Calls onApprove(true) or onApprove(false) accordingly.
+ */
+
+import React, { useCallback } from 'react';
+import { Box, Text, useInput } from 'ink';
+import type { ApprovalRequest } from '../types.js';
+import { TASK_TYPE_LABELS, TASK_TYPE_STYLES } from '../types.js';
+import { THEME_COLORS } from '../config.js';
+
+interface ApprovalPromptProps {
+  request: ApprovalRequest;
+  onApprove: (approved: boolean) => void;
+}
+
+export function ApprovalPrompt({ request, onApprove }: ApprovalPromptProps) {
+  useInput(
+    useCallback(
+      (input: string) => {
+        const key = input.toLowerCase();
+        if (key === 'y') {
+          onApprove(true);
+        } else if (key === 'n') {
+          onApprove(false);
+        }
+      },
+      [onApprove],
+    ),
+  );
+
+  const taskLabel =
+    TASK_TYPE_LABELS[request.task_type] ?? TASK_TYPE_LABELS['default'];
+  const taskColor =
+    TASK_TYPE_STYLES[request.task_type] ?? TASK_TYPE_STYLES['default'];
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={THEME_COLORS.warning}
+      paddingX={2}
+      paddingY={1}
+      marginTop={1}
+    >
+      {/* Header */}
+      <Box flexDirection="row">
+        <Text bold color={THEME_COLORS.warning}>{'⚠ 승인 요청  '}</Text>
+        <Text color={taskColor}>[{taskLabel}]</Text>
+      </Box>
+
+      {/* Description */}
+      {request.description && (
+        <Box marginTop={1}>
+          <Text wrap="wrap">{request.description}</Text>
+        </Box>
+      )}
+
+      {/* Planned tools list */}
+      {request.planned_tools && request.planned_tools.length > 0 && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME_COLORS.muted}>{'실행 예정 도구:'}</Text>
+          {request.planned_tools.map((tool, i) => (
+            <Text key={i} color={THEME_COLORS.muted}>{`  • ${tool}`}</Text>
+          ))}
+        </Box>
+      )}
+
+      {/* Prompt */}
+      <Box marginTop={1}>
+        <Text bold>
+          {'승인하시겠습니까? '}
+          <Text color="green">{'y'}</Text>
+          {' / '}
+          <Text color="red">{'n'}</Text>
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/npm/src/components/Banner.tsx
+++ b/packages/npm/src/components/Banner.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import { THEME_COLORS, getBaseUrl } from '../config.js';
+
+// ASCII art for the 'G' logo, one line per row
+const LOGO_ART = [
+  '  ██████╗ ',
+  ' ██╔════╝ ',
+  ' ██║ ████╗',
+  ' ██║ ╚═██║',
+  ' ╚██████╔╝',
+  '  ╚═════╝ ',
+];
+
+interface BannerProps {
+  version: string;
+}
+
+export function Banner({ version }: BannerProps) {
+  const baseUrl = getBaseUrl();
+
+  // Derive a short label describing the current backend target
+  let modeLabel: string;
+  try {
+    const url = new URL(baseUrl);
+    const isLocal =
+      url.hostname === '127.0.0.1' || url.hostname === 'localhost';
+    modeLabel = isLocal ? '로컬 모드' : `원격: ${url.hostname}`;
+  } catch {
+    modeLabel = '로컬 모드';
+  }
+
+  return (
+    <Box
+      borderStyle="round"
+      borderColor={THEME_COLORS.primary}
+      paddingX={2}
+      paddingY={1}
+      flexDirection="row"
+    >
+      {/* Left column: logo art + version info */}
+      <Box flexDirection="column" marginRight={3}>
+        {LOGO_ART.map((line, i) => (
+          <Text key={i} color={THEME_COLORS.accent}>
+            {line}
+          </Text>
+        ))}
+        <Text> </Text>
+        <Text bold color={THEME_COLORS.accent}>
+          GovOn v{version}
+        </Text>
+        <Text color={THEME_COLORS.muted}>{modeLabel}</Text>
+      </Box>
+
+      {/* Vertical divider */}
+      <Box
+        borderStyle="single"
+        borderLeft
+        borderRight={false}
+        borderTop={false}
+        borderBottom={false}
+        borderColor={THEME_COLORS.primary}
+        marginRight={3}
+      />
+
+      {/* Right column: onboarding tips */}
+      <Box flexDirection="column">
+        <Text bold color={THEME_COLORS.accent}>
+          시작 가이드
+        </Text>
+        <Text color={THEME_COLORS.muted}>
+          질문을 입력하면 AI 에이전트가 분석하고 도구를 사용합니다
+        </Text>
+        <Text color={THEME_COLORS.muted}>/help 로 명령어 목록 확인</Text>
+        <Text color={THEME_COLORS.muted}>/exit 또는 Ctrl+D 로 종료</Text>
+        <Text> </Text>
+        <Text color={THEME_COLORS.muted}>
+          승인 필요 도구는 실행 전 확인을 요청합니다
+        </Text>
+        <Text color={THEME_COLORS.muted}>Esc 로 진행 중인 작업 취소</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/npm/src/components/InputBar.tsx
+++ b/packages/npm/src/components/InputBar.tsx
@@ -1,0 +1,39 @@
+import React, { useState, useCallback } from 'react';
+import { Box, Text } from 'ink';
+import TextInput from 'ink-text-input';
+
+interface InputBarProps {
+  onSubmit: (query: string) => void;
+  /** When true, the input field is read-only and shows a busy placeholder. */
+  disabled?: boolean;
+}
+
+export function InputBar({ onSubmit, disabled = false }: InputBarProps) {
+  const [value, setValue] = useState('');
+
+  const handleSubmit = useCallback(
+    (val: string) => {
+      const trimmed = val.trim();
+      // Ignore empty submissions and block input while a request is in flight
+      if (!trimmed || disabled) return;
+      onSubmit(trimmed);
+      setValue('');
+    },
+    [onSubmit, disabled],
+  );
+
+  return (
+    <Box>
+      {/* Prompt character mirrors the Python TUI green arrow */}
+      <Text bold color={disabled ? 'gray' : 'green'}>
+        {'❯ '}
+      </Text>
+      <TextInput
+        value={value}
+        onChange={setValue}
+        onSubmit={handleSubmit}
+        placeholder={disabled ? '처리 중…' : '질문을 입력하세요'}
+      />
+    </Box>
+  );
+}

--- a/packages/npm/src/components/MarkdownView.tsx
+++ b/packages/npm/src/components/MarkdownView.tsx
@@ -1,0 +1,46 @@
+import React, { useMemo } from 'react';
+import { Box, Text } from 'ink';
+import { marked } from 'marked';
+import { markedTerminal } from 'marked-terminal';
+
+// Configure marked with the terminal renderer once at module load time.
+// markedTerminal() returns a marked extension object compatible with the
+// marked.use() API introduced in marked v5+ and still current in v15.
+marked.use(
+  markedTerminal({
+    reflowText: true,
+    width: process.stdout.columns || 80,
+    showSectionPrefix: false,
+  }),
+);
+
+interface MarkdownViewProps {
+  /** Raw markdown text to render. */
+  content: string;
+  /** Whether more content is still streaming. */
+  streaming?: boolean;
+}
+
+export function MarkdownView({ content, streaming = false }: MarkdownViewProps) {
+  const rendered = useMemo(() => {
+    if (!content) return '';
+    try {
+      // marked.parse() is synchronous when the terminal renderer extension is active.
+      const result = marked.parse(content);
+      // Remove trailing newlines produced by marked's block-level output.
+      return typeof result === 'string' ? result.trimEnd() : '';
+    } catch {
+      // Fall back to raw text so the UI never goes blank on a parse error.
+      return content;
+    }
+  }, [content]);
+
+  if (!rendered) return null;
+
+  return (
+    <Box flexDirection="column">
+      <Text wrap="wrap">{rendered}</Text>
+      {streaming && <Text dimColor>{'▍'}</Text>}
+    </Box>
+  );
+}

--- a/packages/npm/src/components/MessageBubble.tsx
+++ b/packages/npm/src/components/MessageBubble.tsx
@@ -1,0 +1,73 @@
+/**
+ * MessageBubble — renders a single completed chat message (user or assistant).
+ *
+ * For user messages: plain text with a ❯ prefix.
+ * For assistant messages: markdown-rendered content, optional thinking steps,
+ * optional tool invocations, optional evidence/metadata footers.
+ */
+
+import React from 'react';
+import { Box, Text } from 'ink';
+import type { Message } from '../types.js';
+import { THEME_COLORS } from '../config.js';
+import { MarkdownView } from './MarkdownView.js';
+import { ThinkingBlock } from './ThinkingBlock.js';
+import { ToolPanel } from './ToolPanel.js';
+import { MetadataBar } from './MetadataBar.js';
+
+interface MessageBubbleProps {
+  message: Message;
+}
+
+export function MessageBubble({ message }: MessageBubbleProps) {
+  if (message.role === 'user') {
+    return (
+      <Box flexDirection="row" marginTop={1}>
+        <Text bold color="green">{'❯ '}</Text>
+        <Text wrap="wrap">{message.content}</Text>
+      </Box>
+    );
+  }
+
+  // Assistant message
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      {/* Role label */}
+      <Text bold color={THEME_COLORS.primary}>{'GovOn'}</Text>
+
+      {/* Thinking steps (collapsed after completion) */}
+      {message.thinking && message.thinking.length > 0 && (
+        <Box flexDirection="column">
+          {message.thinking.map((step, i) => (
+            <ThinkingBlock
+              key={i}
+              content={step.content}
+              streaming={false}
+            />
+          ))}
+        </Box>
+      )}
+
+      {/* Tool invocations */}
+      {message.tools && message.tools.length > 0 && (
+        <ToolPanel tools={message.tools} />
+      )}
+
+      {/* Main answer content */}
+      {message.error ? (
+        <Box marginLeft={2}>
+          <Text color={THEME_COLORS.error}>{'오류: '}{message.error}</Text>
+        </Box>
+      ) : (
+        <Box marginLeft={2}>
+          <MarkdownView content={message.content} streaming={false} />
+        </Box>
+      )}
+
+      {/* Run metadata footer (evidence display is handled elsewhere) */}
+      {message.metadata && (
+        <MetadataBar metadata={message.metadata} />
+      )}
+    </Box>
+  );
+}

--- a/packages/npm/src/components/MetadataBar.tsx
+++ b/packages/npm/src/components/MetadataBar.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import { THEME_COLORS } from '../config.js';
+import type { RunMetadata } from '../types.js';
+
+interface MetadataBarProps {
+  metadata: RunMetadata;
+}
+
+export function MetadataBar({ metadata }: MetadataBarProps) {
+  const parts: string[] = [];
+  if (metadata.total_iterations !== undefined) {
+    parts.push(`${metadata.total_iterations} iterations`);
+  }
+  if (metadata.total_tool_calls !== undefined) {
+    parts.push(`${metadata.total_tool_calls} tools`);
+  }
+  if (metadata.total_latency_ms !== undefined) {
+    parts.push(`${Math.round(metadata.total_latency_ms).toLocaleString()}ms`);
+  }
+
+  if (parts.length === 0) return null;
+
+  return (
+    <Box marginLeft={2} marginTop={1}>
+      <Text color={THEME_COLORS.muted} dimColor>
+        ─ {parts.join(' · ')}
+      </Text>
+    </Box>
+  );
+}

--- a/packages/npm/src/components/Spinner.tsx
+++ b/packages/npm/src/components/Spinner.tsx
@@ -1,0 +1,65 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Text } from 'ink';
+import { SPINNER } from '../config.js';
+import { SPINNER_VERBS } from '../data/spinnerVerbs.js';
+
+interface SpinnerProps {
+  /** Token count to display alongside elapsed time. */
+  tokens?: number;
+}
+
+/** Format elapsed seconds into a human-readable duration string. */
+function formatElapsed(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}m ${String(s).padStart(2, '0')}s`;
+}
+
+/** Abbreviate large token counts with a 'k' suffix. */
+function formatTokens(count: number): string {
+  if (count >= 1000) return `${(count / 1000).toFixed(1)}k`;
+  return String(count);
+}
+
+/** Pick a random Korean proverb from the verb list. */
+function randomVerb(): string {
+  return SPINNER_VERBS[Math.floor(Math.random() * SPINNER_VERBS.length)];
+}
+
+export function Spinner({ tokens = 0 }: SpinnerProps) {
+  const [frame, setFrame] = useState(0);
+  const [verb, setVerb] = useState(randomVerb);
+  // Record the mount time so elapsed seconds are accurate even after re-renders
+  const startTime = useRef(Date.now());
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setFrame((f) => {
+        const next = f + 1;
+        // Rotate the displayed proverb every verbChangeInterval frames
+        if (next > 0 && next % SPINNER.verbChangeInterval === 0) {
+          setVerb(randomVerb());
+        }
+        return next;
+      });
+    }, 1000 / SPINNER.fps);
+    return () => clearInterval(interval);
+  }, []);
+
+  const char = SPINNER.chars[frame % SPINNER.chars.length];
+  const elapsed = Math.floor((Date.now() - startTime.current) / 1000);
+  const elapsedStr = formatElapsed(elapsed);
+
+  // Append token count only when the backend has reported usage
+  const suffix =
+    tokens > 0
+      ? ` (${elapsedStr} · ↓ ${formatTokens(tokens)} tokens)`
+      : ` (${elapsedStr})`;
+
+  return (
+    <Text dimColor>
+      {char} {verb}…{suffix}
+    </Text>
+  );
+}

--- a/packages/npm/src/components/ThinkingBlock.tsx
+++ b/packages/npm/src/components/ThinkingBlock.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import { THEME_COLORS } from '../config.js';
+
+interface ThinkingBlockProps {
+  /** Accumulated thinking text (may be streaming). */
+  content: string;
+  /** Whether thinking is still in progress. */
+  streaming?: boolean;
+}
+
+export function ThinkingBlock({ content, streaming = false }: ThinkingBlockProps) {
+  if (!content) return null;
+
+  return (
+    <Box flexDirection="column" marginLeft={2}>
+      <Text color={THEME_COLORS.muted} dimColor>
+        {'💭 '}{streaming ? '사고 중…' : '사고 완료'}
+      </Text>
+      <Box marginLeft={2}>
+        <Text color={THEME_COLORS.dimmed} dimColor wrap="wrap">
+          {content}
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/npm/src/components/ToolPanel.tsx
+++ b/packages/npm/src/components/ToolPanel.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import { THEME_COLORS } from '../config.js';
+import { TOOL_DISPLAY_NAMES } from '../types.js';
+import type { ToolInvocation } from '../types.js';
+
+interface ToolPanelProps {
+  tools: ToolInvocation[];
+}
+
+export function ToolPanel({ tools }: ToolPanelProps) {
+  if (tools.length === 0) return null;
+
+  return (
+    <Box flexDirection="column" marginLeft={2}>
+      {tools.map((tool, i) => {
+        const displayName = TOOL_DISPLAY_NAMES[tool.tool] ?? tool.tool;
+        if (tool.pending) {
+          return (
+            <Text key={i} color={THEME_COLORS.warning}>
+              ┌─ ⚙ {tool.tool} ({displayName}) 실행 중…
+            </Text>
+          );
+        }
+        const statusColor = tool.success !== false ? THEME_COLORS.success : THEME_COLORS.error;
+        const statusIcon = tool.success !== false ? '✦' : '✘';
+        const statusText = tool.success !== false ? '완료' : '실패';
+        return (
+          <Text key={i} color={statusColor}>
+            └─ {statusIcon} {tool.tool} ({displayName}) {statusText}
+          </Text>
+        );
+      })}
+    </Box>
+  );
+}

--- a/packages/npm/src/hooks/useDaemon.ts
+++ b/packages/npm/src/hooks/useDaemon.ts
@@ -1,0 +1,62 @@
+import { useState, useEffect, useRef } from 'react';
+import type { GovOnClient } from '../client.js';
+
+interface DaemonState {
+  /** Server is confirmed ready. */
+  ready: boolean;
+  /** Currently waiting for server. */
+  waiting: boolean;
+  /** Error message if server could not be reached. */
+  error: string | null;
+}
+
+/**
+ * Check server health on mount. If the server is sleeping (e.g. HF Space),
+ * call client.waitForReady() which polls with status messages to stderr.
+ */
+export function useDaemon(client: GovOnClient): DaemonState {
+  const [state, setState] = useState<DaemonState>({
+    ready: false,
+    waiting: true,
+    error: null,
+  });
+  const abortRef = useRef(false);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function check() {
+      try {
+        // Quick health check first
+        await client.health();
+        if (mounted) setState({ ready: true, waiting: false, error: null });
+      } catch {
+        // Server not immediately available — try cold start wait
+        if (mounted) setState((s) => ({ ...s, waiting: true }));
+        try {
+          const ok = await client.waitForReady();
+          if (mounted) {
+            setState({
+              ready: ok,
+              waiting: false,
+              error: ok ? null : '서버 연결 시간 초과',
+            });
+          }
+        } catch (err) {
+          if (mounted) {
+            setState({
+              ready: false,
+              waiting: false,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+      }
+    }
+
+    check();
+    return () => { mounted = false; };
+  }, [client]);
+
+  return state;
+}

--- a/packages/npm/src/hooks/useHistory.ts
+++ b/packages/npm/src/hooks/useHistory.ts
@@ -1,0 +1,69 @@
+import { useState, useCallback, useEffect } from 'react';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const HISTORY_DIR = join(homedir(), '.govon');
+const HISTORY_FILE = join(HISTORY_DIR, 'history');
+const MAX_ENTRIES = 500;
+
+/**
+ * Load and persist CLI input history from ~/.govon/history.
+ * Returns the history array, a push function, and a navigate function.
+ */
+export function useHistory() {
+  const [entries, setEntries] = useState<string[]>(() => {
+    try {
+      const raw = readFileSync(HISTORY_FILE, 'utf-8');
+      return raw.split('\n').filter(Boolean).slice(-MAX_ENTRIES);
+    } catch {
+      return [];
+    }
+  });
+
+  const [cursor, setCursor] = useState(-1);
+
+  const push = useCallback((entry: string) => {
+    const trimmed = entry.trim();
+    if (!trimmed) return;
+    setEntries((prev) => {
+      // Deduplicate consecutive
+      const next = prev[prev.length - 1] === trimmed ? prev : [...prev, trimmed];
+      return next.slice(-MAX_ENTRIES);
+    });
+    setCursor(-1);
+  }, []);
+
+  // Navigate up/down through history
+  const navigate = useCallback(
+    (direction: 'up' | 'down'): string | undefined => {
+      if (entries.length === 0) return undefined;
+
+      let next: number;
+      if (direction === 'up') {
+        next = cursor === -1 ? entries.length - 1 : Math.max(0, cursor - 1);
+      } else {
+        next = cursor === -1 ? -1 : Math.min(entries.length - 1, cursor + 1);
+        if (next >= entries.length) {
+          setCursor(-1);
+          return '';
+        }
+      }
+      setCursor(next);
+      return entries[next];
+    },
+    [entries, cursor],
+  );
+
+  // Persist on change
+  useEffect(() => {
+    try {
+      mkdirSync(HISTORY_DIR, { recursive: true });
+      writeFileSync(HISTORY_FILE, entries.join('\n') + '\n', 'utf-8');
+    } catch {
+      // Silently ignore write failures (read-only fs, etc.)
+    }
+  }, [entries]);
+
+  return { entries, push, navigate, cursor };
+}

--- a/packages/npm/src/hooks/useHistory.ts
+++ b/packages/npm/src/hooks/useHistory.ts
@@ -1,69 +1,193 @@
-import { useState, useCallback, useEffect } from 'react';
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { useReducer, useCallback, useEffect, useRef } from 'react';
+import { writeFile } from 'node:fs/promises';
+import { readFileSync, mkdirSync, lstatSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
 const HISTORY_DIR = join(homedir(), '.govon');
 const HISTORY_FILE = join(HISTORY_DIR, 'history');
 const MAX_ENTRIES = 500;
+const MAX_ENTRY_BYTES = 4096;
+const DEBOUNCE_MS = 300;
+
+// ---------------------------------------------------------------------------
+// State shape
+// ---------------------------------------------------------------------------
+
+interface HistoryState {
+  entries: string[];
+  cursor: number; // -1 = at current input
+}
+
+type HistoryAction =
+  | { type: 'PUSH'; entry: string }
+  | { type: 'NAVIGATE'; direction: 'up' | 'down' }
+  | { type: 'RESET_CURSOR' };
+
+// ---------------------------------------------------------------------------
+// Reducer — makes push (entries + cursor) atomic
+// ---------------------------------------------------------------------------
+
+function historyReducer(state: HistoryState, action: HistoryAction): HistoryState {
+  switch (action.type) {
+    case 'PUSH': {
+      const trimmed = action.entry.trim();
+      if (!trimmed) return state;
+      if (Buffer.byteLength(trimmed, 'utf8') > MAX_ENTRY_BYTES) return state;
+
+      // Deduplicate consecutive identical entries
+      const next =
+        state.entries[state.entries.length - 1] === trimmed
+          ? state.entries
+          : [...state.entries, trimmed];
+
+      return { entries: next.slice(-MAX_ENTRIES), cursor: -1 };
+    }
+
+    case 'NAVIGATE': {
+      const { entries, cursor } = state;
+      if (entries.length === 0) return state;
+
+      if (action.direction === 'up') {
+        const next = cursor === -1 ? entries.length - 1 : Math.max(0, cursor - 1);
+        return { ...state, cursor: next };
+      }
+
+      // direction === 'down'
+      if (cursor === -1) return state; // already at current input — nothing to do
+      if (cursor + 1 >= entries.length) {
+        return { ...state, cursor: -1 }; // back to empty input
+      }
+      return { ...state, cursor: cursor + 1 };
+    }
+
+    case 'RESET_CURSOR':
+      return { ...state, cursor: -1 };
+
+    default:
+      return state;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Initial state loader
+// ---------------------------------------------------------------------------
+
+function loadInitialEntries(): string[] {
+  try {
+    const raw = readFileSync(HISTORY_FILE, 'utf-8');
+    return raw.split('\n').filter(Boolean).slice(-MAX_ENTRIES);
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Async persist helper — symlink-safe
+// ---------------------------------------------------------------------------
+
+async function persistEntries(entries: string[]): Promise<void> {
+  try {
+    mkdirSync(HISTORY_DIR, { recursive: true });
+
+    // Reject symlinks to prevent symlink-based write attacks
+    try {
+      const stat = lstatSync(HISTORY_FILE);
+      if (!stat.isFile()) return; // reject symlinks or other non-regular files
+    } catch {
+      // File does not exist yet — safe to create
+    }
+
+    await writeFile(HISTORY_FILE, entries.join('\n') + '\n', 'utf-8');
+  } catch {
+    // Silently ignore write failures (read-only fs, etc.)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
 
 /**
  * Load and persist CLI input history from ~/.govon/history.
- * Returns the history array, a push function, and a navigate function.
+ * Returns the history entries, a push function, a navigate function, and the
+ * current cursor position (-1 means "at current input").
  */
 export function useHistory() {
-  const [entries, setEntries] = useState<string[]>(() => {
-    try {
-      const raw = readFileSync(HISTORY_FILE, 'utf-8');
-      return raw.split('\n').filter(Boolean).slice(-MAX_ENTRIES);
-    } catch {
-      return [];
-    }
-  });
+  const [state, dispatch] = useReducer(historyReducer, undefined, () => ({
+    entries: loadInitialEntries(),
+    cursor: -1,
+  }));
 
-  const [cursor, setCursor] = useState(-1);
+  const { entries, cursor } = state;
+
+  // Debounce + overlap-guard refs for async persistence
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const writeInProgressRef = useRef(false);
+
+  // Persist entries whenever they change, with debounce and overlap guard
+  useEffect(() => {
+    if (debounceTimerRef.current !== null) {
+      clearTimeout(debounceTimerRef.current);
+    }
+
+    debounceTimerRef.current = setTimeout(() => {
+      debounceTimerRef.current = null;
+
+      if (writeInProgressRef.current) return; // skip if a write is already running
+
+      writeInProgressRef.current = true;
+      persistEntries(entries).finally(() => {
+        writeInProgressRef.current = false;
+      });
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (debounceTimerRef.current !== null) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+    };
+  }, [entries]);
 
   const push = useCallback((entry: string) => {
-    const trimmed = entry.trim();
-    if (!trimmed) return;
-    setEntries((prev) => {
-      // Deduplicate consecutive
-      const next = prev[prev.length - 1] === trimmed ? prev : [...prev, trimmed];
-      return next.slice(-MAX_ENTRIES);
-    });
-    setCursor(-1);
+    dispatch({ type: 'PUSH', entry });
   }, []);
 
-  // Navigate up/down through history
+  // Navigate up/down through history.
+  // Returns the selected entry string, '' when returning to current input, or
+  // undefined when there is nothing to navigate.
   const navigate = useCallback(
     (direction: 'up' | 'down'): string | undefined => {
       if (entries.length === 0) return undefined;
 
-      let next: number;
-      if (direction === 'up') {
-        next = cursor === -1 ? entries.length - 1 : Math.max(0, cursor - 1);
-      } else {
-        next = cursor === -1 ? -1 : Math.min(entries.length - 1, cursor + 1);
-        if (next >= entries.length) {
-          setCursor(-1);
-          return '';
+      const prevCursor = cursor;
+
+      if (direction === 'down') {
+        if (prevCursor === -1) return undefined; // already at current input
+        if (prevCursor + 1 >= entries.length) {
+          dispatch({ type: 'NAVIGATE', direction: 'down' });
+          return ''; // signal: restore empty input
         }
       }
-      setCursor(next);
-      return entries[next];
+
+      dispatch({ type: 'NAVIGATE', direction });
+
+      // Compute the next cursor locally so we can return the correct entry
+      // without waiting for the next render cycle.
+      if (direction === 'up') {
+        const next = prevCursor === -1 ? entries.length - 1 : Math.max(0, prevCursor - 1);
+        return entries[next];
+      } else {
+        return entries[prevCursor + 1];
+      }
     },
     [entries, cursor],
   );
 
-  // Persist on change
-  useEffect(() => {
-    try {
-      mkdirSync(HISTORY_DIR, { recursive: true });
-      writeFileSync(HISTORY_FILE, entries.join('\n') + '\n', 'utf-8');
-    } catch {
-      // Silently ignore write failures (read-only fs, etc.)
-    }
-  }, [entries]);
+  const resetCursor = useCallback(() => {
+    dispatch({ type: 'RESET_CURSOR' });
+  }, []);
 
-  return { entries, push, navigate, cursor };
+  return { entries, push, navigate, resetCursor, cursor };
 }

--- a/packages/npm/src/hooks/useSSE.ts
+++ b/packages/npm/src/hooks/useSSE.ts
@@ -1,0 +1,381 @@
+/**
+ * useSSE — React hook managing the SSE streaming lifecycle.
+ *
+ * Mirrors the fallback chain in src/cli/shell.py _try_process_query (lines 164-202):
+ *   1. Try v3 fine-grained streaming  (client.streamV3)
+ *   2. On failure → try v2 node-level streaming  (client.stream)
+ *   3. On failure → try blocking run  (client.run)
+ *
+ * Cancellation is handled via an AbortController stored in a ref.
+ * The controller is shared with the client by aborting the underlying fetch
+ * through the stream generator — on abort the for-await loop throws and
+ * the catch block in each path swallows the error and returns early.
+ */
+
+import { useCallback, useRef } from 'react';
+import type { GovOnClient } from '../client.js';
+import type { V3SSEEvent, V2SSEEvent, Action } from '../types.js';
+import { NODE_STATUS_MESSAGES } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Public interface
+// ---------------------------------------------------------------------------
+
+export interface UseSSEOptions {
+  client: GovOnClient;
+  dispatch: React.Dispatch<Action>;
+  sessionId: string | null;
+}
+
+export interface UseSSEReturn {
+  /** Submit a user query. Resolves when the run finishes (success or error). */
+  submit: (query: string) => Promise<void>;
+  /** Abort the in-flight request immediately. */
+  cancel: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook implementation
+// ---------------------------------------------------------------------------
+
+export function useSSE({ client, dispatch, sessionId }: UseSSEOptions): UseSSEReturn {
+  /** Holds the AbortController for the current in-flight request. */
+  const abortRef = useRef<AbortController | null>(null);
+
+  // -------------------------------------------------------------------------
+  // cancel — abort the current streaming request
+  // -------------------------------------------------------------------------
+
+  const cancel = useCallback(() => {
+    if (abortRef.current) {
+      abortRef.current.abort();
+      abortRef.current = null;
+    }
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // submit — attempt v3 → v2 → blocking, dispatch actions along the way
+  // -------------------------------------------------------------------------
+
+  const submit = useCallback(
+    async (query: string): Promise<void> => {
+      // Cancel any previous in-flight request before starting a new one.
+      cancel();
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      // Stable message ID for the assistant slot opened before streaming begins.
+      const assistantMsgId = crypto.randomUUID();
+      const timestamp = new Date().toISOString();
+      const sid = sessionId ?? undefined;
+
+      dispatch({ type: 'SET_LOADING', payload: true });
+      dispatch({ type: 'SET_ERROR', payload: null });
+      dispatch({
+        type: 'START_ASSISTANT_MESSAGE',
+        payload: { id: assistantMsgId, timestamp },
+      });
+
+      // ------------------------------------------------------------------
+      // Path 1: v3 fine-grained streaming
+      // ------------------------------------------------------------------
+      const v3Success = await _tryV3(
+        client,
+        query,
+        sid,
+        assistantMsgId,
+        controller,
+        dispatch,
+      );
+
+      if (v3Success) {
+        dispatch({ type: 'SET_API_VERSION', payload: 'v3' });
+        dispatch({ type: 'SET_LOADING', payload: false });
+        abortRef.current = null;
+        return;
+      }
+
+      // Bail out immediately if the user cancelled.
+      if (controller.signal.aborted) {
+        dispatch({ type: 'SET_LOADING', payload: false });
+        abortRef.current = null;
+        return;
+      }
+
+      // ------------------------------------------------------------------
+      // Path 2: v2 node-level streaming
+      // ------------------------------------------------------------------
+      const v2Success = await _tryV2(
+        client,
+        query,
+        sid,
+        assistantMsgId,
+        controller,
+        dispatch,
+      );
+
+      if (v2Success) {
+        dispatch({ type: 'SET_API_VERSION', payload: 'v2' });
+        dispatch({ type: 'SET_LOADING', payload: false });
+        abortRef.current = null;
+        return;
+      }
+
+      if (controller.signal.aborted) {
+        dispatch({ type: 'SET_LOADING', payload: false });
+        abortRef.current = null;
+        return;
+      }
+
+      // ------------------------------------------------------------------
+      // Path 3: blocking run
+      // ------------------------------------------------------------------
+      await _tryBlocking(client, query, sid, assistantMsgId, controller, dispatch);
+
+      dispatch({ type: 'SET_LOADING', payload: false });
+      abortRef.current = null;
+    },
+    [client, dispatch, sessionId, cancel],
+  );
+
+  return { submit, cancel };
+}
+
+// ---------------------------------------------------------------------------
+// Internal path helpers  (module-level to keep the hook body lean)
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempt v3 SSE streaming. Returns true when the run completed successfully,
+ * false when any error occurs so the caller can fall through to the next path.
+ */
+async function _tryV3(
+  client: GovOnClient,
+  query: string,
+  sessionId: string | undefined,
+  assistantMsgId: string,
+  controller: AbortController,
+  dispatch: React.Dispatch<Action>,
+): Promise<boolean> {
+  try {
+    for await (const raw of client.streamV3(query, sessionId)) {
+      // Respect cancellation mid-stream.
+      if (controller.signal.aborted) return false;
+
+      const event = raw as V3SSEEvent;
+
+      switch (event.type) {
+        case 'thinking_start':
+          dispatch({
+            type: 'START_THINKING_STEP',
+            payload: { iteration: event.iteration },
+          });
+          break;
+
+        case 'thinking_delta':
+          dispatch({
+            type: 'APPEND_STREAMING_THINKING',
+            payload: event.content,
+          });
+          break;
+
+        case 'thinking_end':
+          dispatch({
+            type: 'END_THINKING_STEP',
+            payload: { iteration: event.iteration, tool_calls: event.tool_calls },
+          });
+          break;
+
+        case 'tool_start':
+          dispatch({
+            type: 'MARK_TOOL_START',
+            payload: { tool: event.tool },
+          });
+          break;
+
+        case 'tool_end':
+          dispatch({
+            type: 'MARK_TOOL_END',
+            payload: { tool: event.tool, success: event.success },
+          });
+          break;
+
+        case 'response_delta':
+          dispatch({
+            type: 'APPEND_STREAMING_CONTENT',
+            payload: event.content,
+          });
+          break;
+
+        case 'run_complete':
+          dispatch({
+            type: 'FINALIZE_ASSISTANT_MESSAGE',
+            payload: {
+              messageId: assistantMsgId,
+              content: event.text,
+              evidence: event.evidence_items,
+              metadata: event.metadata,
+              sessionId: event.session_id,
+              threadId: event.thread_id,
+            },
+          });
+          // run_complete signals a clean finish — return success immediately.
+          return true;
+
+        case 'error':
+          dispatch({ type: 'SET_ERROR', payload: event.error });
+          // An explicit error event from v3 is still a "handled" terminal state;
+          // return false so the caller falls through to v2/blocking.
+          return false;
+
+        default:
+          // Unknown event type — ignore and continue streaming.
+          break;
+      }
+    }
+
+    // Generator exhausted without a run_complete event — treat as failure.
+    return false;
+  } catch {
+    // Network error, HTTP non-2xx, abort, or JSON parse failure from the client.
+    return false;
+  }
+}
+
+/**
+ * Attempt v2 node-level SSE streaming. Returns true on clean completion,
+ * false on error so the caller can fall through to the blocking path.
+ */
+async function _tryV2(
+  client: GovOnClient,
+  query: string,
+  sessionId: string | undefined,
+  assistantMsgId: string,
+  controller: AbortController,
+  dispatch: React.Dispatch<Action>,
+): Promise<boolean> {
+  try {
+    for await (const raw of client.stream(query, sessionId)) {
+      if (controller.signal.aborted) return false;
+
+      const event = raw as V2SSEEvent;
+      const { node, status } = event;
+
+      // Update the status bar label for recognised node transitions.
+      const statusMsg = NODE_STATUS_MESSAGES[node];
+      if (statusMsg !== undefined) {
+        dispatch({ type: 'SET_STATUS_LABEL', payload: statusMsg });
+      }
+
+      if (node === 'agent' && status === 'completed') {
+        if (event.planned_tools && event.planned_tools.length > 0) {
+          // Agent has decided which tools to call next.
+          dispatch({
+            type: 'SET_STATUS_LABEL',
+            payload: `도구 실행 예정: ${event.planned_tools.join(', ')}`,
+          });
+        }
+
+        // When final_text is present, the agent run finished on this node.
+        if (event.final_text !== undefined) {
+          dispatch({
+            type: 'FINALIZE_ASSISTANT_MESSAGE',
+            payload: {
+              messageId: assistantMsgId,
+              content: event.final_text,
+              evidence: event.evidence_items ?? [],
+              metadata: {},
+              sessionId: event.session_id ?? '',
+              threadId: event.thread_id ?? '',
+            },
+          });
+          return true;
+        }
+      }
+
+      if (node === 'tools' && status === 'completed') {
+        // Tool node finished — update status label; individual tool tracking
+        // is not available at v2 granularity so we only set the label.
+        dispatch({ type: 'SET_STATUS_LABEL', payload: '도구 실행 완료' });
+      }
+
+      if (node === 'approval_wait' && status === 'awaiting_approval') {
+        if (event.approval_request !== undefined) {
+          dispatch({
+            type: 'SET_PENDING_APPROVAL',
+            payload: event.approval_request,
+          });
+        }
+      }
+
+      if (node === 'persist' && status === 'completed') {
+        if (event.final_text !== undefined) {
+          dispatch({
+            type: 'FINALIZE_ASSISTANT_MESSAGE',
+            payload: {
+              messageId: assistantMsgId,
+              content: event.final_text,
+              evidence: event.evidence_items ?? [],
+              metadata: {},
+              sessionId: event.session_id ?? '',
+              threadId: event.thread_id ?? '',
+            },
+          });
+          return true;
+        }
+      }
+
+      if (node === 'error') {
+        dispatch({
+          type: 'SET_ERROR',
+          payload: event.error ?? 'Unknown error from v2 stream',
+        });
+        return false;
+      }
+    }
+
+    // Generator exhausted without a persist/agent run_complete event.
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Attempt the blocking /v2/agent/run endpoint as a last resort.
+ * Dispatches FINALIZE on success, SET_ERROR on failure.
+ */
+async function _tryBlocking(
+  client: GovOnClient,
+  query: string,
+  sessionId: string | undefined,
+  assistantMsgId: string,
+  controller: AbortController,
+  dispatch: React.Dispatch<Action>,
+): Promise<void> {
+  if (controller.signal.aborted) return;
+
+  try {
+    const result = await client.run(query, sessionId);
+
+    if (controller.signal.aborted) return;
+
+    dispatch({
+      type: 'FINALIZE_ASSISTANT_MESSAGE',
+      payload: {
+        messageId: assistantMsgId,
+        content: result.text,
+        evidence: result.evidence_items ?? [],
+        metadata: result.metadata ?? {},
+        sessionId: result.session_id,
+        threadId: result.thread_id ?? '',
+      },
+    });
+  } catch (err) {
+    if (controller.signal.aborted) return;
+
+    const msg = err instanceof Error ? err.message : String(err);
+    dispatch({ type: 'SET_ERROR', payload: msg });
+  }
+}

--- a/packages/npm/src/hooks/useTheme.ts
+++ b/packages/npm/src/hooks/useTheme.ts
@@ -1,0 +1,69 @@
+/**
+ * useTheme — resolves brand color tokens from the runtime environment.
+ *
+ * Respects the NO_COLOR convention (https://no-color.org/):
+ * when NO_COLOR is set to any value (including empty string), all color
+ * tokens are returned as empty strings so callers can safely pass them
+ * to Ink's <Text color="..."> prop without emitting ANSI sequences.
+ *
+ * The returned object is stable across renders (memoised with no deps)
+ * because process.env values never change at runtime.
+ */
+
+import { useMemo } from 'react';
+import { THEME_COLORS } from '../config.js';
+
+// ---------------------------------------------------------------------------
+// Public interface
+// ---------------------------------------------------------------------------
+
+/** Brand color tokens used throughout the TUI. */
+export interface ThemeTokens {
+  /** Primary brand green — main interactive elements. */
+  primary: string;
+  /** Accent warm sand — highlights and callouts. */
+  accent: string;
+  /** Muted sage — secondary text and borders. */
+  muted: string;
+  /** Error red — destructive actions and error messages. */
+  error: string;
+  /** Warning amber — non-critical warnings. */
+  warning: string;
+  /** Success green — confirmation and done states. */
+  success: string;
+  /** Info blue — informational badges and labels. */
+  info: string;
+  /** Dimmed grey — disabled states and placeholders. */
+  dimmed: string;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns resolved theme color tokens for the current runtime environment.
+ *
+ * Usage:
+ *   const theme = useTheme();
+ *   <Text color={theme.primary}>Hello</Text>
+ */
+export function useTheme(): ThemeTokens {
+  return useMemo(() => {
+    // NO_COLOR env var present → strip all color output regardless of value.
+    if (process.env.NO_COLOR !== undefined) {
+      return {
+        primary: '',
+        accent: '',
+        muted: '',
+        error: '',
+        warning: '',
+        success: '',
+        info: '',
+        dimmed: '',
+      };
+    }
+
+    return { ...THEME_COLORS };
+  }, []);
+}

--- a/packages/npm/src/index.tsx
+++ b/packages/npm/src/index.tsx
@@ -1,0 +1,41 @@
+/**
+ * index.tsx — CLI entry point for the GovOn npm TUI.
+ *
+ * Parses CLI arguments with yargs and renders the <App /> component via Ink.
+ */
+
+import React from 'react';
+import { render } from 'ink';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import { createRequire } from 'node:module';
+import { App } from './App.js';
+
+// Read version from package.json at runtime (avoid bundling the whole file)
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json') as { version: string };
+
+const argv = yargs(hideBin(process.argv))
+  .scriptName('govon')
+  .usage('$0 [query]', 'GovOn agentic TUI for civil complaint assistance')
+  .positional('query', {
+    type: 'string',
+    describe: 'Initial query to submit immediately',
+  })
+  .option('version', {
+    alias: 'v',
+    type: 'boolean',
+    describe: 'Show version',
+  })
+  .help()
+  .parseSync();
+
+if (argv.version) {
+  process.stdout.write(pkg.version + '\n');
+  process.exit(0);
+}
+
+// argv._[0] is the positional <query> argument when provided
+const query = argv._[0] as string | undefined;
+
+render(<App version={pkg.version} initialQuery={query} />);

--- a/packages/npm/src/types/marked-terminal.d.ts
+++ b/packages/npm/src/types/marked-terminal.d.ts
@@ -1,0 +1,24 @@
+/**
+ * Minimal type declarations for marked-terminal v7.
+ * The package ships no bundled .d.ts and there is no @types/marked-terminal.
+ */
+declare module 'marked-terminal' {
+  import type { MarkedExtension } from 'marked';
+
+  interface MarkedTerminalOptions {
+    reflowText?: boolean;
+    width?: number;
+    showSectionPrefix?: boolean;
+    unescape?: boolean;
+    emoji?: boolean;
+    firstHeading?: unknown;
+    tab?: number;
+    tableOptions?: Record<string, unknown>;
+  }
+
+  /** Factory that returns a marked extension for terminal rendering. */
+  export function markedTerminal(options?: MarkedTerminalOptions): MarkedExtension;
+
+  /** Default export mirrors the named export for CJS interop. */
+  export default markedTerminal;
+}

--- a/packages/npm/vitest.config.ts
+++ b/packages/npm/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.{ts,tsx}'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['src/**/*.test.{ts,tsx}', 'src/types/**'],
+    },
+  },
+});


### PR DESCRIPTION
## Related Issue
- N/A (internal bug fix surfaced via code review)

## Background
Four bugs were identified in `packages/npm/src/hooks/useHistory.ts`:
1. **Critical** — `writeFileSync` blocked the Node.js event loop on every history-change render.
2. **Major** — `navigate('down')` had an unreachable branch; `Math.min` capped the cursor so the `>= entries.length` guard could never fire, meaning "return to empty input" was silently broken.
3. **Major** — `setEntries` and `setCursor` were two separate `useState` calls, so a `push()` could produce an intermediate render with entries updated but cursor still stale.
4. **Security/Medium** — No symlink check before writing allowed a symlink-based write-redirect attack; also, no per-entry byte cap meant arbitrarily large entries could accumulate.

## Key Changes
- Replace `writeFileSync` with `writeFile` (fs/promises) wrapped in a 300 ms debounce + `writeInProgress` ref to prevent concurrent writes (Fix 1)
- Rewrite `navigate('down')` to check bounds **before** clamping, returning `''` when the user goes past the last entry (Fix 2)
- Replace two `useState` calls with a single `useReducer` (`PUSH` / `NAVIGATE` / `RESET_CURSOR`) so entries and cursor always update atomically (Fix 3)
- Add `lstatSync` symlink guard in `persistEntries` and a 4096-byte UTF-8 cap per entry in the `PUSH` reducer case (Fix 4)

## Test Results
- [ ] `npx tsc --noEmit` passes with zero errors on `packages/npm`
- [ ] Existing functionality verified (navigate up/down, push deduplication, MAX_ENTRIES cap)

## Additional Notes
`resetCursor` is now also exported from the hook (no-op dispatch to `RESET_CURSOR`) for callers that need to programmatically reset cursor state without pushing an entry.

---

## Merge Checklist
- [ ] At least one code review approval
- [ ] CODEOWNERS (team lead) final approval
- [ ] All review comments resolved

## Reviewer Guide

| Tag | Meaning | Example |
|-----|---------|---------|
| `[MUST]` | Must fix (security, bug, performance issue) | `[MUST] API key is exposed in logs.` |
| `[SHOULD]` | Strongly recommended (code quality, maintainability) | `[SHOULD] This logic should be extracted into a separate function.` |
| `[NITS]` | Minor improvement (style, naming) | `[NITS] \`parsed_output\` is clearer than \`result\` as a variable name.` |
| `[QUESTION]` | Question for understanding | `[QUESTION] Can this condition ever be always True?` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a terminal-based interactive user interface for the npm package with real-time streaming responses.
  * Added CLI support with version flag and query input capabilities.
  * Added interactive approval prompts for tool execution requests.
  * Added command history persistence and navigation.
  * Added markdown rendering support within the terminal.
  * Added keyboard shortcuts for navigation and exit (Ctrl+C, Ctrl+D, Esc).
  * Added progress indicators and status feedback during processing.

* **Chores**
  * Added build configuration for ESM bundling.
  * Added test suite configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->