### PR TITLE
chore: bump to 1.4.6

### DIFF
--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govon",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "GovOn CLI — Agentic TUI for Korean civil complaint assistance powered by React + Ink",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "govon"
-version = "1.4.5"
+version = "1.4.6"
 description = "Agentic CLI shell for Korean public-sector civil complaint workflows"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
SEA matrix fail-fast disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version updated to 1.4.6 across all distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->