### PR TITLE
fix(tui): replace ink-use-stdout-dimensions with inline hook — ESM compat

### DIFF
--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -45,7 +45,6 @@
     "ink": "^5.2.0",
     "ink-spinner": "^5.0.0",
     "ink-text-input": "^6.0.0",
-    "ink-use-stdout-dimensions": "^1.0.5",
     "marked": "^15.0.0",
     "marked-terminal": "^7.3.0",
     "react": "^18.3.1",

--- a/packages/npm/src/components/MarkdownView.tsx
+++ b/packages/npm/src/components/MarkdownView.tsx
@@ -1,6 +1,5 @@
-import React, { useMemo } from 'react';
-import { Box, Text } from 'ink';
-import useStdoutDimensions from 'ink-use-stdout-dimensions';
+import React, { useMemo, useState, useEffect } from 'react';
+import { Box, Text, useStdout } from 'ink';
 import { Marked } from 'marked';
 import { markedTerminal } from 'marked-terminal';
 
@@ -17,9 +16,26 @@ function stripAnsi(str: string): string {
   return str.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '');
 }
 
+/**
+ * Subscribe to stdout column changes via the "resize" event.
+ * Unlike useStdout() alone, this triggers a React state update on resize.
+ */
+function useColumns(): number {
+  const { stdout } = useStdout();
+  const [columns, setColumns] = useState(stdout?.columns ?? 80);
+
+  useEffect(() => {
+    if (!stdout) return;
+    const onResize = () => setColumns(stdout.columns);
+    stdout.on('resize', onResize);
+    return () => { stdout.off('resize', onResize); };
+  }, [stdout]);
+
+  return columns;
+}
+
 export function MarkdownView({ content, streaming = false }: MarkdownViewProps) {
-  const [columns] = useStdoutDimensions();
-  const width = columns ?? 80;
+  const width = useColumns();
 
   const rendered = useMemo(() => {
     if (!content) return '';


### PR DESCRIPTION
## Summary
- Remove `ink-use-stdout-dimensions` package (CJS, incompatible with Ink v5 ESM)
- Replace with inline `useColumns()` hook using `useStdout()` + `stdout.on('resize')` — identical logic

## Root cause
`ink-use-stdout-dimensions` is built as CJS and calls `require('ink')`, but Ink v5 is ESM-only with top-level await → runtime crash on `govon` startup.

## Test plan
- [ ] `govon` starts without ESM error
- [ ] Terminal resize reflows markdown content correctly