### PR TITLE
fix(ci): use npm install in build-sea.yml

### DIFF
--- a/.github/workflows/build-sea.yml
+++ b/.github/workflows/build-sea.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: '22'
       - name: Install dependencies
         working-directory: packages/npm
-        run: npm ci
+        run: npm install --no-audit --no-fund
       - name: Bundle for SEA
         working-directory: packages/npm
         run: |


### PR DESCRIPTION
Fix npm ci failure — no package-lock.json in packages/npm/