### PR TITLE
feat(npm-tui): Node SEA build pipeline — Phase 5

### DIFF
--- a/.github/workflows/build-sea.yml
+++ b/.github/workflows/build-sea.yml
@@ -1,0 +1,101 @@
+name: Build Node SEA Binaries
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+
+jobs:
+  build-js:
+    name: Bundle JavaScript
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Install dependencies
+        working-directory: packages/npm
+        run: npm ci
+      - name: Bundle for SEA
+        working-directory: packages/npm
+        run: |
+          npx esbuild src/index.tsx \
+            --bundle \
+            --platform=node \
+            --target=node22 \
+            --format=esm \
+            --jsx=automatic \
+            --outfile=dist/sea-bundle.js \
+            --define:process.env.NODE_ENV=\"production\" \
+            --external:react-devtools-core
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sea-bundle
+          path: packages/npm/dist/sea-bundle.js
+
+  build-sea:
+    name: SEA ${{ matrix.platform }}
+    needs: build-js
+    strategy:
+      matrix:
+        include:
+          - os: macos-13
+            platform: darwin-x64
+          - os: macos-14
+            platform: darwin-arm64
+          - os: ubuntu-latest
+            platform: linux-x64
+          - os: ubuntu-24.04-arm
+            platform: linux-arm64
+          - os: windows-latest
+            platform: win-x64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - uses: actions/download-artifact@v4
+        with:
+          name: sea-bundle
+          path: packages/npm/dist
+      - name: Install postject
+        run: npm install -g postject
+      - name: Generate SEA blob
+        working-directory: packages/npm
+        run: node --experimental-sea-config sea-config.json
+      - name: Create SEA binary
+        working-directory: packages/npm
+        shell: bash
+        run: |
+          BINARY="dist/govon-${{ matrix.platform }}"
+          if [[ "${{ matrix.platform }}" == win-* ]]; then
+            BINARY="${BINARY}.exe"
+            cp "$(which node).exe" "$BINARY" 2>/dev/null || cp "$(which node)" "$BINARY"
+          else
+            cp "$(which node)" "$BINARY"
+          fi
+
+          # Remove signature on macOS before injection
+          if [[ "${{ matrix.platform }}" == darwin-* ]]; then
+            codesign --remove-signature "$BINARY"
+          fi
+
+          # Inject SEA blob
+          npx postject "$BINARY" NODE_SEA_BLOB dist/sea-prep.blob \
+            --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
+
+          # Re-sign on macOS
+          if [[ "${{ matrix.platform }}" == darwin-* ]]; then
+            codesign --sign - "$BINARY"
+          fi
+
+          ls -lh "$BINARY"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: govon-${{ matrix.platform }}
+          path: packages/npm/dist/govon-${{ matrix.platform }}*

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -56,6 +56,7 @@
     "@types/yargs": "^17.0.33",
     "esbuild": "^0.25.0",
     "ink-testing-library": "^4.0.0",
+    "postject": "^1.0.0",
     "typescript": "^5.7.0",
     "vitest": "^3.1.0"
   }

--- a/packages/npm/scripts/build-sea.sh
+++ b/packages/npm/scripts/build-sea.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_DIR"
+
+# Detect platform
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64) ARCH="x64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+esac
+PLATFORM="${OS}-${ARCH}"
+
+echo "Building Node SEA binary for ${PLATFORM}..."
+
+# Step 1: Build single-file ESM bundle with all deps inlined
+echo "  [1/5] Bundling with esbuild..."
+npx esbuild src/index.tsx \
+  --bundle \
+  --platform=node \
+  --target=node22 \
+  --format=esm \
+  --jsx=automatic \
+  --outfile=dist/sea-bundle.js \
+  --define:process.env.NODE_ENV=\"production\" \
+  --external:react-devtools-core
+
+# Step 2: Generate SEA preparation blob
+echo "  [2/5] Generating SEA blob..."
+node --experimental-sea-config sea-config.json
+
+# Step 3: Copy node binary
+BINARY_NAME="govon-${PLATFORM}"
+if [ "$OS" = "windows" ] || [[ "$OS" == mingw* ]]; then
+  BINARY_NAME="${BINARY_NAME}.exe"
+fi
+echo "  [3/5] Copying node binary -> dist/${BINARY_NAME}"
+cp "$(command -v node)" "dist/${BINARY_NAME}"
+
+# Step 4: Remove existing signature on macOS (required before injection)
+if [ "$OS" = "darwin" ]; then
+  echo "  [4/5] Removing macOS code signature..."
+  codesign --remove-signature "dist/${BINARY_NAME}"
+fi
+
+# Step 5: Inject SEA blob
+echo "  [4/5] Injecting SEA blob..."
+npx postject "dist/${BINARY_NAME}" NODE_SEA_BLOB dist/sea-prep.blob \
+  --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
+
+# Step 6: Re-sign on macOS
+if [ "$OS" = "darwin" ]; then
+  echo "  [5/5] Re-signing macOS binary..."
+  codesign --sign - "dist/${BINARY_NAME}"
+fi
+
+# Verify
+echo ""
+echo "SEA binary created: dist/${BINARY_NAME}"
+ls -lh "dist/${BINARY_NAME}"
+echo "Test: dist/${BINARY_NAME} --version"
+"dist/${BINARY_NAME}" --version || echo "(version check may fail if index.tsx requires terminal)"

