### PR TITLE
fix(ci): shasum for macOS SEA checksum

### DIFF
--- a/.github/workflows/build-sea.yml
+++ b/.github/workflows/build-sea.yml
@@ -37,7 +37,7 @@ jobs:
             --external:react-devtools-core
       - name: Generate checksum
         working-directory: packages/npm
-        run: sha256sum dist/sea-bundle.js > dist/sea-bundle.js.sha256
+        run: shasum -a 256 dist/sea-bundle.js > dist/sea-bundle.js.sha256
       - uses: actions/upload-artifact@v4
         with:
           name: sea-bundle
@@ -74,7 +74,7 @@ jobs:
       - name: Verify bundle checksum
         working-directory: packages/npm
         shell: bash
-        run: sha256sum --check dist/sea-bundle.js.sha256
+        run: shasum -a 256 --check dist/sea-bundle.js.sha256
       - name: Install postject
         run: npm install -g postject@1.0.0-alpha.6
       - name: Generate SEA blob


### PR DESCRIPTION
sha256sum doesn't exist on macOS. Use shasum -a 256 which works on both Linux and macOS.