### PR TITLE
fix: replace AsyncSqliteSaver with MemorySaver + 1-min session TTL

### DIFF
--- a/src/inference/api_server.py
+++ b/src/inference/api_server.py
@@ -153,10 +153,8 @@ class vLLMEngineManager:
         self.agent_manager = AgentManager(AGENTS_DIR)
         self._api_lookup_action = None  # MinwonAnalysisAction (지연 초기화)
         self._domain_adapter_fn = None  # Domain adapter generation closure (lazy init)
-        self.graph = None  # LangGraph CompiledGraph (v2 엔드포인트용)
-        self.graph_v3 = None  # v3 ReAct graph (v3 엔드포인트용)
-        self._checkpointer_ctx = None  # AsyncSqliteSaver 컨텍스트 매니저 (lifespan에서 관리)
-        self._sync_checkpointer_conn = None  # SqliteSaver용 sqlite3 connection (leak 방지)
+        self.graph = None  # LangGraph CompiledGraph (v2 endpoint)
+        self.graph_v3 = None  # v3 ReAct graph (v3 endpoint)
         # session_id 단위 비동기 락: 동시 요청 race condition 방지
         self._session_locks: dict[str, asyncio.Lock] = {}
         self._init_tools()
@@ -598,24 +596,19 @@ class vLLMEngineManager:
             domain_adapter_fn=self._domain_adapter_fn,
         )
 
-    def _init_graph_with_async_checkpointer(self, checkpointer: object) -> None:
-        """lifespan에서 AsyncSqliteSaver가 준비된 후 graph를 재구성한다."""
-        self._init_graph(checkpointer=checkpointer)
-
     def _init_graph(self, checkpointer: Optional[object] = None) -> None:
-        """LangGraph StateGraph를 초기화한다.
+        """Initialize the LangGraph StateGraph.
 
-        v4 아키텍처: ReAct + ToolNode 기반.
-        LLM이 자율적으로 도구 호출을 결정한다.
+        v4 architecture: ReAct + ToolNode.  The LLM decides tool calls autonomously.
 
         Parameters
         ----------
         checkpointer : optional
-            외부에서 주입할 LangGraph checkpointer.
-            None이면 SqliteSaver(동기 sqlite3)를 시도하고,
-            import 실패 시 MemorySaver로 fallback한다.
-            SqliteSaver DB 경로는 SessionStore DB와 같은 디렉터리에
-            ``langgraph_checkpoints.db``로 생성된다 (관심사 분리).
+            LangGraph checkpointer injected from the outside.
+            When None (default), a MemorySaver is used — no file handles, no
+            persistent connections, safe for HF Spaces sleep mode.
+            Pass an explicit checkpointer only when durable persistence is required
+            (e.g. CHECKPOINTER=sqlite env var in local/self-hosted deployments).
         """
         try:
             from src.inference.graph.builder import build_govon_graph
@@ -667,15 +660,17 @@ class vLLMEngineManager:
                 max_tokens=_llm_max_tokens,
             )
 
-        # checkpointer가 외부에서 주입되지 않으면 SqliteSaver를 시도한다.
+        # Use MemorySaver by default — no file handles, no persistent connections.
+        # Opt-in to SQLite via CHECKPOINTER=sqlite for local/self-hosted deployments.
         if checkpointer is None:
-            checkpointer, conn = _build_sync_sqlite_checkpointer(self.session_store.db_path)
-            if self._sync_checkpointer_conn is not None:
-                try:
-                    self._sync_checkpointer_conn.close()
-                except Exception:
-                    pass
-            self._sync_checkpointer_conn = conn
+            _cp_mode = os.getenv("CHECKPOINTER", "memory").lower()
+            if _cp_mode == "sqlite":
+                checkpointer, _ = _build_sync_sqlite_checkpointer(self.session_store.db_path)
+            else:
+                from langgraph.checkpoint.memory import MemorySaver
+
+                checkpointer = MemorySaver()
+                logger.info("LangGraph checkpointer: MemorySaver (in-memory, no file handles)")
 
         self.graph = build_govon_graph(
             llm=llm,
@@ -708,45 +703,30 @@ class vLLMEngineManager:
 def _build_sync_sqlite_checkpointer(
     session_db_path: str,
 ) -> tuple:
-    """SqliteSaver(동기) 또는 MemorySaver(fallback)를 반환한다.
+    """Build a SqliteSaver checkpointer for opt-in durable persistence.
 
-    LangGraph checkpointer용 SQLite DB는 SessionStore의 sessions.sqlite3와
-    같은 디렉터리에 별도 파일 ``langgraph_checkpoints.db``로 생성한다.
-    두 DB를 분리함으로써 관심사(세션 메타 vs. graph 체크포인트)를 명확히 구분한다.
-
-    SqliteSaver는 프로세스 재시작 후에도 interrupt 상태를 SQLite에서 복원하므로
-    MemorySaver와 달리 재시작-안전(restart-safe)하다.
+    Only called when CHECKPOINTER=sqlite is set explicitly.  The SQLite DB is
+    placed in the same directory as sessions.sqlite3 but in a separate file
+    (langgraph_checkpoints.db) to keep concerns separated.
 
     Parameters
     ----------
     session_db_path : str
-        SessionStore가 사용 중인 sessions.sqlite3 파일 경로.
-        이 경로의 부모 디렉터리에 langgraph_checkpoints.db를 생성한다.
+        Path to the SessionStore sessions.sqlite3 file.
+        langgraph_checkpoints.db is created in the same parent directory.
 
     Returns
     -------
-    tuple[SqliteSaver | MemorySaver, sqlite3.Connection | None]
-        (checkpointer, conn) 튜플.
-        SqliteSaver 사용 시 conn은 열린 sqlite3.Connection이며,
-        호출자가 적절한 시점에 close해야 한다.
-        MemorySaver fallback 시 conn은 None이다.
+    tuple[SqliteSaver, sqlite3.Connection]
+        (checkpointer, conn).  The caller is responsible for closing conn.
     """
     cp_db_path = str(Path(session_db_path).parent / "langgraph_checkpoints.db")
