### PR TITLE
chore: bump to 1.6.1 — fix ESM compat crash

### DIFF
--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govon",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "GovOn CLI — AX platform TUI for unified government infrastructure powered by React + Ink",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "govon"
-version = "1.6.0"
+version = "1.6.1"
 description = "GovOn Agentic Shell — CLI client for the GovOn AX national infrastructure platform"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- Bump to 1.6.1 — hotfix for startup crash caused by ink-use-stdout-dimensions ESM incompatibility (#700)

## Test plan
- [ ] `npm install -g govon@latest && govon` starts without ESM error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.6.1 for npm and Python packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->