### PR TITLE
fix(ci): disable fail-fast in SEA build matrix

### DIFF
--- a/.github/workflows/build-sea.yml
+++ b/.github/workflows/build-sea.yml
@@ -49,6 +49,7 @@ jobs:
     name: SEA ${{ matrix.platform }}
     needs: build-js
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: macos-13


### PR DESCRIPTION
Prevent one slow/cancelled runner from cancelling all other platform builds.