### PR TITLE
fix(ci): lightweight PyPI wheel + first-run SEA download

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -15,19 +15,9 @@ permissions:
   contents: read
 
 jobs:
-  # Step 1: Build Node SEA binaries for all platforms
-  build-sea:
-    name: Build SEA binaries
-    uses: ./.github/workflows/build-sea.yml
-    with:
-      version: ${{ github.ref_name }}
-    permissions:
-      contents: read
-
-  # Step 2: Build Python wheel with SEA binaries bundled
+  # Step 1: Build lightweight Python wheel (launcher only, no SEA binaries)
   build:
     name: Build distribution
-    needs: build-sea
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -65,53 +55,8 @@ jobs:
           fi
           echo "Version check passed: $TOML_VERSION"
 
-      # Download SEA platform binaries into the _bin/ directory
-      # NOTE: darwin-x64 temporarily excluded (macos-13 runners unavailable)
-      - name: Download SEA binary (darwin-arm64)
-        uses: actions/download-artifact@v4
-        with:
-          name: govon-darwin-arm64
-          path: src/govon_cli/_bin/
-      - name: Download SEA binary (linux-x64)
-        uses: actions/download-artifact@v4
-        with:
-          name: govon-linux-x64
-          path: src/govon_cli/_bin/
-      - name: Download SEA binary (linux-arm64)
-        uses: actions/download-artifact@v4
-        with:
-          name: govon-linux-arm64
-          path: src/govon_cli/_bin/
-      - name: Download SEA binary (win-x64)
-        uses: actions/download-artifact@v4
-        with:
-          name: govon-win-x64
-          path: src/govon_cli/_bin/
-
-      - name: Verify SEA binaries
-        run: |
-          echo "=== SEA binaries in _bin/ ==="
-          ls -lh src/govon_cli/_bin/
-          EXPECTED=("govon-darwin-arm64" "govon-linux-x64" "govon-linux-arm64" "govon-win-x64.exe")
-          for bin in "${EXPECTED[@]}"; do
-            if [ ! -f "src/govon_cli/_bin/$bin" ]; then
-              echo "::error::Missing SEA binary: $bin"
-              exit 1
-            fi
-            echo "  ✓ $bin ($(stat -c%s "src/govon_cli/_bin/$bin" 2>/dev/null || stat -f%z "src/govon_cli/_bin/$bin") bytes)"
-          done
-
       - name: Build wheel and sdist
         run: python -m build
