### PR TITLE
chore: bump to 1.4.1 — fix PyPI SEA bundling

### DIFF
--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govon",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "GovOn CLI — Agentic TUI for Korean civil complaint assistance powered by React + Ink",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "govon"
-version = "1.4.0"
+version = "1.4.1"
 description = "Agentic CLI shell for Korean public-sector civil complaint workflows"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Patch release to fix empty _bin/ in PyPI wheel. SEA binaries are now bundled via build-sea.yml pipeline.