### PR TITLE
chore: bump to 1.4.0

### DIFF
--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govon",
-  "version": "0.1.0",
+  "version": "1.4.0",
   "description": "GovOn CLI — Agentic TUI for Korean civil complaint assistance powered by React + Ink",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "govon"
-version = "1.3.0"
+version = "1.4.0"
 description = "Agentic CLI shell for Korean public-sector civil complaint workflows"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
Version bump to 1.4.0 for the React+Ink TUI rebuild release.

## Changes
- `pyproject.toml`: 1.3.0 → 1.4.0
- `packages/npm/package.json`: 0.1.0 → 1.4.0

## What's in 1.4.0
- React + Ink + TypeScript TUI (replaces Python CLI)
- Node SEA build pipeline (5 platforms)
- Python launcher for pip install (delegates to SEA binary)
- CI/CD: npm-check job, publish-npm build steps, build-sea workflow
- Python CLI removed (-4,977 LOC)