### PR TITLE
fix(ci): bundle SEA binaries into PyPI wheel

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -15,8 +15,19 @@ permissions:
   contents: read
 
 jobs:
+  # Step 1: Build Node SEA binaries for all platforms
+  build-sea:
+    name: Build SEA binaries
+    uses: ./.github/workflows/build-sea.yml
+    with:
+      version: ${{ github.ref_name }}
+    permissions:
+      contents: read
+
+  # Step 2: Build Python wheel with SEA binaries bundled
   build:
     name: Build distribution
+    needs: build-sea
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -54,8 +65,57 @@ jobs:
           fi
           echo "Version check passed: $TOML_VERSION"
 
+      # Download all SEA platform binaries into the _bin/ directory
+      - name: Download SEA binary (darwin-x64)
+        uses: actions/download-artifact@v4
+        with:
+          name: govon-darwin-x64
+          path: src/govon_cli/_bin/
+      - name: Download SEA binary (darwin-arm64)
+        uses: actions/download-artifact@v4
+        with:
+          name: govon-darwin-arm64
+          path: src/govon_cli/_bin/
+      - name: Download SEA binary (linux-x64)
+        uses: actions/download-artifact@v4
+        with:
+          name: govon-linux-x64
+          path: src/govon_cli/_bin/
+      - name: Download SEA binary (linux-arm64)
+        uses: actions/download-artifact@v4
+        with:
+          name: govon-linux-arm64
+          path: src/govon_cli/_bin/
+      - name: Download SEA binary (win-x64)
+        uses: actions/download-artifact@v4
+        with:
+          name: govon-win-x64
+          path: src/govon_cli/_bin/
+
+      - name: Verify SEA binaries
+        run: |
+          echo "=== SEA binaries in _bin/ ==="
+          ls -lh src/govon_cli/_bin/
+          EXPECTED=("govon-darwin-x64" "govon-darwin-arm64" "govon-linux-x64" "govon-linux-arm64" "govon-win-x64.exe")
+          for bin in "${EXPECTED[@]}"; do
+            if [ ! -f "src/govon_cli/_bin/$bin" ]; then
+              echo "::error::Missing SEA binary: $bin"
+              exit 1
+            fi
+            echo "  ✓ $bin ($(stat -c%s "src/govon_cli/_bin/$bin" 2>/dev/null || stat -f%z "src/govon_cli/_bin/$bin") bytes)"
+          done
+
       - name: Build wheel and sdist
         run: python -m build
+
+      - name: Verify wheel contains binaries
+        run: |
+          WHEEL=$(ls dist/*.whl)
+          echo "Wheel: $WHEEL"
+          python -m zipfile -l "$WHEEL" | grep _bin/ || {
+            echo "::error::Wheel does not contain _bin/ binaries"
+            exit 1
+          }
 
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v7
@@ -63,6 +123,7 @@ jobs:
           name: python-package-distributions
           path: dist/
 
+  # Step 3: Publish to PyPI
   publish-pypi:
     name: Publish to PyPI
     needs: build


### PR DESCRIPTION
## Summary
Fix `pip install govon` shipping empty `_bin/` directory by wiring `build-sea.yml` into `publish-pypi.yml`.

## Problem
`pip install govon` installed the Python launcher but no Node SEA binary, causing:
```
Error: No GovOn CLI binary for darwin-arm64.
```

## Solution
Updated `publish-pypi.yml` pipeline:
1. **build-sea** job (reusable workflow) → builds SEA binaries for 5 platforms
2. **build** job → downloads all 5 SEA artifacts into `src/govon_cli/_bin/`
3. Verifies binaries present before `python -m build`
4. Verifies wheel contains `_bin/` entries after build
5. Publishes to PyPI

## Test plan
- [ ] CI checks pass
- [ ] Manual: trigger `build-sea.yml` via workflow_dispatch to verify binary creation
- [ ] After v1.4.1 tag: `pip install govon==1.4.1 && govon --version`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release process to bundle pre-compiled platform-specific binaries for macOS (Intel and Apple Silicon), Linux (x64 and ARM64), and Windows (x64) in published packages, with automated validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->