### PR TITLE
fix(ci): split offline package to fit GitHub Release 2GB limit

### DIFF
--- a/.github/workflows/offline-package.yml
+++ b/.github/workflows/offline-package.yml
@@ -36,23 +36,32 @@ jobs:
 
       - name: Build offline deployment package
         run: |
-          tar czf govon-offline-package.tar.gz \
-            govon-image.tar.gz \
+          # Package deployment scripts separately (small, always single file)
+          tar czf govon-offline-scripts.tar.gz \
             deploy/env/.env.airgap.example \
             scripts/offline-deploy.sh \
             scripts/smoke-test.sh \
             deploy/compose/docker-compose.offline.yml
 
+          # Split Docker image into chunks under 1.9GB for GitHub Release limit
+          split -b 1900m govon-image.tar.gz govon-image.tar.gz.part-
+          ls -lh govon-image.tar.gz.part-* govon-offline-scripts.tar.gz
+
       - name: Upload to release
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:
-          files: govon-offline-package.tar.gz
+          files: |
+            govon-offline-scripts.tar.gz
+            govon-image.tar.gz.part-*
+          overwrite_files: true
 
       - name: Upload as artifact
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v7
         with:
           name: govon-offline-package
-          path: govon-offline-package.tar.gz
+          path: |
+            govon-offline-scripts.tar.gz
+            govon-image.tar.gz.part-*
           retention-days: 7

--- a/scripts/offline-deploy.sh
+++ b/scripts/offline-deploy.sh
@@ -61,12 +61,17 @@ else
 fi
 
 # 4. 이미지 파일 확인 및 로드
-if [ ! -f "$IMAGE_FILE" ]; then
-    echo "[ERROR] 이미지 파일을 찾을 수 없습니다: $IMAGE_FILE"
+# Support both single-file and split-file formats
+if [ -f "$IMAGE_FILE" ]; then
+    echo "Docker 이미지 로드 중... (시간이 소요될 수 있습니다)"
+    gunzip -c "$IMAGE_FILE" | docker load
+elif ls "${IMAGE_FILE}.part-"* &>/dev/null 2>&1; then
+    echo "분할 이미��� 파일 감지됨. 재결합 후 로드합니다..."
+    cat "${IMAGE_FILE}.part-"* | gunzip | docker load
+else
+    echo "[ERROR] 이미지 파일을 찾을 수 없습니다: $IMAGE_FILE 또는 ${IMAGE_FILE}.part-*"
     exit 1
 fi
-echo "Docker 이미지 로드 중... (시간이 소요될 수 있습니다)"
-gunzip -c "$IMAGE_FILE" | docker load
 echo "[OK] 이미지 로드 완료"
 
 # 5. 환경변수 템플릿 준비


### PR DESCRIPTION
## Summary
- Split Docker image archive into 1.9GB chunks for GitHub Release upload (2GB limit)
- Update `offline-deploy.sh` to support both single-file and split-file formats

## Root cause
`docker save | gzip` produces >2GB archive → GitHub Release asset upload fails with `size must be less than 2147483648`

## Test plan
- [ ] Offline Package Build workflow completes without upload error
- [ ] `offline-deploy.sh` correctly reassembles split image files