### PR TITLE
fix: replace AsyncSqliteSaver with MemorySaver + 1-min session TTL

### DIFF
--- a/src/inference/api_server.py
+++ b/src/inference/api_server.py
@@ -153,14 +153,12 @@ class vLLMEngineManager:
         self.agent_manager = AgentManager(AGENTS_DIR)
         self._api_lookup_action = None  # MinwonAnalysisAction (지연 초기화)
         self._domain_adapter_fn = None  # Domain adapter generation closure (lazy init)
-        self.graph = None  # LangGraph CompiledGraph (v2 엔드포인트용)
-        self.graph_v3 = None  # v3 ReAct graph (v3 엔드포인트용)
-        self._checkpointer_ctx = None  # AsyncSqliteSaver 컨텍스트 매니저 (lifespan에서 관리)
-        self._sync_checkpointer_conn = None  # SqliteSaver용 sqlite3 connection (leak 방지)
-        # session_id 단위 비동기 락: 동시 요청 race condition 방지
+        self.graph = None  # LangGraph CompiledGraph (v2 endpoint)
+        self.graph_v3 = None  # v3 ReAct graph (v3 endpoint)
+        # session_id-level async locks: prevent race conditions on concurrent requests
         self._session_locks: dict[str, asyncio.Lock] = {}
         self._init_tools()
-        # _init_graph()는 lifespan()에서 호출 — 모듈 로드 시점 실행 방지
+        # _init_graph() is called from lifespan() — avoid running at module import time
 
     def get_session_lock(self, session_id: str) -> asyncio.Lock:
         """session_id 단위 비동기 락을 반환한다. 동시 요청 race condition 방지."""
@@ -598,24 +596,17 @@ class vLLMEngineManager:
             domain_adapter_fn=self._domain_adapter_fn,
         )
 
-    def _init_graph_with_async_checkpointer(self, checkpointer: object) -> None:
-        """lifespan에서 AsyncSqliteSaver가 준비된 후 graph를 재구성한다."""
-        self._init_graph(checkpointer=checkpointer)
-
     def _init_graph(self, checkpointer: Optional[object] = None) -> None:
-        """LangGraph StateGraph를 초기화한다.
+        """Initialize the LangGraph StateGraph.
 
-        v4 아키텍처: ReAct + ToolNode 기반.
-        LLM이 자율적으로 도구 호출을 결정한다.
+        v4 architecture: ReAct + ToolNode.  The LLM autonomously decides tool
+        calls.
 
         Parameters
         ----------
         checkpointer : optional
