### PR TITLE
revert: undo #702 MemorySaver + #705 lint fix (unnecessary change)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,10 +1,6 @@
 name: Docker Publish
 
 on:
-  workflow_run:
-    workflows: ["PR Gate"]
-    types: [completed]
-    branches: [main]
   push:
     tags: ['v*']
   workflow_dispatch:
@@ -27,38 +23,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  check-changes:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_run'
-    outputs:
-      should-build: ${{ steps.filter.outputs.docker }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            docker:
-              - 'deploy/docker/Dockerfile'
-              - '.dockerignore'
-              - 'deploy/compose/docker-compose*.yml'
-              - 'src/**'
-              - 'pyproject.toml'
-              - 'uv.lock'
-              - '.github/workflows/docker-publish.yml'
-
   build-and-push:
-    needs: [check-changes]
-    if: |
-      always() && (
-        github.event_name == 'workflow_dispatch' ||
-        github.event_name == 'push' ||
-        (github.event_name == 'workflow_run' &&
-         github.event.workflow_run.conclusion == 'success' &&
-         needs.check-changes.outputs.should-build == 'true')
-      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -67,12 +32,6 @@ jobs:
       image_tag: ${{ steps.build-metadata.outputs.image_tag }}
 
     steps:
-      - name: Checkout workflow-run commit
-        if: github.event_name == 'workflow_run'
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-
       - name: Checkout requested ref
         if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v6
@@ -107,11 +66,9 @@ jobs:
           PRIMARY_TAG="${IMAGE_BASE}:sha-${SHORT_SHA}"
           TAGS="${PRIMARY_TAG}"
 
-          if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            TAGS="${TAGS}"$'\n'"${IMAGE_BASE}:latest"
-            SOURCE="main branch after PR Gate success"
-          elif [ "${{ github.event_name }}" = "push" ]; then
+          if [ "${{ github.event_name }}" = "push" ]; then
             TAGS="${TAGS}"$'\n'"${IMAGE_BASE}:${GITHUB_REF_NAME}"
+            TAGS="${TAGS}"$'\n'"${IMAGE_BASE}:latest"
             SOURCE="release tag ${GITHUB_REF_NAME}"
           else
             SOURCE="manual dispatch (${GITHUB_EVENT_NAME})"

--- a/src/inference/api_server.py
+++ b/src/inference/api_server.py
@@ -153,8 +153,10 @@ class vLLMEngineManager:
         self.agent_manager = AgentManager(AGENTS_DIR)
         self._api_lookup_action = None  # MinwonAnalysisAction (지연 초기화)
         self._domain_adapter_fn = None  # Domain adapter generation closure (lazy init)
-        self.graph = None  # LangGraph CompiledGraph (v2 endpoint)
-        self.graph_v3 = None  # v3 ReAct graph (v3 endpoint)
+        self.graph = None  # LangGraph CompiledGraph (v2 엔드포인트용)
+        self.graph_v3 = None  # v3 ReAct graph (v3 엔드포인트용)
+        self._checkpointer_ctx = None  # AsyncSqliteSaver 컨텍스트 매니저 (lifespan에서 관리)
+        self._sync_checkpointer_conn = None  # SqliteSaver용 sqlite3 connection (leak 방지)
         # session_id 단위 비동기 락: 동시 요청 race condition 방지
         self._session_locks: dict[str, asyncio.Lock] = {}
         self._init_tools()
@@ -596,19 +598,24 @@ class vLLMEngineManager:
             domain_adapter_fn=self._domain_adapter_fn,
         )
 
-    def _init_graph(self, checkpointer: Optional[object] = None) -> None:
-        """Initialize the LangGraph StateGraph.
+    def _init_graph_with_async_checkpointer(self, checkpointer: object) -> None:
+        """lifespan에서 AsyncSqliteSaver가 준비된 후 graph를 재구성한다."""
+        self._init_graph(checkpointer=checkpointer)
 
-        v4 architecture: ReAct + ToolNode.  The LLM decides tool calls autonomously.
+    def _init_graph(self, checkpointer: Optional[object] = None) -> None:
+        """LangGraph StateGraph를 초기화한다.
+
+        v4 아키텍처: ReAct + ToolNode 기반.
+        LLM이 자율적으로 도구 호출을 결정한다.
 
         Parameters
         ----------
         checkpointer : optional
-            LangGraph checkpointer injected from the outside.
-            When None (default), a MemorySaver is used — no file handles, no
-            persistent connections, safe for HF Spaces sleep mode.
-            Pass an explicit checkpointer only when durable persistence is required
-            (e.g. CHECKPOINTER=sqlite env var in local/self-hosted deployments).
+            외부에서 주입할 LangGraph checkpointer.
+            None이면 SqliteSaver(동기 sqlite3)를 시도하고,
+            import 실패 시 MemorySaver로 fallback한다.
+            SqliteSaver DB 경로는 SessionStore DB와 같은 디렉터리에
+            ``langgraph_checkpoints.db``로 생성된다 (관심사 분리).
         """
         try:
             from src.inference.graph.builder import build_govon_graph
@@ -660,17 +667,15 @@ class vLLMEngineManager:
                 max_tokens=_llm_max_tokens,
             )
 
-        # Use MemorySaver by default — no file handles, no persistent connections.
-        # Opt-in to SQLite via CHECKPOINTER=sqlite for local/self-hosted deployments.
+        # checkpointer가 외부에서 주입되지 않으면 SqliteSaver를 시도한다.
         if checkpointer is None:
-            _cp_mode = os.getenv("CHECKPOINTER", "memory").lower()
-            if _cp_mode == "sqlite":
-                checkpointer, _ = _build_sync_sqlite_checkpointer(self.session_store.db_path)
-            else:
-                from langgraph.checkpoint.memory import MemorySaver
-
-                checkpointer = MemorySaver()
-                logger.info("LangGraph checkpointer: MemorySaver (in-memory, no file handles)")
+            checkpointer, conn = _build_sync_sqlite_checkpointer(self.session_store.db_path)
+            if self._sync_checkpointer_conn is not None:
+                try:
+                    self._sync_checkpointer_conn.close()
+                except Exception:
+                    pass
+            self._sync_checkpointer_conn = conn
 
         self.graph = build_govon_graph(
             llm=llm,
@@ -703,30 +708,45 @@ class vLLMEngineManager:
 def _build_sync_sqlite_checkpointer(
     session_db_path: str,
 ) -> tuple:
-    """Build a SqliteSaver checkpointer for opt-in durable persistence.
+    """SqliteSaver(동기) 또는 MemorySaver(fallback)를 반환한다.
 
-    Only called when CHECKPOINTER=sqlite is set explicitly.  The SQLite DB is
-    placed in the same directory as sessions.sqlite3 but in a separate file
-    (langgraph_checkpoints.db) to keep concerns separated.
+    LangGraph checkpointer용 SQLite DB는 SessionStore의 sessions.sqlite3와
+    같은 디렉터리에 별도 파일 ``langgraph_checkpoints.db``로 생성한다.
+    두 DB를 분리함으로써 관심사(세션 메타 vs. graph 체크포인트)를 명확히 구분한다.
+
+    SqliteSaver는 프로세스 재시작 후에도 interrupt 상태를 SQLite에서 복원하므로
+    MemorySaver와 달리 재시작-안전(restart-safe)하다.
 
     Parameters
     ----------
     session_db_path : str
-        Path to the SessionStore sessions.sqlite3 file.
-        langgraph_checkpoints.db is created in the same parent directory.
+        SessionStore가 사용 중인 sessions.sqlite3 파일 경로.
+        이 경로의 부모 디렉터리에 langgraph_checkpoints.db를 생성한다.
 
     Returns
     -------
-    tuple[SqliteSaver, sqlite3.Connection]
-        (checkpointer, conn).  The caller is responsible for closing conn.
+    tuple[SqliteSaver | MemorySaver, sqlite3.Connection | None]
+        (checkpointer, conn) 튜플.
+        SqliteSaver 사용 시 conn은 열린 sqlite3.Connection이며,
+        호출자가 적절한 시점에 close해야 한다.
+        MemorySaver fallback 시 conn은 None이다.
     """
     cp_db_path = str(Path(session_db_path).parent / "langgraph_checkpoints.db")
-    from langgraph.checkpoint.sqlite import SqliteSaver
+    try:
+        from langgraph.checkpoint.sqlite import SqliteSaver
 
-    conn = __import__("sqlite3").connect(cp_db_path, check_same_thread=False)
-    saver = SqliteSaver(conn)
-    logger.info(f"LangGraph checkpointer: SqliteSaver ({cp_db_path})")
-    return saver, conn
+        conn = __import__("sqlite3").connect(cp_db_path, check_same_thread=False)
+        saver = SqliteSaver(conn)
+        logger.info(f"LangGraph checkpointer: SqliteSaver ({cp_db_path})")
+        return saver, conn
+    except ImportError:
+        logger.warning(
+            "langgraph-checkpoint-sqlite 미설치 — MemorySaver로 fallback합니다. "
+            "프로세스 재시작 시 interrupt 상태가 소멸됩니다."
+        )
+        from langgraph.checkpoint.memory import MemorySaver
+
+        return MemorySaver(), None
 
 
 manager = vLLMEngineManager()
@@ -734,32 +754,48 @@ manager = vLLMEngineManager()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """FastAPI lifespan: model/index initialization and single graph init.
+    """FastAPI lifespan: 모델/인덱스 초기화 및 graph 단일 초기화.
 
-    Uses MemorySaver by default — no SQLite file handles, no persistent
-    connections, allowing HF Spaces to enter sleep mode when idle.
-
-    To opt-in to durable SQLite checkpointing (local / self-hosted only):
-        CHECKPOINTER=sqlite
-
-    Graph is initialized exactly once to prevent double-init.
-    httpx AsyncClient is closed on shutdown to prevent resource leaks.
+    AsyncSqliteSaver가 사용 가능하면 그것으로 한 번만 초기화한다.
+    import 실패 시 SqliteSaver(동기) 또는 MemorySaver로 fallback한다.
+    graph 이중 초기화를 방지하기 위해 _init_graph()를 한 번만 호출한다.
+    shutdown 시 httpx AsyncClient를 반드시 종료하여 leak을 방지한다.
     """
     await manager.initialize()
 
+    # API_KEY 미설정 경고 (운영 프로필에서 명시적으로 알림)
     if _API_KEY is None and runtime_config.profile.value not in ("local",):
-        logger.warning(
-            "API_KEY not set: set the API_KEY environment variable in production."
-        )
+        logger.warning("API_KEY 미설정: 운영 환경에서는 반드시 API_KEY 환경변수를 설정하세요.")
 
-    # _init_graph() selects MemorySaver or SQLite based on CHECKPOINTER env var.
+    # checkpointer 결정 후 graph를 한 번만 초기화 (이중 초기화 방지)
+    async_cp_db = str(Path(manager.session_store.db_path).parent / "langgraph_checkpoints.db")
+    try:
+        from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+
+        async with AsyncSqliteSaver.from_conn_string(async_cp_db) as async_saver:
+            manager._init_graph(checkpointer=async_saver)
+            manager._checkpointer_ctx = async_saver
+            logger.info(f"LangGraph: AsyncSqliteSaver ({async_cp_db})")
+            try:
+                yield
+            finally:
+                manager._checkpointer_ctx = None
+                if manager._http_client:
+                    await manager._http_client.aclose()
+                    logger.info("httpx AsyncClient 종료 완료")
+        return
+    except ImportError:
+        pass
+
+    # fallback: SqliteSaver(동기) 또는 MemorySaver
     manager._init_graph()
+    logger.info("LangGraph: SqliteSaver(동기) 또는 MemorySaver로 실행합니다.")
     try:
         yield
     finally:
         if manager._http_client:
             await manager._http_client.aclose()
-            logger.info("httpx AsyncClient closed")
+            logger.info("httpx AsyncClient 종료 완료")
 
 
 app = FastAPI(
@@ -784,20 +820,6 @@ if ALLOWED_ORIGINS and ALLOWED_ORIGINS[0]:
 if _RATE_LIMIT_AVAILABLE and limiter is not None:
     app.state.limiter = limiter
     app.add_middleware(SlowAPIMiddleware)
-
-
-# ---------------------------------------------------------------------------
-# Idle-time tracker — updated on every request so HF Spaces can sleep when idle
-# ---------------------------------------------------------------------------
-
-_last_request_time: float = time.monotonic()
-
-
-@app.middleware("http")
-async def _track_request_time(request: Request, call_next):
-    global _last_request_time
-    _last_request_time = time.monotonic()
-    return await call_next(request)
 
 
 @app.get("/health")

--- a/src/inference/api_server.py
+++ b/src/inference/api_server.py
@@ -748,7 +748,9 @@ async def lifespan(app: FastAPI):
     await manager.initialize()
 
     if _API_KEY is None and runtime_config.profile.value not in ("local",):
-        logger.warning("API_KEY not set: set the API_KEY environment variable in production.")
+        logger.warning(
+            "API_KEY not set: set the API_KEY environment variable in production."
+        )
 
     # _init_graph() selects MemorySaver or SQLite based on CHECKPOINTER env var.
     manager._init_graph()

--- a/src/inference/session_context.py
+++ b/src/inference/session_context.py
@@ -1,27 +1,20 @@
-"""Session context and SQLite-backed session store.
+"""세션 컨텍스트 및 SQLite 기반 세션 저장소.
 
-The GovOn Shell MVP session model stores:
+GovOn Shell MVP의 세션 모델은 다음을 저장한다.
 
-- Conversation history
-- Tool-use records
-- Task-loop execution logs
+- 대화 기록
+- tool 사용 기록
+- task loop 단위 실행 로그
 
-Heavy state such as draft versions and selection rationale lists is excluded
-from the default persistence scope.
+초안 버전, 선택 근거 목록 같은 무거운 상태는 제품 기본 저장 범위에서 제외한다.
 
 Schema versioning
 -----------------
-_init_db() manages sequential migrations via a schema_version table.
-Current latest version: SCHEMA_VERSION = 2
+_init_db()는 schema_version 테이블을 통해 순차 migration을 관리한다.
+현재 최신 버전: SCHEMA_VERSION = 2
 
 Migration history:
-  v1 -> v2: add graph_run_request_id column to tool_runs (previously ad-hoc ALTER TABLE)
-
-Session TTL
------------
-SESSION_TTL_SECONDS controls how long an in-memory session lives after the last
-activity.  Expired sessions are evicted on the next get_or_create() / get() call.
-Set via GOVON_SESSION_TTL env var (default: 60 seconds).
+  v1 → v2: tool_runs에 graph_run_request_id 컬럼 추가 (이전에는 ad-hoc ALTER TABLE)
 """
 
 from __future__ import annotations
@@ -39,12 +32,7 @@ from typing import Any, Callable, Dict, List, Optional
 from loguru import logger
 
 SCHEMA_VERSION = 2
-"""Current SessionStore SQLite schema version."""
-
-# ---------------------------------------------------------------------------
-# Session TTL — configurable via env var; default 60 s
-# ---------------------------------------------------------------------------
-SESSION_TTL_SECONDS: int = int(os.getenv("GOVON_SESSION_TTL", "60"))
+"""현재 SessionStore SQLite 스키마 버전."""
 
 
 def _default_session_db_path() -> str:
@@ -94,7 +82,7 @@ class GraphRunRecord:
 
 @dataclass
 class SessionContext:
-    """Session-scoped conversation and tool-use context."""
+    """세션 기반 대화/도구 기록 컨텍스트."""
 
     session_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     max_history: int = 20
@@ -103,29 +91,19 @@ class SessionContext:
     graph_runs: List[GraphRunRecord] = field(default_factory=list)
     metadata: Dict[str, Any] = field(default_factory=dict)
     created_at: float = field(default_factory=time.time)
-    last_activity_at: float = field(default_factory=time.time)
     _persist_turn: Optional[Callable[[ConversationTurn], None]] = field(default=None, repr=False)
     _persist_tool_run: Optional[Callable[[ToolRunRecord], None]] = field(default=None, repr=False)
     _persist_graph_run: Optional[Callable[[GraphRunRecord], None]] = field(default=None, repr=False)
     _persist_metadata: Optional[Callable[[str, Any], None]] = field(default=None, repr=False)
 
-    def touch(self) -> None:
-        """Update last_activity_at to the current time."""
-        self.last_activity_at = time.time()
-
-    def is_expired(self, ttl_seconds: int = SESSION_TTL_SECONDS) -> bool:
-        """Return True if the session has been idle longer than ttl_seconds."""
-        return (time.time() - self.last_activity_at) > ttl_seconds
-
     def add_turn(self, role: str, content: str, **kwargs: Any) -> None:
-        """Append a conversation turn and persist if a callback is registered."""
-        self.touch()
+        """대화 턴을 추가하고 필요 시 영속화한다."""
         turn = ConversationTurn(role=role, content=content, metadata=kwargs)
         self.conversations.append(turn)
         if len(self.conversations) > self.max_history:
             removed = len(self.conversations) - self.max_history
             self.conversations = self.conversations[removed:]
-            logger.debug(f"Session {self.session_id}: removed {removed} old turns")
+            logger.debug(f"세션 {self.session_id}: 오래된 대화 {removed}턴 제거")
 
         if self._persist_turn:
             self._persist_turn(turn)
@@ -139,8 +117,7 @@ class SessionContext:
         error: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
-        """Append a tool-run record and persist if a callback is registered."""
-        self.touch()
+        """도구 실행 로그를 추가하고 필요 시 영속화한다."""
         record = ToolRunRecord(
             tool=tool,
             graph_run_request_id=graph_run_request_id,
@@ -174,8 +151,7 @@ class SessionContext:
         started_at: Optional[float] = None,
         completed_at: Optional[float] = None,
     ) -> None:
-        """Append or update a graph-run record and persist if a callback is registered."""
-        self.touch()
+        """task loop 단위 실행 로그를 추가하고 필요 시 영속화한다."""
         record = GraphRunRecord(
             request_id=request_id,
             plan_summary=plan_summary,
@@ -243,18 +219,11 @@ class SessionContext:
 
 
 class SessionStore:
-    """SQLite-backed session store with in-memory TTL eviction.
-
-    Sessions are tracked in ``_live_sessions`` (a dict keyed by session_id).
-    On every get_or_create() / get() call, expired entries (idle > SESSION_TTL_SECONDS)
-    are evicted first via cleanup_expired().
-    """
+    """SQLite 기반 세션 저장소."""
 
     def __init__(self, db_path: Optional[str] = None, max_history: int = 20) -> None:
         self._db_path = db_path or os.getenv("GOVON_SESSION_DB") or _default_session_db_path()
         self._max_history = max_history
-        # In-memory activity registry: session_id -> last_activity_at timestamp
-        self._live_sessions: Dict[str, float] = {}
         self._init_db()
 
     @property
@@ -693,58 +662,21 @@ class SessionStore:
             _persist_metadata=lambda key, value: self._upsert_metadata(session_id, key, value),
         )
 
-    def cleanup_expired(self, ttl_seconds: int = SESSION_TTL_SECONDS) -> int:
-        """Remove all sessions that have been idle longer than ttl_seconds.
-
-        Returns the number of sessions evicted from the in-memory registry.
-        This does NOT delete rows from SQLite — SQLite is the durable store.
-        """
-        now = time.time()
-        expired = [
-            sid for sid, last in list(self._live_sessions.items())
-            if (now - last) > ttl_seconds
-        ]
-        for sid in expired:
-            self._live_sessions.pop(sid, None)
-        if expired:
-            logger.debug(f"SessionStore: evicted {len(expired)} expired session(s) from memory")
-        return len(expired)
-
-    def _touch(self, session_id: str) -> None:
-        """Record the current time as the last-activity timestamp for session_id."""
-        self._live_sessions[session_id] = time.time()
-
-    def _is_expired(self, session_id: str, ttl_seconds: int = SESSION_TTL_SECONDS) -> bool:
-        """Return True if session_id is tracked and its idle time exceeds ttl_seconds."""
-        last = self._live_sessions.get(session_id)
-        if last is None:
-            # Never seen in this process — treated as expired (will be re-loaded from DB)
-            return False
-        return (time.time() - last) > ttl_seconds
-
     def get_or_create(
         self,
         session_id: Optional[str] = None,
         max_history: Optional[int] = None,
     ) -> SessionContext:
-        self.cleanup_expired()
         history_limit = max_history or self._max_history
         if session_id:
-            # If session is tracked but expired, drop it and create a fresh one
-            if self._is_expired(session_id):
-                logger.info(f"Session {session_id} expired — starting fresh")
-                self._live_sessions.pop(session_id, None)
-            else:
-                existing = self._build_context(session_id, history_limit)
-                if existing is not None:
-                    self._touch(session_id)
-                    return existing
+            existing = self._build_context(session_id, history_limit)
+            if existing is not None:
+                return existing
 
         sid = session_id or str(uuid.uuid4())
         created_at = time.time()
         self._ensure_session(sid, created_at=created_at)
-        self._touch(sid)
-        logger.info(f"New session created: {sid}")
+        logger.info(f"새 세션 생성: {sid}")
         return SessionContext(
             session_id=sid,
             max_history=history_limit,
@@ -756,15 +688,7 @@ class SessionStore:
         )
 
     def get(self, session_id: str) -> Optional[SessionContext]:
-        self.cleanup_expired()
-        if self._is_expired(session_id):
-            logger.info(f"Session {session_id} expired — returning None")
-            self._live_sessions.pop(session_id, None)
-            return None
-        ctx = self._build_context(session_id, self._max_history)
-        if ctx is not None:
-            self._touch(session_id)
-        return ctx
+        return self._build_context(session_id, self._max_history)
 
     def delete(self, session_id: str) -> bool:
         with closing(self._connect()) as conn, conn:

--- a/src/inference/session_context.py
+++ b/src/inference/session_context.py
@@ -701,7 +701,8 @@ class SessionStore:
         """
         now = time.time()
         expired = [
-            sid for sid, last in list(self._live_sessions.items()) if (now - last) > ttl_seconds
+            sid for sid, last in list(self._live_sessions.items())
+            if (now - last) > ttl_seconds
         ]
         for sid in expired:
             self._live_sessions.pop(sid, None)


### PR DESCRIPTION
## Summary
- Revert #702 (MemorySaver + session TTL) and #705 (its lint fix)
- HF Space sleep confirmed working without these changes
- Restores original AsyncSqliteSaver checkpointer

## Test plan
- [ ] CI passes
- [ ] Server starts normally with AsyncSqliteSaver

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed connection lifecycle to prevent resource leaks in checkpoint storage.

* **Changes**
  * Checkpoint data now persists to a local SQLite database for improved reliability and recovery.
  * Sessions are no longer automatically evicted due to idle time; session state is persisted and retained.

* **Documentation**
  * Some module docstrings and log messages updated to Korean.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->