### PR TITLE
fix(sea): disable useCodeCache for ESM compatibility

### DIFF
--- a/packages/npm/sea-config.json
+++ b/packages/npm/sea-config.json
@@ -3,6 +3,6 @@
   "output": "dist/sea-prep.blob",
   "disableExperimentalSEAWarning": true,
   "useSnapshot": false,
-  "useCodeCache": true,
+  "useCodeCache": false,
   "assets": {}
 }


### PR DESCRIPTION
V8 code cache cannot be generated for ESM bundles with top-level await. Set useCodeCache: false in sea-config.json.