-            외부에서 주입할 LangGraph checkpointer.
-            None이면 SqliteSaver(동기 sqlite3)를 시도하고,
-            import 실패 시 MemorySaver로 fallback한다.
-            SqliteSaver DB 경로는 SessionStore DB와 같은 디렉터리에
-            ``langgraph_checkpoints.db``로 생성된다 (관심사 분리).
+            LangGraph checkpointer to inject.  When None a fresh MemorySaver is
+            used — no file handles, no persistent SQLite connections.
         """
         try:
             from src.inference.graph.builder import build_govon_graph
@@ -667,15 +658,14 @@ class vLLMEngineManager:
                 max_tokens=_llm_max_tokens,
             )
 
-        # checkpointer가 외부에서 주입되지 않으면 SqliteSaver를 시도한다.
+        # Use MemorySaver when no checkpointer is injected from outside.
+        # MemorySaver holds no file handles and keeps no persistent connections,
+        # which allows HF Spaces to transition to sleep after idle periods.
         if checkpointer is None:
-            checkpointer, conn = _build_sync_sqlite_checkpointer(self.session_store.db_path)
-            if self._sync_checkpointer_conn is not None:
-                try:
-                    self._sync_checkpointer_conn.close()
-                except Exception:
-                    pass
-            self._sync_checkpointer_conn = conn
+            from langgraph.checkpoint.memory import MemorySaver
+
+            checkpointer = MemorySaver()
+            logger.info("LangGraph checkpointer: MemorySaver (in-memory, no persistent files)")
 
         self.graph = build_govon_graph(
             llm=llm,
@@ -705,48 +695,9 @@ class vLLMEngineManager:
             self.graph_v3 = None
 
 
-def _build_sync_sqlite_checkpointer(
-    session_db_path: str,
-) -> tuple:
-    """SqliteSaver(동기) 또는 MemorySaver(fallback)를 반환한다.
-
-    LangGraph checkpointer용 SQLite DB는 SessionStore의 sessions.sqlite3와
-    같은 디렉터리에 별도 파일 ``langgraph_checkpoints.db``로 생성한다.
-    두 DB를 분리함으로써 관심사(세션 메타 vs. graph 체크포인트)를 명확히 구분한다.
-
-    SqliteSaver는 프로세스 재시작 후에도 interrupt 상태를 SQLite에서 복원하므로
-    MemorySaver와 달리 재시작-안전(restart-safe)하다.
-
-    Parameters
-    ----------
-    session_db_path : str
-        SessionStore가 사용 중인 sessions.sqlite3 파일 경로.
-        이 경로의 부모 디렉터리에 langgraph_checkpoints.db를 생성한다.
-
-    Returns
-    -------
-    tuple[SqliteSaver | MemorySaver, sqlite3.Connection | None]
-        (checkpointer, conn) 튜플.
-        SqliteSaver 사용 시 conn은 열린 sqlite3.Connection이며,
-        호출자가 적절한 시점에 close해야 한다.
-        MemorySaver fallback 시 conn은 None이다.
-    """
-    cp_db_path = str(Path(session_db_path).parent / "langgraph_checkpoints.db")
-    try:
-        from langgraph.checkpoint.sqlite import SqliteSaver
-
-        conn = __import__("sqlite3").connect(cp_db_path, check_same_thread=False)
-        saver = SqliteSaver(conn)
-        logger.info(f"LangGraph checkpointer: SqliteSaver ({cp_db_path})")
-        return saver, conn
-    except ImportError:
-        logger.warning(
-            "langgraph-checkpoint-sqlite 미설치 — MemorySaver로 fallback합니다. "
-            "프로세스 재시작 시 interrupt 상태가 소멸됩니다."
-        )
-        from langgraph.checkpoint.memory import MemorySaver
-
-        return MemorySaver(), None
+# _build_sync_sqlite_checkpointer has been removed.
+# The server now uses MemorySaver exclusively so that HF Spaces can sleep.
+# Set CHECKPOINTER=sqlite in env to opt back into SQLite persistence (advanced use).
 
 
 manager = vLLMEngineManager()
@@ -754,48 +705,63 @@ manager = vLLMEngineManager()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """FastAPI lifespan: 모델/인덱스 초기화 및 graph 단일 초기화.
+    """FastAPI lifespan: model/index init and single graph initialization.
 
-    AsyncSqliteSaver가 사용 가능하면 그것으로 한 번만 초기화한다.
-    import 실패 시 SqliteSaver(동기) 또는 MemorySaver로 fallback한다.
-    graph 이중 초기화를 방지하기 위해 _init_graph()를 한 번만 호출한다.
-    shutdown 시 httpx AsyncClient를 반드시 종료하여 leak을 방지한다.
+    Uses MemorySaver for LangGraph checkpointing — no file handles, no
+    persistent SQLite connections.  This allows HF Spaces to enter sleep mode
+    after the configured idle period.
+
+    Set CHECKPOINTER=sqlite env var to opt into SQLite persistence (keeps the
+    server alive, suitable for long-running on-prem deployments).
+
+    Guarantees graph is initialized exactly once.
+    Always closes the httpx AsyncClient on shutdown to prevent leaks.
     """
     await manager.initialize()
 
-    # API_KEY 미설정 경고 (운영 프로필에서 명시적으로 알림)
     if _API_KEY is None and runtime_config.profile.value not in ("local",):
-        logger.warning("API_KEY 미설정: 운영 환경에서는 반드시 API_KEY 환경변수를 설정하세요.")
+        logger.warning("API_KEY not set: set API_KEY env var in production.")
 
-    # checkpointer 결정 후 graph를 한 번만 초기화 (이중 초기화 방지)
-    async_cp_db = str(Path(manager.session_store.db_path).parent / "langgraph_checkpoints.db")
-    try:
-        from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+    checkpointer_mode = os.getenv("CHECKPOINTER", "memory").lower()
 