-
-      - name: Verify wheel contains binaries
-        run: |
-          WHEEL=$(ls dist/*.whl)
-          echo "Wheel: $WHEEL"
-          python -m zipfile -l "$WHEEL" | grep _bin/ || {
-            echo "::error::Wheel does not contain _bin/ binaries"
-            exit 1
-          }
 
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v7
@@ -119,7 +64,7 @@ jobs:
           name: python-package-distributions
           path: dist/
 
-  # Step 3: Publish to PyPI
+  # Step 2: Publish lightweight wheel to PyPI
   publish-pypi:
     name: Publish to PyPI
     needs: build
@@ -138,3 +83,40 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  # Step 3: Build SEA binaries and attach to GitHub Release
+  build-sea:
+    name: Build & attach SEA binaries
+    needs: publish-pypi
+    uses: ./.github/workflows/build-sea.yml
+    with:
+      version: ${{ github.ref_name }}
+    permissions:
+      contents: read
+
+  attach-sea:
+    name: Attach SEA to Release
+    needs: build-sea
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # needed to upload release assets
+    steps:
+      - name: Download SEA binaries
+        uses: actions/download-artifact@v4
+        with:
+          path: sea-binaries/
+          pattern: govon-*
+          merge-multiple: true
+
+      - name: List binaries
+        run: ls -lh sea-binaries/
+
+      - name: Attach to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          for binary in sea-binaries/govon-*; do
+            echo "Uploading $(basename $binary) to release $TAG..."
+            gh release upload "$TAG" "$binary" --repo "$GITHUB_REPOSITORY" --clobber || true
+          done

--- a/src/govon_cli/_launcher.py
+++ b/src/govon_cli/_launcher.py
@@ -1,8 +1,8 @@
-"""GovOn CLI launcher — finds and executes the bundled Node SEA binary.
+"""GovOn CLI launcher — finds and executes the Node SEA binary.
 
-This module is the entry point for `pip install govon`. It locates the
-platform-specific Node SEA binary bundled inside the wheel and exec's it,
-replacing the Python process entirely (on Unix) or spawning it (on Windows).
+This module is the entry point for `pip install govon`. On first run it
+downloads the platform-specific SEA binary from GitHub Releases into
+~/.govon/bin/ and then exec's it.
 """
 
 from __future__ import annotations
@@ -11,9 +11,10 @@ import os
 import platform
 import subprocess
 import sys
+import urllib.request
 from pathlib import Path
 
-# Map Python platform.machine() to binary naming convention
+# Map Python platform identifiers to binary naming convention
 _ARCH_MAP: dict[str, str] = {
     "x86_64": "x64",
     "amd64": "x64",
@@ -21,18 +22,30 @@ _ARCH_MAP: dict[str, str] = {
     "arm64": "arm64",
 }
 
-# Map Python platform.system() to binary naming convention
 _SYSTEM_MAP: dict[str, str] = {
     "windows": "win",
     "darwin": "darwin",
     "linux": "linux",
 }
 
-_SUPPORTED_PLATFORMS = "darwin-x64, darwin-arm64, linux-x64, linux-arm64, win-x64"
+_SUPPORTED_PLATFORMS = "darwin-arm64, linux-x64, linux-arm64, win-x64"
+
+# Binary cache directory
+_BIN_DIR = Path.home() / ".govon" / "bin"
 
 
-def _resolve_binary() -> Path:
-    """Locate the SEA binary for the current platform."""
+def _get_version() -> str:
+    """Read the installed package version."""
+    try:
+        from importlib.metadata import version
+
+        return version("govon")
+    except Exception:
+        return "0.0.0"
+
+
+def _resolve_platform() -> tuple[str, str]:
+    """Detect current platform and architecture."""
     system_raw = platform.system().lower()
     system = _SYSTEM_MAP.get(system_raw, system_raw)
 
@@ -47,22 +60,64 @@ def _resolve_binary() -> Path:
         )
         sys.exit(1)
 
+    return system, arch
+
+
+def _binary_name(system: str, arch: str) -> str:
+    """Construct the binary filename for the given platform."""
     name = f"govon-{system}-{arch}"
     if system == "win":
         name += ".exe"
+    return name
 
-    bin_dir = Path(__file__).parent / "_bin"
-    binary = bin_dir / name
 
-    if not binary.exists():
+def _download_binary(version: str, system: str, arch: str, dest: Path) -> None:
+    """Download the SEA binary from GitHub Releases."""
+    name = _binary_name(system, arch)
+    url = f"https://github.com/GovOn-Org/GovOn/releases/download/v{version}/{name}"
+
+    print(f"Downloading GovOn CLI binary for {system}-{arch}...", file=sys.stderr)
+    print(f"  {url}", file=sys.stderr)
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        urllib.request.urlretrieve(url, str(dest))
+    except Exception as exc:
         print(
-            f"Error: No GovOn CLI binary for {system}-{arch}.\n"
-            f"Supported platforms: {_SUPPORTED_PLATFORMS}\n"
+            f"Error: Failed to download binary: {exc}\n"
             f"Try: npm install -g govon (requires Node.js 18+)",
             file=sys.stderr,
         )
+        # Clean up partial download
+        dest.unlink(missing_ok=True)
         sys.exit(1)
 
+    # Make executable on Unix
+    if os.name != "nt":
+        dest.chmod(dest.stat().st_mode | 0o755)
+
+    print(f"  Installed to {dest}", file=sys.stderr)
+
+
+def _resolve_binary() -> Path:
+    """Locate or download the SEA binary for the current platform."""
+    version = _get_version()
+    system, arch = _resolve_platform()
+    name = _binary_name(system, arch)
+
+    # Check local cache first
+    binary = _BIN_DIR / version / name
+    if binary.exists():
+        return binary
+
+    # Check bundled _bin/ (for platform-specific wheels)
+    bundled = Path(__file__).parent / "_bin" / name
+    if bundled.exists():
+        return bundled
+
+    # Download from GitHub Releases
+    _download_binary(version, system, arch, binary)
     return binary
 
 
@@ -71,14 +126,11 @@ def main() -> None:
     binary = _resolve_binary()
 
     if os.name == "nt":
-        # Windows does not support true process replacement via os.execv.
-        # Use subprocess.run and propagate the exit code.
         result = subprocess.run([str(binary), *sys.argv[1:]])
         sys.exit(result.returncode)
     else:
-        # Make executable on Unix (wheels may strip execute bits)
+        # Ensure executable
         mode = binary.stat().st_mode
         if not (mode & 0o111):
             binary.chmod(mode | 0o755)
-        # Replace the Python process entirely
         os.execv(str(binary), [str(binary)] + sys.argv[1:])


### PR DESCRIPTION
PyPI 100MB limit exceeded. Wheel now contains only the launcher. SEA binaries download on first run from GitHub Releases.