### PR TITLE
fix(deploy): add sleep_time to HF Space to stop idle credit drain

### DIFF
--- a/.github/workflows/deploy-hfspace.yml
+++ b/.github/workflows/deploy-hfspace.yml
@@ -33,6 +33,7 @@ on:
     branches: [main]
     paths:
       - 'deploy/docker/Dockerfile.hfspace'
+      - 'deploy/hfspace/**'
       - 'src/**'
       - 'requirements.txt'
 
@@ -118,6 +119,8 @@ jobs:
 
           # Copy deploy/docker/Dockerfile.hfspace → Space Dockerfile
           cp $GITHUB_WORKSPACE/deploy/docker/Dockerfile.hfspace Dockerfile
+          # Copy HF Space README.md (contains sleep_time for auto-sleep)
+          cp $GITHUB_WORKSPACE/deploy/hfspace/README.md README.md
           cp $GITHUB_WORKSPACE/requirements.txt requirements.txt
           rsync -a --delete $GITHUB_WORKSPACE/src/ src/
 

--- a/deploy/hfspace/README.md
+++ b/deploy/hfspace/README.md
@@ -1,0 +1,16 @@
+---
+title: GovOn Runtime
+emoji: "\U0001F3DB"
+colorFrom: blue
+colorTo: indigo
+sdk: docker
+app_port: 7860
+suggested_hardware: a100-large
+sleep_time: 300
+---
+
+# GovOn Runtime
+
+AI-powered civil complaint analysis system.
+
+Deployed automatically from [GovOn-Org/GovOn](https://github.com/GovOn-Org/GovOn).


### PR DESCRIPTION
## Summary
- HF Docker Space가 비활성 시에도 sleep 모드로 전환되지 않아 GPU 크레딧이 계속 소모되는 문제 수정
- `deploy/hfspace/README.md` 템플릿에 `sleep_time: 300` (5분) 설정 추가
- `deploy-hfspace.yml` 워크플로우에서 README.md를 HF Space repo에 복사하도록 업데이트

## Root Cause
HF Docker Spaces는 README.md YAML frontmatter의 `sleep_time` 필드로 auto-sleep 동작을 제어합니다. 이 설정이 없으면 Space가 무기한 running 상태를 유지하여, 요청이 없어도 GPU 크레딧이 지속적으로 소모됩니다.

## Changes
| File | Change |
|------|--------|
| `deploy/hfspace/README.md` | New — HF Space frontmatter with `sleep_time: 300` |
| `.github/workflows/deploy-hfspace.yml` | Copy README.md to Space repo + trigger path |

## Test plan
- [ ] Merge 후 Deploy HF Space 워크플로우가 README.md를 포함하여 push하는지 확인
- [ ] HF Space가 5분 비활성 후 sleep 모드로 전환되는지 확인
- [ ] Sleep 상태에서 요청 시 정상 wake-up 되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to automatically trigger when deployment configuration files are modified.
  * Added metadata configuration for Hugging Face Space deployment, including app branding, title, runtime settings, and recommended hardware specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->