### PR TITLE
fix: #708 로고 블록 문자를 narrow ASCII로 교체 — 한국어 터미널 레이아웃 깨짐 수정

### DIFF
--- a/packages/npm/src/components/Banner.tsx
+++ b/packages/npm/src/components/Banner.tsx
@@ -3,12 +3,14 @@ import { Box, Text } from 'ink';
 import { THEME_COLORS, getBaseUrl } from '../config.js';
 
 // ASCII art for the 'G' logo, one line per row
+// Note: uses only narrow-width ASCII characters to ensure correct layout
+// across Korean-locale terminals where U+2588 FULL BLOCK renders as 2 columns.
 const LOGO_ART = [
-  '  ██████╗ ',
-  ' ██╔════╝ ',
-  ' ██║ ████╗',
-  ' ██║ ╚═██║',
-  ' ╚██████╔╝',
+  '  ######╗ ',
+  ' ##╔════╝ ',
+  ' ##║ ####╗',
+  ' ##║ ╚═##║',
+  ' ╚######╔╝',
   '  ╚═════╝ ',
 ];
 


### PR DESCRIPTION
## Related Issue
Closes #708
Refs #711

## Background
실사용 테스트(#710) 중 발견된 버그.
`LOGO_ART`에 사용된 `█` (U+2588 FULL BLOCK)이 한국어 환경 터미널에서 2칸(wide)으로 렌더링되어 배너 레이아웃이 어긋났다. GovOn의 주 사용 대상인 한국 공무원 환경에서 첫 실행 화면이 깨져 보이는 문제다.

## Key Changes
- `packages/npm/src/components/Banner.tsx`
  - `LOGO_ART`의 `█` → `#` 교체 (narrow-width ASCII, 환경에 무관하게 1칸 보장)

**변경 전**
```
  ██████╗ 
 ██╔════╝ 
 ██║ ████╗
```

**변경 후**
```
  ######╗ 
 ##╔════╝ 
 ##║ ####╗
```

## Test Results
- [x] Local test complete — `govon` 실행 후 배너 레이아웃 정렬 확인
- [x] Existing functionality verified — 로고 형태 유지, 기능 변경 없음

## Additional Notes
박스 테두리 문자(`╗`, `╔`, `═` 등)는 narrow-width로 분류되어 문제 없음. `█`만 교체 대상.

---

## Merge Checklist
- [ ] At least one code review approval
- [ ] CODEOWNERS (team lead) final approval
- [ ] All review comments resolved

## Reviewer Guide

| Tag | Meaning | Example |
|-----|---------|---------|
| `[MUST]` | Must fix (security, bug, performance issue) | `[MUST] API key is exposed in logs.` |
| `[SHOULD]` | Strongly recommended (code quality, maintainability) | `[SHOULD] This logic should be extracted into a separate function.` |
| `[NITS]` | Minor improvement (style, naming) | `[NITS] \`parsed_output\` is clearer than \`result\` as a variable name.` |
| `[QUESTION]` | Question for understanding | `[QUESTION] Can this condition ever be always True?` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated the banner's ASCII logo with improved character rendering for better visual consistency across different terminal environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->