### PR TITLE
fix(tui): dynamic markdown width on terminal resize

### DIFF
--- a/packages/npm/src/components/MarkdownView.tsx
+++ b/packages/npm/src/components/MarkdownView.tsx
@@ -1,18 +1,7 @@
 import React, { useMemo } from 'react';
-import { Box, Text } from 'ink';
-import { marked } from 'marked';
+import { Box, Text, useStdout } from 'ink';
+import { Marked } from 'marked';
 import { markedTerminal } from 'marked-terminal';
-
-// Configure marked with the terminal renderer once at module load time.
-// markedTerminal() returns a marked extension object compatible with the
-// marked.use() API introduced in marked v5+ and still current in v15.
-marked.use(
-  markedTerminal({
-    reflowText: true,
-    width: process.stdout.columns || 80,
-    showSectionPrefix: false,
-  }),
-);
 
 interface MarkdownViewProps {
   /** Raw markdown text to render. */
@@ -28,18 +17,30 @@ function stripAnsi(str: string): string {
 }
 
 export function MarkdownView({ content, streaming = false }: MarkdownViewProps) {
+  const { stdout } = useStdout();
+  const width = stdout?.columns ?? 80;
+
   const rendered = useMemo(() => {
     if (!content) return '';
     try {
+      // Create a fresh Marked instance with the current terminal width so that
+      // re-renders after a terminal resize use the correct column count.
+      const md = new Marked(
+        markedTerminal({
+          reflowText: true,
+          width,
+          showSectionPrefix: false,
+        }),
+      );
       // marked.parse() is synchronous when the terminal renderer extension is active.
-      const result = marked.parse(stripAnsi(content));
+      const result = md.parse(stripAnsi(content));
       // Remove trailing newlines produced by marked's block-level output.
       return typeof result === 'string' ? result.trimEnd() : '';
     } catch {
       // Fall back to raw text so the UI never goes blank on a parse error.
       return content;
     }
-  }, [content]);
+  }, [content, width]);
 
   if (!rendered) return null;
 


### PR DESCRIPTION
## Summary
- Fix terminal resize rendering by making markdown renderer width dynamic
- Replace static module-level `marked.use()` with per-render `new Marked()` instance
- Use `useStdout()` hook to reactively track terminal column width

## Changes
- `packages/npm/src/components/MarkdownView.tsx`: Use `Marked` class instead of singleton, add `useStdout()` for reactive width, memoize on `[content, width]`

## Test plan
- [ ] Run `govon` CLI and resize terminal window — markdown content should reflow correctly
- [ ] Verify separator line width updates on resize
- [ ] Check that streaming content renders properly during resize

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Markdown rendering now dynamically adapts to terminal width changes for better responsiveness and layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->