--- a/packages/npm/sea-config.json
+++ b/packages/npm/sea-config.json
@@ -1,0 +1,8 @@
+{
+  "main": "dist/sea-bundle.js",
+  "output": "dist/sea-prep.blob",
+  "disableExperimentalSEAWarning": true,
+  "useSnapshot": false,
+  "useCodeCache": true,
+  "assets": {}
+}

--- a/packages/npm/src/App.tsx
+++ b/packages/npm/src/App.tsx
@@ -328,10 +328,11 @@ export function App({ version, initialQuery }: AppProps) {
     }
   }, [daemon.ready, initialQuery, handleSubmit]);
 
-  // Keyboard shortcut: Ctrl+D / Ctrl+C exits
-  useInput((input: string, key: { ctrl: boolean }) => {
+  // Keyboard shortcuts: Ctrl+D/Ctrl+C exits, Esc cancels in-flight request
+  useInput((input: string, key: { ctrl: boolean; escape: boolean }) => {
     if (key.ctrl && input === 'd') exit();
     if (key.ctrl && input === 'c') exit();
+    if (key.escape && state.isLoading) cancel();
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/npm/src/components/ApprovalPrompt.tsx
+++ b/packages/npm/src/components/ApprovalPrompt.tsx
@@ -6,7 +6,7 @@
  * Calls onApprove(true) or onApprove(false) accordingly.
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { Box, Text, useInput } from 'ink';
 import type { ApprovalRequest } from '../types.js';
 import { TASK_TYPE_LABELS, TASK_TYPE_STYLES } from '../types.js';
@@ -21,14 +21,19 @@ const MAX_DESCRIPTION_LENGTH = 1000;
 
 export function ApprovalPrompt({ request, onApprove }: ApprovalPromptProps) {
   const safeDescription = request.description?.slice(0, MAX_DESCRIPTION_LENGTH);
+  // Prevent duplicate approval submissions from repeated keypresses
+  const decidedRef = useRef(false);
 
   useInput(
     useCallback(
       (input: string) => {
+        if (decidedRef.current) return;
         const key = input.toLowerCase();
         if (key === 'y') {
+          decidedRef.current = true;
           onApprove(true);
         } else if (key === 'n') {
+          decidedRef.current = true;
           onApprove(false);
         }
       },

--- a/packages/npm/src/hooks/useHistory.ts
+++ b/packages/npm/src/hooks/useHistory.ts
@@ -124,8 +124,13 @@ export function useHistory() {
   // Debounce + overlap-guard refs for async persistence
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const writeInProgressRef = useRef(false);
+  const pendingWriteRef = useRef(false);
+  const latestEntriesRef = useRef(entries);
 
-  // Persist entries whenever they change, with debounce and overlap guard
+  // Keep latest entries ref in sync
+  latestEntriesRef.current = entries;
+
+  // Persist entries whenever they change, with debounce and trailing-write guard
   useEffect(() => {
     if (debounceTimerRef.current !== null) {
       clearTimeout(debounceTimerRef.current);
@@ -134,11 +139,23 @@ export function useHistory() {
     debounceTimerRef.current = setTimeout(() => {
       debounceTimerRef.current = null;
 
-      if (writeInProgressRef.current) return; // skip if a write is already running
+      if (writeInProgressRef.current) {
+        // A write is running — queue a trailing write so the latest state is persisted
+        pendingWriteRef.current = true;
+        return;
+      }
 
       writeInProgressRef.current = true;
-      persistEntries(entries).finally(() => {
+      persistEntries(latestEntriesRef.current).finally(() => {
         writeInProgressRef.current = false;
+        // If entries changed while the write was in progress, flush the latest
+        if (pendingWriteRef.current) {
+          pendingWriteRef.current = false;
+          writeInProgressRef.current = true;
+          void persistEntries(latestEntriesRef.current).finally(() => {
+            writeInProgressRef.current = false;
+          });
+        }
       });
     }, DEBOUNCE_MS);
 

--- a/packages/npm/src/hooks/useSSE.ts
+++ b/packages/npm/src/hooks/useSSE.ts
@@ -91,6 +91,10 @@ export function useSSE({ client, dispatch, sessionId }: UseSSEOptions): UseSSERe
       const controller = new AbortController();
       abortRef.current = controller;
 
+      // Guard against stale cleanup: if a newer submit() starts while this
+      // one is still unwinding, we must not null out the newer controller.
+      const isCurrentRun = () => abortRef.current === controller;
+
       // Stable message ID for the assistant slot opened before streaming begins.
       const assistantMsgId = crypto.randomUUID();
       const timestamp = new Date().toISOString();
@@ -118,14 +122,14 @@ export function useSSE({ client, dispatch, sessionId }: UseSSEOptions): UseSSERe
       if (v3Success) {
         safeDispatch({ type: 'SET_API_VERSION', payload: 'v3' });
         safeDispatch({ type: 'SET_LOADING', payload: false });
-        abortRef.current = null;
+        if (isCurrentRun()) abortRef.current = null;
         return;
       }
 
       // Bail out immediately if the user cancelled.
       if (controller.signal.aborted) {
         safeDispatch({ type: 'SET_LOADING', payload: false });
-        abortRef.current = null;
+        if (isCurrentRun()) abortRef.current = null;
         return;
       }
 
@@ -139,7 +143,7 @@ export function useSSE({ client, dispatch, sessionId }: UseSSEOptions): UseSSERe
           payload: 'Streaming interrupted after partial response — please retry.',
         });
         safeDispatch({ type: 'SET_LOADING', payload: false });
-        abortRef.current = null;
+        if (isCurrentRun()) abortRef.current = null;
         return;
       }
 
@@ -158,13 +162,13 @@ export function useSSE({ client, dispatch, sessionId }: UseSSEOptions): UseSSERe
       if (v2Success) {
         safeDispatch({ type: 'SET_API_VERSION', payload: 'v2' });
         safeDispatch({ type: 'SET_LOADING', payload: false });
-        abortRef.current = null;
+        if (isCurrentRun()) abortRef.current = null;
         return;
       }
 
       if (controller.signal.aborted) {
         safeDispatch({ type: 'SET_LOADING', payload: false });
-        abortRef.current = null;
+        if (isCurrentRun()) abortRef.current = null;
         return;
       }
 
@@ -174,7 +178,7 @@ export function useSSE({ client, dispatch, sessionId }: UseSSEOptions): UseSSERe
       await _tryBlocking(client, query, sid, assistantMsgId, controller, safeDispatch);
 
       safeDispatch({ type: 'SET_LOADING', payload: false });
-      abortRef.current = null;
+      if (isCurrentRun()) abortRef.current = null;
     },
     [client, safeDispatch, sessionId, cancel],
   );


### PR DESCRIPTION
## Summary
- Node SEA (Single Executable Application) build pipeline for standalone binaries
- Fix all CodeRabbit findings from PR #661

## Node SEA Pipeline
| File | Description |
|------|-------------|
| `sea-config.json` | ESM entry config for Node 22+ SEA |
| `scripts/build-sea.sh` | Local SEA builder (esbuild → blob → postject inject) |
| `.github/workflows/build-sea.yml` | 5-platform matrix CI (darwin-x64/arm64, linux-x64/arm64, win-x64) |

## CodeRabbit #661 Fixes
| Issue | Fix |
|-------|-----|
| Esc key not wired to cancel() | Added `key.escape` handler in App.tsx useInput |
| ApprovalPrompt duplicate keypress | Added `decidedRef` guard |
| useSSE stale submit cleanup race | Added `isCurrentRun()` guard for abortRef cleanup |
| useHistory debounce drops latest | Added trailing-write mechanism with pendingWriteRef |

## Test plan
- [x] `npx tsc --noEmit` — type check passes
- [ ] CI checks pass
- [ ] `build-sea.yml` workflow can be triggered manually

## Context
Phase 5 of 8 in the npm TUI rebuild.
Next: Phase 6 — Python launcher + pyproject.toml changes.