-        async with AsyncSqliteSaver.from_conn_string(async_cp_db) as async_saver:
-            manager._init_graph(checkpointer=async_saver)
-            manager._checkpointer_ctx = async_saver
-            logger.info(f"LangGraph: AsyncSqliteSaver ({async_cp_db})")
-            try:
-                yield
-            finally:
-                manager._checkpointer_ctx = None
-                if manager._http_client:
-                    await manager._http_client.aclose()
-                    logger.info("httpx AsyncClient 종료 완료")
-        return
-    except ImportError:
-        pass
+    if checkpointer_mode == "sqlite":
+        # Opt-in SQLite persistence for on-prem / non-HF deployments.
+        cp_db = str(Path(manager.session_store.db_path).parent / "langgraph_checkpoints.db")
+        try:
+            from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 
-    # fallback: SqliteSaver(동기) 또는 MemorySaver
+            async with AsyncSqliteSaver.from_conn_string(cp_db) as async_saver:
+                manager._init_graph(checkpointer=async_saver)
+                logger.info(f"LangGraph checkpointer: AsyncSqliteSaver ({cp_db})")
+                try:
+                    yield
+                finally:
+                    if manager._http_client:
+                        await manager._http_client.aclose()
+                        logger.info("httpx AsyncClient closed")
+            return
+        except ImportError:
+            logger.warning(
+                "CHECKPOINTER=sqlite requested but langgraph-checkpoint-sqlite not installed. "
+                "Falling back to MemorySaver."
+            )
+
+    # Default: MemorySaver — no persistent file handles, HF Space sleep-compatible.
     manager._init_graph()
-    logger.info("LangGraph: SqliteSaver(동기) 또는 MemorySaver로 실행합니다.")
+    logger.info("LangGraph checkpointer: MemorySaver (HF Space sleep-compatible)")
     try:
         yield
     finally:
         if manager._http_client:
             await manager._http_client.aclose()