-    try:
-        from langgraph.checkpoint.sqlite import SqliteSaver
+    from langgraph.checkpoint.sqlite import SqliteSaver
 
-        conn = __import__("sqlite3").connect(cp_db_path, check_same_thread=False)
-        saver = SqliteSaver(conn)
-        logger.info(f"LangGraph checkpointer: SqliteSaver ({cp_db_path})")
-        return saver, conn
-    except ImportError:
-        logger.warning(
-            "langgraph-checkpoint-sqlite 미설치 — MemorySaver로 fallback합니다. "
-            "프로세스 재시작 시 interrupt 상태가 소멸됩니다."
-        )
-        from langgraph.checkpoint.memory import MemorySaver
-
-        return MemorySaver(), None
+    conn = __import__("sqlite3").connect(cp_db_path, check_same_thread=False)
+    saver = SqliteSaver(conn)
+    logger.info(f"LangGraph checkpointer: SqliteSaver ({cp_db_path})")
+    return saver, conn
 
 
 manager = vLLMEngineManager()
@@ -754,48 +734,32 @@ manager = vLLMEngineManager()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """FastAPI lifespan: 모델/인덱스 초기화 및 graph 단일 초기화.
+    """FastAPI lifespan: model/index initialization and single graph init.
 
-    AsyncSqliteSaver가 사용 가능하면 그것으로 한 번만 초기화한다.
-    import 실패 시 SqliteSaver(동기) 또는 MemorySaver로 fallback한다.
-    graph 이중 초기화를 방지하기 위해 _init_graph()를 한 번만 호출한다.
-    shutdown 시 httpx AsyncClient를 반드시 종료하여 leak을 방지한다.
+    Uses MemorySaver by default — no SQLite file handles, no persistent
+    connections, allowing HF Spaces to enter sleep mode when idle.
+
+    To opt-in to durable SQLite checkpointing (local / self-hosted only):
+        CHECKPOINTER=sqlite
+
+    Graph is initialized exactly once to prevent double-init.
+    httpx AsyncClient is closed on shutdown to prevent resource leaks.
     """
     await manager.initialize()
 
-    # API_KEY 미설정 경고 (운영 프로필에서 명시적으로 알림)
     if _API_KEY is None and runtime_config.profile.value not in ("local",):
-        logger.warning("API_KEY 미설정: 운영 환경에서는 반드시 API_KEY 환경변수를 설정하세요.")
+        logger.warning(
+            "API_KEY not set: set the API_KEY environment variable in production."
+        )
 
-    # checkpointer 결정 후 graph를 한 번만 초기화 (이중 초기화 방지)
-    async_cp_db = str(Path(manager.session_store.db_path).parent / "langgraph_checkpoints.db")
-    try:
-        from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
-
-        async with AsyncSqliteSaver.from_conn_string(async_cp_db) as async_saver:
-            manager._init_graph(checkpointer=async_saver)
-            manager._checkpointer_ctx = async_saver
-            logger.info(f"LangGraph: AsyncSqliteSaver ({async_cp_db})")
-            try:
-                yield
-            finally:
-                manager._checkpointer_ctx = None
-                if manager._http_client:
-                    await manager._http_client.aclose()
-                    logger.info("httpx AsyncClient 종료 완료")
-        return
-    except ImportError:
-        pass
-
-    # fallback: SqliteSaver(동기) 또는 MemorySaver
+    # _init_graph() selects MemorySaver or SQLite based on CHECKPOINTER env var.
     manager._init_graph()
-    logger.info("LangGraph: SqliteSaver(동기) 또는 MemorySaver로 실행합니다.")
     try:
         yield
     finally:
         if manager._http_client:
             await manager._http_client.aclose()
-            logger.info("httpx AsyncClient 종료 완료")
+            logger.info("httpx AsyncClient closed")
 
 
 app = FastAPI(
@@ -820,6 +784,20 @@ if ALLOWED_ORIGINS and ALLOWED_ORIGINS[0]:
 if _RATE_LIMIT_AVAILABLE and limiter is not None:
     app.state.limiter = limiter
     app.add_middleware(SlowAPIMiddleware)
+
+
+# ---------------------------------------------------------------------------
+# Idle-time tracker — updated on every request so HF Spaces can sleep when idle
+# ---------------------------------------------------------------------------
+
+_last_request_time: float = time.monotonic()
+
+
+@app.middleware("http")
+async def _track_request_time(request: Request, call_next):
+    global _last_request_time
+    _last_request_time = time.monotonic()
+    return await call_next(request)
 
 
 @app.get("/health")

--- a/src/inference/session_context.py
+++ b/src/inference/session_context.py
@@ -1,20 +1,27 @@
-"""세션 컨텍스트 및 SQLite 기반 세션 저장소.
+"""Session context and SQLite-backed session store.
 
-GovOn Shell MVP의 세션 모델은 다음을 저장한다.
+The GovOn Shell MVP session model stores:
 
-- 대화 기록
-- tool 사용 기록
-- task loop 단위 실행 로그
+- Conversation history
+- Tool-use records
+- Task-loop execution logs
 
-초안 버전, 선택 근거 목록 같은 무거운 상태는 제품 기본 저장 범위에서 제외한다.
+Heavy state such as draft versions and selection rationale lists is excluded
+from the default persistence scope.
 
 Schema versioning
 -----------------
-_init_db()는 schema_version 테이블을 통해 순차 migration을 관리한다.
-현재 최신 버전: SCHEMA_VERSION = 2
+_init_db() manages sequential migrations via a schema_version table.
+Current latest version: SCHEMA_VERSION = 2
 
 Migration history:
-  v1 → v2: tool_runs에 graph_run_request_id 컬럼 추가 (이전에는 ad-hoc ALTER TABLE)
+  v1 -> v2: add graph_run_request_id column to tool_runs (previously ad-hoc ALTER TABLE)
+
+Session TTL
+-----------
+SESSION_TTL_SECONDS controls how long an in-memory session lives after the last
+activity.  Expired sessions are evicted on the next get_or_create() / get() call.
+Set via GOVON_SESSION_TTL env var (default: 60 seconds).
 """
 
 from __future__ import annotations
