### PR TITLE
chore: update homebrew formula to 1.4.8

### DIFF
--- a/homebrew/govon.rb
+++ b/homebrew/govon.rb
@@ -6,8 +6,8 @@ class Govon < Formula
 
   desc "Agentic CLI shell for Korean public-sector civil complaint workflows"
   homepage "https://github.com/GovOn-Org/GovOn"
-  url "https://files.pythonhosted.org/packages/30/b8/62725992650091af305325ee5c5039a09f850b50d7ead29020ef74252734/govon-1.3.0.tar.gz"
-  sha256 "fbcd019c7aa4337007058dca48d55bde0c14cdb8f450818aec72ed8d6ce12356"
+  url "https://files.pythonhosted.org/packages/54/c2/bde43626756c1e9e01976833938e36f47e20c421194b96f35718ba67c30e/govon-1.4.8.tar.gz"
+  sha256 "a55faae190ccd83b8579ae70525faf998797ae353d54d5162ad3077231ea19e6"
   license "MIT"
 
   depends_on "python@3.12"
@@ -50,36 +50,6 @@ class Govon < Formula
   resource "loguru" do
     url "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz"
     sha256 "19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6"
-  end
-
-  resource "rich" do
-    url "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz"
-    sha256 "b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b"
-  end
-
-  resource "pygments" do
-    url "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz"
-    sha256 "6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"
-  end
-
-  resource "markdown-it-py" do
-    url "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz"
-    sha256 "cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3"
-  end
-
-  resource "mdurl" do
-    url "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz"
-    sha256 "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"
-  end
-
-  resource "prompt-toolkit" do
-    url "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz"
-    sha256 "28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855"
-  end
-
-  resource "wcwidth" do
-    url "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz"
-    sha256 "cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159"
   end
 
   def install


### PR DESCRIPTION
Update URL, SHA256, remove dropped CLI deps (rich, prompt-toolkit, etc).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded govon from version 1.3.0 to 1.4.8 in the Homebrew formula with updated package source and verification checksum.
  * Simplified the Homebrew installation package by removing previously bundled Python dependencies for text formatting, syntax highlighting, and prompting utilities, while retaining essential networking and utility libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->