-            logger.info("httpx AsyncClient 종료 완료")
+            logger.info("httpx AsyncClient closed")
+
+
+# ---------------------------------------------------------------------------
+# Idle-time tracker — updated on every incoming request so external
+# health-check scripts can determine if the server is truly idle.
+# ---------------------------------------------------------------------------
+_last_request_time: float = time.monotonic()
 
 
 app = FastAPI(
@@ -803,6 +769,15 @@ app = FastAPI(
     description="Local FastAPI daemon for the GovOn Agentic Shell MVP.",
     lifespan=lifespan,
 )
+
+
+@app.middleware("http")
+async def _update_last_request_time(request: Request, call_next):
+    """Record the monotonic timestamp of the most recent request."""
+    global _last_request_time
+    _last_request_time = time.monotonic()
+    return await call_next(request)
+
 
 ALLOWED_ORIGINS = os.getenv("CORS_ORIGINS", "").split(",")
 if ALLOWED_ORIGINS and ALLOWED_ORIGINS[0]:
@@ -1021,9 +996,9 @@ async def v2_agent_run(
        동일 thread_id에 새 graph_run을 시작한다. LangGraph checkpointer가
        동일 thread_id에서 이전 상태를 누적하므로 대화 히스토리가 보존된다.
 
-    3. **프로세스 재시작 후**: SqliteSaver 사용 시 DB에서 checkpoint가 복원되므로
-       interrupt 상태가 유지된다. 클라이언트는 기존 thread_id로 `/v2/agent/approve`
-       를 다시 호출하면 중단된 지점에서 resume할 수 있다.
+    3. **After process restart**: With MemorySaver checkpoints are in-memory only
+       and do not survive restarts.  Set CHECKPOINTER=sqlite to opt into SQLite
+       persistence for restart-safe interrupt resumption.
 
     Note: session_id == thread_id. 두 값은 항상 동일하게 유지된다.
     """

--- a/src/inference/session_context.py
+++ b/src/inference/session_context.py
@@ -1,20 +1,29 @@
-"""세션 컨텍스트 및 SQLite 기반 세션 저장소.
+"""Session context and SQLite-based session store.
 
-GovOn Shell MVP의 세션 모델은 다음을 저장한다.
+GovOn Shell MVP session model stores:
 
-- 대화 기록
-- tool 사용 기록
-- task loop 단위 실행 로그
+- Conversation history
+- Tool usage records
+- Task loop execution logs
 
-초안 버전, 선택 근거 목록 같은 무거운 상태는 제품 기본 저장 범위에서 제외한다.
+Heavy state (draft versions, selection rationale lists) is excluded from the default
+persistence scope.
 
 Schema versioning
 -----------------
-_init_db()는 schema_version 테이블을 통해 순차 migration을 관리한다.
-현재 최신 버전: SCHEMA_VERSION = 2
+_init_db() manages sequential migrations via the schema_version table.
+Current latest version: SCHEMA_VERSION = 2
 
 Migration history:
-  v1 → v2: tool_runs에 graph_run_request_id 컬럼 추가 (이전에는 ad-hoc ALTER TABLE)
+  v1 -> v2: added graph_run_request_id column to tool_runs
+
+Session TTL
+-----------
+SESSION_TTL_SECONDS controls how long an in-memory session lives after the last
+activity.  After the TTL elapses the entry is evicted from _active_sessions so
+the process holds no references and HF Spaces can transition to sleep.
+The SQLite store itself is untouched — only the in-memory activity-tracking dict
+is cleared.
 """
 
 from __future__ import annotations
@@ -32,7 +41,24 @@ from typing import Any, Callable, Dict, List, Optional
 from loguru import logger
 
 SCHEMA_VERSION = 2
-"""현재 SessionStore SQLite 스키마 버전."""
+"""Current SessionStore SQLite schema version."""
+
+# ---------------------------------------------------------------------------
+# Session TTL
+# ---------------------------------------------------------------------------
+try:
+    from .runtime_config import govon_config as _govon_config
+
+    SESSION_TTL_SECONDS: int = getattr(_govon_config, "session_ttl_seconds", 60)
+except Exception:
+    SESSION_TTL_SECONDS = 60
+
+SESSION_TTL_SECONDS = int(os.getenv("SESSION_TTL_SECONDS", SESSION_TTL_SECONDS))
+"""Idle timeout in seconds before an in-memory session entry is evicted.
+
+Configurable via the SESSION_TTL_SECONDS environment variable.
+Default: 60 seconds.
+"""
 
 
 def _default_session_db_path() -> str:
@@ -219,11 +245,23 @@ class SessionContext:
 
 
 class SessionStore:
-    """SQLite 기반 세션 저장소."""
+    """SQLite-backed session store with in-memory idle-TTL tracking.
+
+    Each session's last-activity timestamp is recorded in ``_active_sessions``.
+    When the elapsed time since last activity exceeds ``SESSION_TTL_SECONDS`` the
+    entry is removed from the dict on the next ``get_or_create`` / ``get`` call,
+    allowing the process (and HF Space container) to become truly idle.
+
+    The SQLite rows themselves are NOT deleted by the TTL — only the in-memory
+    activity tracker is cleared.  Use ``cleanup_old_sessions`` for persistent
+    cleanup.
+    """
 
     def __init__(self, db_path: Optional[str] = None, max_history: int = 20) -> None:
         self._db_path = db_path or os.getenv("GOVON_SESSION_DB") or _default_session_db_path()
         self._max_history = max_history
+        # Maps session_id -> last-activity monotonic timestamp
+        self._active_sessions: Dict[str, float] = {}
         self._init_db()
 
     @property
@@ -662,21 +700,75 @@ class SessionStore:
             _persist_metadata=lambda key, value: self._upsert_metadata(session_id, key, value),
         )
 
+    # ------------------------------------------------------------------
+    # In-memory TTL helpers
+    # ------------------------------------------------------------------
+
+    def _touch(self, session_id: str) -> None:
+        """Record or refresh the last-activity timestamp for *session_id*."""
+        self._active_sessions[session_id] = time.monotonic()
+
+    def _is_expired(self, session_id: str) -> bool:
+        """Return True if *session_id* has exceeded the idle TTL."""
+        last = self._active_sessions.get(session_id)
+        if last is None:
+            # Never seen in this process — treat as expired so the caller
+            # decides whether to load from DB or create fresh.
+            return False
+        return (time.monotonic() - last) > SESSION_TTL_SECONDS
+
+    def cleanup_expired(self) -> int:
+        """Evict all sessions that have exceeded SESSION_TTL_SECONDS.
+
+        Only removes the in-memory activity-tracking entry; SQLite rows are
+        left intact for audit purposes.
+
+        Returns
+        -------
+        int
+            Number of sessions evicted from the in-memory tracker.
+        """
+        now = time.monotonic()
+        expired = [
+            sid
+            for sid, last in list(self._active_sessions.items())
+            if (now - last) > SESSION_TTL_SECONDS
+        ]
+        for sid in expired:
+            del self._active_sessions[sid]
+        if expired:
+            logger.debug(f"SessionStore: evicted {len(expired)} expired in-memory sessions")
+        return len(expired)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
     def get_or_create(
         self,
         session_id: Optional[str] = None,
         max_history: Optional[int] = None,
     ) -> SessionContext:
+        # Evict stale sessions on every call — keeps _active_sessions lean.
+        self.cleanup_expired()
+
         history_limit = max_history or self._max_history
         if session_id:
+            if self._is_expired(session_id):
+                # TTL elapsed: discard in-memory entry; load fresh from DB below.
+                self._active_sessions.pop(session_id, None)
+                logger.debug(f"Session {session_id}: TTL expired, starting fresh")
+
             existing = self._build_context(session_id, history_limit)
             if existing is not None:
+                self._touch(session_id)
                 return existing
 
         sid = session_id or str(uuid.uuid4())
         created_at = time.time()
         self._ensure_session(sid, created_at=created_at)
-        logger.info(f"새 세션 생성: {sid}")
+        self._touch(sid)
+        logger.info(f"New session created: {sid}")
         return SessionContext(
             session_id=sid,
             max_history=history_limit,
@@ -688,7 +780,14 @@ class SessionStore:
         )
 
     def get(self, session_id: str) -> Optional[SessionContext]:
-        return self._build_context(session_id, self._max_history)
+        if self._is_expired(session_id):
+            self._active_sessions.pop(session_id, None)
+            logger.debug(f"Session {session_id}: TTL expired on get()")
+            return None
+        ctx = self._build_context(session_id, self._max_history)
+        if ctx is not None:
+            self._touch(session_id)
+        return ctx
 
     def delete(self, session_id: str) -> bool:
         with closing(self._connect()) as conn, conn:


### PR DESCRIPTION
## Related Issue
- N/A (HF Space sleep regression caused by persistent SQLite connections)

## Background
`AsyncSqliteSaver` holds open SQLite connections for the entire server lifetime.
HF Spaces detects the process as "active" due to these file handles and never
enters sleep mode, wasting compute quota.

## Key Changes
- `src/inference/api_server.py`: Replace `AsyncSqliteSaver` (and the sync
  `SqliteSaver` fallback) with `MemorySaver` as the default LangGraph
  checkpointer.  No file handles are held open.  Add opt-in `CHECKPOINTER=sqlite`
  env var for on-prem deployments that need restart-safe persistence.
  Remove `_checkpointer_ctx`, `_sync_checkpointer_conn` fields and the
  `_build_sync_sqlite_checkpointer()` helper.  Simplify `lifespan()`.
  Add `_last_request_time` monotonic tracker updated via HTTP middleware.
- `src/inference/session_context.py`: Add `SESSION_TTL_SECONDS = 60` idle
  eviction to `SessionStore`.  New helpers `_touch()`, `_is_expired()`,
  `cleanup_expired()` track per-session last-activity timestamps and drop
  stale in-memory entries automatically on every `get_or_create()` call.

## Test Results
- [ ] Local test complete
- [ ] Existing functionality verified

## Additional Notes
`CHECKPOINTER=sqlite` opt-in path preserves the old `AsyncSqliteSaver` code
for teams that deploy on-prem and need interrupt resumption across restarts.
The default (no env var) is now `MemorySaver`.

`SESSION_TTL_SECONDS` is configurable via environment variable (default 60).

---

## Merge Checklist
- [ ] At least one code review approval
- [ ] CODEOWNERS (team lead) final approval
- [ ] All review comments resolved

## Reviewer Guide

| Tag | Meaning | Example |
|-----|---------|---------|
| `[MUST]` | Must fix (security, bug, performance issue) | `[MUST] API key is exposed in logs.` |
| `[SHOULD]` | Strongly recommended (code quality, maintainability) | `[SHOULD] This logic should be extracted into a separate function.` |
| `[NITS]` | Minor improvement (style, naming) | `[NITS] \`parsed_output\` is clearer than \`result\` as a variable name.` |
| `[QUESTION]` | Question for understanding | `[QUESTION] Can this condition ever be always True?` |