@@ -32,7 +39,12 @@ from typing import Any, Callable, Dict, List, Optional
 from loguru import logger
 
 SCHEMA_VERSION = 2
-"""현재 SessionStore SQLite 스키마 버전."""
+"""Current SessionStore SQLite schema version."""
+
+# ---------------------------------------------------------------------------
+# Session TTL — configurable via env var; default 60 s
+# ---------------------------------------------------------------------------
+SESSION_TTL_SECONDS: int = int(os.getenv("GOVON_SESSION_TTL", "60"))
 
 
 def _default_session_db_path() -> str:
@@ -82,7 +94,7 @@ class GraphRunRecord:
 
 @dataclass
 class SessionContext:
-    """세션 기반 대화/도구 기록 컨텍스트."""
+    """Session-scoped conversation and tool-use context."""
 
     session_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     max_history: int = 20
@@ -91,19 +103,29 @@ class SessionContext:
     graph_runs: List[GraphRunRecord] = field(default_factory=list)
     metadata: Dict[str, Any] = field(default_factory=dict)
     created_at: float = field(default_factory=time.time)
+    last_activity_at: float = field(default_factory=time.time)
     _persist_turn: Optional[Callable[[ConversationTurn], None]] = field(default=None, repr=False)
     _persist_tool_run: Optional[Callable[[ToolRunRecord], None]] = field(default=None, repr=False)
     _persist_graph_run: Optional[Callable[[GraphRunRecord], None]] = field(default=None, repr=False)
     _persist_metadata: Optional[Callable[[str, Any], None]] = field(default=None, repr=False)
 
+    def touch(self) -> None:
+        """Update last_activity_at to the current time."""
+        self.last_activity_at = time.time()
+
+    def is_expired(self, ttl_seconds: int = SESSION_TTL_SECONDS) -> bool:
+        """Return True if the session has been idle longer than ttl_seconds."""
+        return (time.time() - self.last_activity_at) > ttl_seconds
+
     def add_turn(self, role: str, content: str, **kwargs: Any) -> None:
-        """대화 턴을 추가하고 필요 시 영속화한다."""
+        """Append a conversation turn and persist if a callback is registered."""
+        self.touch()
         turn = ConversationTurn(role=role, content=content, metadata=kwargs)
         self.conversations.append(turn)
         if len(self.conversations) > self.max_history:
             removed = len(self.conversations) - self.max_history
             self.conversations = self.conversations[removed:]
-            logger.debug(f"세션 {self.session_id}: 오래된 대화 {removed}턴 제거")
+            logger.debug(f"Session {self.session_id}: removed {removed} old turns")
 
         if self._persist_turn:
             self._persist_turn(turn)
@@ -117,7 +139,8 @@ class SessionContext:
         error: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
-        """도구 실행 로그를 추가하고 필요 시 영속화한다."""
+        """Append a tool-run record and persist if a callback is registered."""
+        self.touch()
         record = ToolRunRecord(
             tool=tool,
             graph_run_request_id=graph_run_request_id,
@@ -151,7 +174,8 @@ class SessionContext:
         started_at: Optional[float] = None,
         completed_at: Optional[float] = None,
     ) -> None:
-        """task loop 단위 실행 로그를 추가하고 필요 시 영속화한다."""
+        """Append or update a graph-run record and persist if a callback is registered."""
+        self.touch()
         record = GraphRunRecord(
             request_id=request_id,
             plan_summary=plan_summary,
@@ -219,11 +243,18 @@ class SessionContext:
 
 
 class SessionStore:
-    """SQLite 기반 세션 저장소."""
+    """SQLite-backed session store with in-memory TTL eviction.
+
+    Sessions are tracked in ``_live_sessions`` (a dict keyed by session_id).
+    On every get_or_create() / get() call, expired entries (idle > SESSION_TTL_SECONDS)
+    are evicted first via cleanup_expired().
+    """
 
     def __init__(self, db_path: Optional[str] = None, max_history: int = 20) -> None:
         self._db_path = db_path or os.getenv("GOVON_SESSION_DB") or _default_session_db_path()
         self._max_history = max_history
+        # In-memory activity registry: session_id -> last_activity_at timestamp
+        self._live_sessions: Dict[str, float] = {}
         self._init_db()
 
     @property
@@ -662,21 +693,58 @@ class SessionStore:
             _persist_metadata=lambda key, value: self._upsert_metadata(session_id, key, value),
         )
 
+    def cleanup_expired(self, ttl_seconds: int = SESSION_TTL_SECONDS) -> int:
+        """Remove all sessions that have been idle longer than ttl_seconds.
+
+        Returns the number of sessions evicted from the in-memory registry.
+        This does NOT delete rows from SQLite — SQLite is the durable store.
+        """
+        now = time.time()
+        expired = [
+            sid for sid, last in list(self._live_sessions.items())
+            if (now - last) > ttl_seconds
+        ]
+        for sid in expired:
+            self._live_sessions.pop(sid, None)
+        if expired:
+            logger.debug(f"SessionStore: evicted {len(expired)} expired session(s) from memory")
+        return len(expired)
+
+    def _touch(self, session_id: str) -> None:
+        """Record the current time as the last-activity timestamp for session_id."""
+        self._live_sessions[session_id] = time.time()
+
+    def _is_expired(self, session_id: str, ttl_seconds: int = SESSION_TTL_SECONDS) -> bool:
+        """Return True if session_id is tracked and its idle time exceeds ttl_seconds."""
+        last = self._live_sessions.get(session_id)
+        if last is None:
+            # Never seen in this process — treated as expired (will be re-loaded from DB)
+            return False
+        return (time.time() - last) > ttl_seconds
+
     def get_or_create(
         self,
         session_id: Optional[str] = None,
         max_history: Optional[int] = None,
     ) -> SessionContext:
+        self.cleanup_expired()
         history_limit = max_history or self._max_history
         if session_id:
-            existing = self._build_context(session_id, history_limit)
-            if existing is not None:
-                return existing
+            # If session is tracked but expired, drop it and create a fresh one
+            if self._is_expired(session_id):
+                logger.info(f"Session {session_id} expired — starting fresh")
+                self._live_sessions.pop(session_id, None)
+            else:
+                existing = self._build_context(session_id, history_limit)
+                if existing is not None:
+                    self._touch(session_id)
+                    return existing
 
         sid = session_id or str(uuid.uuid4())
         created_at = time.time()
         self._ensure_session(sid, created_at=created_at)
-        logger.info(f"새 세션 생성: {sid}")
+        self._touch(sid)
+        logger.info(f"New session created: {sid}")
         return SessionContext(
             session_id=sid,
             max_history=history_limit,
@@ -688,7 +756,15 @@ class SessionStore:
         )
 
     def get(self, session_id: str) -> Optional[SessionContext]:
-        return self._build_context(session_id, self._max_history)
+        self.cleanup_expired()
+        if self._is_expired(session_id):
+            logger.info(f"Session {session_id} expired — returning None")
+            self._live_sessions.pop(session_id, None)
+            return None
+        ctx = self._build_context(session_id, self._max_history)
+        if ctx is not None:
+            self._touch(session_id)
+        return ctx
 
     def delete(self, session_id: str) -> bool:
         with closing(self._connect()) as conn, conn:


### PR DESCRIPTION
## Related Issue
-

## Background
`AsyncSqliteSaver` held open SQLite file connections for the entire server lifetime.
HF Spaces detects these open handles as server activity and never enters sleep mode.
Replacing with `MemorySaver` (in-memory, no file handles) eliminates the root cause.
A 1-minute session TTL ensures idle sessions are evicted from memory automatically.

## Key Changes
- `src/inference/api_server.py`
  - Remove `AsyncSqliteSaver`, `_checkpointer_ctx`, `_sync_checkpointer_conn` entirely
  - `lifespan` simplified: calls `_init_graph()` directly, no async context manager needed
  - `_init_graph()`: default checkpointer is `MemorySaver`; opt-in to SQLite via `CHECKPOINTER=sqlite`
  - Add `_last_request_time` + HTTP middleware to track last-request timestamp for idle detection
- `src/inference/session_context.py`
  - Add `SESSION_TTL_SECONDS = 60` (configurable via `GOVON_SESSION_TTL` env var)
  - `SessionContext`: add `last_activity_at` field, `touch()`, `is_expired()` methods
  - `SessionContext.add_turn/add_tool_run/add_graph_run`: call `touch()` on every activity
  - `SessionStore`: add `_live_sessions` in-memory registry, `cleanup_expired()`, `_touch()`, `_is_expired()`
  - `get_or_create()` / `get()`: evict expired sessions before serving; call `cleanup_expired()` on every access

## Test Results
- [ ] Local test complete
- [ ] Existing functionality verified

## Additional Notes
Backward compatibility: `CHECKPOINTER=sqlite` env var restores durable SQLite checkpointing for local/self-hosted deployments that need restart-safe interrupt state.

---

## Merge Checklist
- [ ] At least one code review approval
- [ ] CODEOWNERS (team lead) final approval
- [ ] All review comments resolved

## Reviewer Guide

| Tag | Meaning | Example |
|-----|---------|---------|
| `[MUST]` | Must fix (security, bug, performance issue) | `[MUST] API key is exposed in logs.` |
| `[SHOULD]` | Strongly recommended (code quality, maintainability) | `[SHOULD] This logic should be extracted into a separate function.` |
| `[NITS]` | Minor improvement (style, naming) | `[NITS] \`parsed_output\` is clearer than \`result\` as a variable name.` |
| `[QUESTION]` | Question for understanding | `[QUESTION] Can this condition ever be always True?` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session timeout functionality now available with configurable TTL (default 60 seconds); expired sessions are automatically cleaned up.
  * Request activity tracking added to support Hugging Face Spaces idle behavior.

* **Refactor**
  * Simplified checkpointing behavior: in-memory storage is now default, with explicit SQLite option available when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->