### PR TITLE
feat(tui): add offline mock client for serverless UI development

### DIFF
--- a/packages/npm/MOCK_TEST_PROMPTS.md
+++ b/packages/npm/MOCK_TEST_PROMPTS.md
@@ -1,0 +1,39 @@
+# Mock Test Prompts
+
+Offline mock mode for TUI development without a running backend.
+
+```bash
+cd packages/npm
+npm run build && npm run dev:mock
+```
+
+## Prompts
+
+| Prompt | Scenario | UI Elements | SSE Path |
+|--------|----------|-------------|----------|
+| `민원 통계` | v3 normal streaming | ThinkingBlock(2 iter) → ToolPanel(stats_lookup ✦, keyword_analyzer ✦) → answer stream → MetadataBar | v3 → `run_complete` |
+| `승인 테스트` | v2 approval flow | v3 throw → v2 fallback → ApprovalPrompt box (y/n) → approve response | v3 fail → v2 → `approval_wait` |
+| `에러 테스트` | server error | ThinkingBlock mid-stream → red error message | v3 → `error` event |
+| `도구 실패` | partial tool failure | stats_lookup ✦ ok → demographics_lookup ✘ fail (red) → partial answer | v3 → `tool_end` success=false |
+| `간단 질문` | direct answer, no tools | ThinkingBlock(1 iter, "No tools needed") → answer stream only | v3 → thinking → response |
+| `긴 답변` | long markdown stress test | 3 tools → long report (tables, code blocks, lists) streaming | v3 → 3 tools → long stream |
+
+Any input not matching the above keywords falls back to the `민원 통계` scenario.
+
+## Matching Rules
+
+```
+query.includes('승인')           → approval
+query.includes('에러' | '오류')  → error
+query.includes('실패')           → tool_fail
+query.includes('간단')           → simple
+query.includes('긴 답변' | '길게') → long
+(default)                        → stats
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `GOVON_MOCK=true` | Enable mock mode (required) |
+| `GOVON_RUNTIME_URL` | Ignored in mock mode |

--- a/packages/npm/MOCK_TEST_PROMPTS.md
+++ b/packages/npm/MOCK_TEST_PROMPTS.md
@@ -22,7 +22,7 @@ Any input not matching the above keywords falls back to the `민원 통계` scen
 
 ## Matching Rules
 
-```
+```text
 query.includes('승인')           → approval
 query.includes('에러' | '오류')  → error
 query.includes('실패')           → tool_fail

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -10,6 +10,7 @@
     "build": "tsc && node esbuild.config.mjs",
     "dev": "tsc --watch",
     "typecheck": "tsc --noEmit",
+    "dev:mock": "GOVON_MOCK=true node bin/govon.js",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/npm/src/App.tsx
+++ b/packages/npm/src/App.tsx
@@ -17,7 +17,7 @@
 
 import React, { useReducer, useCallback, useMemo } from 'react';
 import { Box, Text, Static, useApp, useInput, useStdout } from 'ink';
-import { GovOnClient } from './client.js';
+import { createClient, isMockMode } from './clientFactory.js';
 import { getBaseUrl, THEME_COLORS } from './config.js';
 import type { AppState, Action, Message } from './types.js';
 import { useDaemon } from './hooks/useDaemon.js';
@@ -247,8 +247,8 @@ export function App({ version, initialQuery }: AppProps) {
   const { stdout } = useStdout();
   const [state, dispatch] = useReducer(reducer, initialState);
 
-  // GovOnClient is stable for the lifetime of the app
-  const client = useMemo(() => new GovOnClient(state.apiBase), [state.apiBase]);
+  // Client is stable for the lifetime of the app (mock or real based on GOVON_MOCK)
+  const client = useMemo(() => createClient(state.apiBase), [state.apiBase]);
 
   // Wait for server readiness
   const daemon = useDaemon(client);
@@ -458,7 +458,7 @@ export function App({ version, initialQuery }: AppProps) {
       {/* ── 7. Status footer ── */}
       <Box marginTop={1}>
         <Text dimColor color={THEME_COLORS.dimmed}>
-          {'esc 취소 · Ctrl+D 종료 · /help 도움말'}
+          {isMockMode ? '[MOCK] esc 취소 · Ctrl+D 종료 · /help 도움말' : 'esc 취소 · Ctrl+D 종료 · /help 도움말'}
         </Text>
       </Box>
     </Box>

--- a/packages/npm/src/client.interface.ts
+++ b/packages/npm/src/client.interface.ts
@@ -1,0 +1,48 @@
+/**
+ * IClient — shared interface for the GovOn daemon HTTP client.
+ *
+ * Both GovOnClient (real) and MockGovOnClient (offline dev) implement this
+ * contract so that hooks and components remain agnostic of the backend.
+ */
+
+import type {
+  V3SSEEvent,
+  V2SSEEvent,
+  AgentRunResponse,
+  ApprovalResponse,
+} from './types.js';
+
+export interface IClient {
+  health(): Promise<Record<string, unknown>>;
+  waitForReady(): Promise<boolean>;
+
+  streamV3(
+    query: string,
+    sessionId?: string,
+    maxIterations?: number,
+    signal?: AbortSignal,
+  ): AsyncGenerator<V3SSEEvent>;
+
+  stream(
+    query: string,
+    sessionId?: string,
+    signal?: AbortSignal,
+  ): AsyncGenerator<V2SSEEvent>;
+
+  run(
+    query: string,
+    sessionId?: string,
+    signal?: AbortSignal,
+  ): Promise<AgentRunResponse>;
+
+  runV3(
+    query: string,
+    sessionId?: string,
+    maxIterations?: number,
+    signal?: AbortSignal,
+  ): Promise<Record<string, unknown>>;
+
+  approve(threadId: string, approved: boolean): Promise<ApprovalResponse>;
+
+  cancel(threadId: string): Promise<Record<string, unknown>>;
+}

--- a/packages/npm/src/clientFactory.ts
+++ b/packages/npm/src/clientFactory.ts
@@ -1,0 +1,27 @@
+/**
+ * Client factory — returns MockGovOnClient or GovOnClient based on GOVON_MOCK env var.
+ *
+ * Usage:  const client = createClient();
+ */
+
+import type { IClient } from './client.interface.js';
+import { GovOnClient } from './client.js';
+import { MockGovOnClient } from './mockClient.js';
+import { getBaseUrl } from './config.js';
+
+/** true when GOVON_MOCK is set to any truthy value. */
+export const isMockMode = ['true', '1', 'yes'].includes(
+  (process.env.GOVON_MOCK ?? '').toLowerCase(),
+);
+
+/**
+ * Create the appropriate client for the current environment.
+ *
+ * @param baseUrl - Only used for the real client; ignored in mock mode.
+ */
+export function createClient(baseUrl?: string): IClient {
+  if (isMockMode) {
+    return new MockGovOnClient();
+  }
+  return new GovOnClient(baseUrl ?? getBaseUrl());
+}

--- a/packages/npm/src/hooks/useDaemon.ts
+++ b/packages/npm/src/hooks/useDaemon.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import type { GovOnClient } from '../client.js';
+import type { IClient } from '../client.interface.js';
 
 interface DaemonState {
   /** Server is confirmed ready. */
@@ -14,7 +14,7 @@ interface DaemonState {
  * Check server health on mount. If the server is sleeping (e.g. HF Space),
  * call client.waitForReady() which polls with status messages to stderr.
  */
-export function useDaemon(client: GovOnClient): DaemonState {
+export function useDaemon(client: IClient): DaemonState {
   const [state, setState] = useState<DaemonState>({
     ready: false,
     waiting: true,

--- a/packages/npm/src/hooks/useSSE.ts
+++ b/packages/npm/src/hooks/useSSE.ts
@@ -14,7 +14,7 @@
  */
 
 import { useCallback, useEffect, useRef } from 'react';
-import type { GovOnClient } from '../client.js';
+import type { IClient } from '../client.interface.js';
 import type { V3SSEEvent, V2SSEEvent, Action } from '../types.js';
 import { NODE_STATUS_MESSAGES } from '../types.js';
 
@@ -23,7 +23,7 @@ import { NODE_STATUS_MESSAGES } from '../types.js';
 // ---------------------------------------------------------------------------
 
 export interface UseSSEOptions {
-  client: GovOnClient;
+  client: IClient;
   dispatch: React.Dispatch<Action>;
   sessionId: string | null;
 }
@@ -215,7 +215,7 @@ interface V3Result {
  *   to true so the caller surfaces the error rather than trying v2.
  */
 async function _tryV3(
-  client: GovOnClient,
+  client: IClient,
   query: string,
   sessionId: string | undefined,
   assistantMsgId: string,
@@ -318,7 +318,7 @@ async function _tryV3(
  * false on error so the caller can fall through to the blocking path.
  */
 async function _tryV2(
-  client: GovOnClient,
+  client: IClient,
   query: string,
   sessionId: string | undefined,
   assistantMsgId: string,
@@ -418,7 +418,7 @@ async function _tryV2(
  * Dispatches FINALIZE on success, SET_ERROR on failure.
  */
 async function _tryBlocking(
-  client: GovOnClient,
+  client: IClient,
   query: string,
   sessionId: string | undefined,
   assistantMsgId: string,

--- a/packages/npm/src/mockClient.ts
+++ b/packages/npm/src/mockClient.ts
@@ -31,8 +31,30 @@ import type {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+/**
+ * Abort-aware sleep. Rejects immediately with AbortError when the signal fires,
+ * so Esc cancellation propagates without waiting for the full delay.
+ */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
 }
 
 function uuid(): string {
@@ -48,7 +70,7 @@ async function* streamWords(
   const words = text.split(' ');
   for (const word of words) {
     if (signal?.aborted) return;
-    await sleep(delayMs);
+    await sleep(delayMs, signal);
     yield { type: 'response_delta', content: word + ' ' };
   }
 }
@@ -168,7 +190,7 @@ async function* scenarioStats(
     'Let me also check for keyword analysis to provide additional context. ',
   ]) {
     if (signal?.aborted) return;
-    await sleep(80);
+    await sleep(80, signal);
     yield { type: 'thinking_delta', content: line };
   }
   yield {
@@ -183,17 +205,17 @@ async function* scenarioStats(
   // Tool execution
   yield { type: 'tool_start', tool: 'stats_lookup' };
   if (signal?.aborted) return;
-  await sleep(300);
+  await sleep(300, signal);
   yield { type: 'tool_end', tool: 'stats_lookup', success: true };
 
   yield { type: 'tool_start', tool: 'keyword_analyzer' };
   if (signal?.aborted) return;
-  await sleep(200);
+  await sleep(200, signal);
   yield { type: 'tool_end', tool: 'keyword_analyzer', success: true };
 
   // Iteration 2: compose final answer
   yield { type: 'thinking_start', iteration: 2 };
-  await sleep(50);
+  await sleep(50, signal);
   yield { type: 'thinking_delta', content: 'Tools returned successfully. Composing the final answer now.' };
   yield { type: 'thinking_end', iteration: 2, tool_calls: [] };
 
@@ -218,12 +240,12 @@ async function* scenarioError(
 ): AsyncGenerator<V3SSEEvent> {
   // Start thinking, then crash mid-stream
   yield { type: 'thinking_start', iteration: 1 };
-  await sleep(100);
+  await sleep(100, signal);
   yield { type: 'thinking_delta', content: 'Processing the query... ' };
   if (signal?.aborted) return;
-  await sleep(200);
+  await sleep(200, signal);
   yield { type: 'thinking_delta', content: 'Attempting to connect to data source... ' };
-  await sleep(300);
+  await sleep(300, signal);
   yield { type: 'error', error: '[MockError] Backend service unavailable: connection to data source timed out after 30s' };
 }
 
@@ -235,7 +257,7 @@ async function* scenarioToolFail(
 ): AsyncGenerator<V3SSEEvent> {
   // Iteration 1: thinking → 2 tools, one fails
   yield { type: 'thinking_start', iteration: 1 };
-  await sleep(60);
+  await sleep(60, signal);
   yield { type: 'thinking_delta', content: 'I need to look up demographics and statistics for this query. ' };
   yield {
     type: 'thinking_end',
@@ -248,18 +270,18 @@ async function* scenarioToolFail(
 
   yield { type: 'tool_start', tool: 'stats_lookup' };
   if (signal?.aborted) return;
-  await sleep(250);
+  await sleep(250, signal);
   yield { type: 'tool_end', tool: 'stats_lookup', success: true };
 
   yield { type: 'tool_start', tool: 'demographics_lookup' };
   if (signal?.aborted) return;
-  await sleep(500);
+  await sleep(500, signal);
   // This one FAILS
   yield { type: 'tool_end', tool: 'demographics_lookup', success: false };
 
   // Iteration 2: recover and answer with partial data
   yield { type: 'thinking_start', iteration: 2 };
-  await sleep(80);
+  await sleep(80, signal);
   yield { type: 'thinking_delta', content: 'demographics_lookup failed with timeout. I will use cached data to answer. ' };
   yield { type: 'thinking_end', iteration: 2, tool_calls: [] };
 
@@ -284,7 +306,7 @@ async function* scenarioSimple(
 ): AsyncGenerator<V3SSEEvent> {
   // Single iteration — no tool calls, direct answer
   yield { type: 'thinking_start', iteration: 1 };
-  await sleep(60);
+  await sleep(60, signal);
   yield { type: 'thinking_delta', content: 'This is a general question about GovOn. No tools needed — I can answer directly. ' };
   yield { type: 'thinking_end', iteration: 1, tool_calls: [] };
 
@@ -308,7 +330,7 @@ async function* scenarioLong(
 ): AsyncGenerator<V3SSEEvent> {
   // Iteration 1: thinking → 3 tool calls (heavy workload)
   yield { type: 'thinking_start', iteration: 1 };
-  await sleep(80);
+  await sleep(80, signal);
   yield { type: 'thinking_delta', content: 'User is requesting a comprehensive analysis. I need multiple data sources. ' };
   yield { type: 'thinking_delta', content: 'Planning: stats_lookup for volume, keyword_analyzer for trends, demographics_lookup for regional breakdown. ' };
   yield {
@@ -324,22 +346,22 @@ async function* scenarioLong(
   // 3 tools in sequence
   yield { type: 'tool_start', tool: 'stats_lookup' };
   if (signal?.aborted) return;
-  await sleep(400);
+  await sleep(400, signal);
   yield { type: 'tool_end', tool: 'stats_lookup', success: true };
 
   yield { type: 'tool_start', tool: 'keyword_analyzer' };
   if (signal?.aborted) return;
-  await sleep(350);
+  await sleep(350, signal);
   yield { type: 'tool_end', tool: 'keyword_analyzer', success: true };
 
   yield { type: 'tool_start', tool: 'demographics_lookup' };
   if (signal?.aborted) return;
-  await sleep(500);
+  await sleep(500, signal);
   yield { type: 'tool_end', tool: 'demographics_lookup', success: true };
 
   // Iteration 2: compose long report
   yield { type: 'thinking_start', iteration: 2 };
-  await sleep(60);
+  await sleep(60, signal);
   yield { type: 'thinking_delta', content: 'All three tools returned successfully. Composing a comprehensive report with tables and code blocks. ' };
   yield { type: 'thinking_end', iteration: 2, tool_calls: [] };
 
@@ -365,6 +387,15 @@ async function* scenarioLong(
 // ---------------------------------------------------------------------------
 
 export class MockGovOnClient implements IClient {
+  /**
+   * Tracks pending approval requests by thread_id so that approve() can
+   * resolve the waiting v2 stream and reuse the original session_id.
+   */
+  private readonly _pendingApprovals = new Map<
+    string,
+    { sessionId: string; resolve: () => void }
+  >();
+
   async health(): Promise<Record<string, unknown>> {
     return { status: 'ok', mock: true };
   }
@@ -423,7 +454,7 @@ export class MockGovOnClient implements IClient {
     if (scenario === 'approval') {
       // --- V2 approval flow ---
       yield { node: 'session_load', status: 'completed' };
-      await sleep(100);
+      await sleep(100, _signal);
 
       yield {
         node: 'agent',
@@ -431,7 +462,7 @@ export class MockGovOnClient implements IClient {
         planned_tools: ['stats_lookup'],
         task_type: 'stats_query',
       };
-      await sleep(150);
+      await sleep(150, _signal);
 
       // Trigger the approval prompt
       yield {
@@ -447,25 +478,29 @@ export class MockGovOnClient implements IClient {
         },
       };
 
-      // The TUI will show ApprovalPrompt and wait for y/n.
-      // After the user approves via client.approve(), the stream ends.
-      // The approval response from approve() contains the final text.
+      // Keep the generator alive until approve()/cancel() resolves it.
+      // The TUI shows ApprovalPrompt and waits for y/n; once the user
+      // decides, approve() resolves this promise and the stream ends.
+      await new Promise<void>((resolve) => {
+        this._pendingApprovals.set(tid, { sessionId: sid, resolve });
+      });
+
       return;
     }
 
     // Default v2 fallback for non-approval scenarios
     yield { node: 'session_load', status: 'completed' };
-    await sleep(100);
+    await sleep(100, _signal);
 
     yield {
       node: 'agent',
       status: 'completed',
       planned_tools: ['stats_lookup'],
     };
-    await sleep(200);
+    await sleep(200, _signal);
 
     yield { node: 'tools', status: 'completed', tool_results: {} };
-    await sleep(100);
+    await sleep(100, _signal);
 
     yield {
       node: 'persist',
@@ -482,7 +517,7 @@ export class MockGovOnClient implements IClient {
     sessionId?: string,
     _signal?: AbortSignal,
   ): Promise<AgentRunResponse> {
-    await sleep(500);
+    await sleep(500, _signal);
     const sid = sessionId ?? uuid();
     const scenario = resolveScenario(query);
     const text = ANSWERS[scenario] || ANSWERS.stats;
@@ -517,12 +552,23 @@ export class MockGovOnClient implements IClient {
     return result as unknown as Record<string, unknown>;
   }
 
-  async approve(_threadId: string, approved: boolean): Promise<ApprovalResponse> {
+  async approve(threadId: string, approved: boolean): Promise<ApprovalResponse> {
     await sleep(200);
+
+    // Retrieve and clean up the pending approval to reuse the original session_id
+    const pending = this._pendingApprovals.get(threadId);
+    const sid = pending?.sessionId ?? uuid();
+
+    // Resolve the waiting v2 stream so the generator can finish
+    if (pending) {
+      pending.resolve();
+      this._pendingApprovals.delete(threadId);
+    }
+
     return {
       status: approved ? 'approved' : 'rejected',
-      thread_id: _threadId,
-      session_id: uuid(),
+      thread_id: threadId,
+      session_id: sid,
       text: approved ? ANSWERS.approval : undefined,
       evidence_items: approved
         ? [{ source_type: 'api', content: 'Direct DB query result (mock)', score: 0.93 }]
@@ -531,7 +577,13 @@ export class MockGovOnClient implements IClient {
     };
   }
 
-  async cancel(_threadId: string): Promise<Record<string, unknown>> {
-    return { status: 'cancelled', thread_id: _threadId };
+  async cancel(threadId: string): Promise<Record<string, unknown>> {
+    // Clean up any pending approval for this thread
+    const pending = this._pendingApprovals.get(threadId);
+    if (pending) {
+      pending.resolve();
+      this._pendingApprovals.delete(threadId);
+    }
+    return { status: 'cancelled', thread_id: threadId };
   }
 }

--- a/packages/npm/src/mockClient.ts
+++ b/packages/npm/src/mockClient.ts
@@ -37,23 +37,26 @@ import type {
  */
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
-    if (signal?.aborted) {
-      reject(new DOMException('Aborted', 'AbortError'));
-      return;
-    }
-
-    const timer = setTimeout(() => {
-      signal?.removeEventListener('abort', onAbort);
-      resolve();
-    }, ms);
+    let timer: ReturnType<typeof setTimeout> | undefined;
 
     const onAbort = () => {
-      clearTimeout(timer);
+      if (timer !== undefined) clearTimeout(timer);
       signal?.removeEventListener('abort', onAbort);
       reject(new DOMException('Aborted', 'AbortError'));
     };
 
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+
+    // Register listener BEFORE starting the timer to close the race window.
     signal?.addEventListener('abort', onAbort, { once: true });
+
+    timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
   });
 }
 

--- a/packages/npm/src/mockClient.ts
+++ b/packages/npm/src/mockClient.ts
@@ -61,17 +61,21 @@ function uuid(): string {
   return crypto.randomUUID();
 }
 
-/** Stream text word-by-word as response_delta events. */
-async function* streamWords(
+/**
+ * Stream text in small chunks as response_delta events.
+ * Uses a fixed chunk size instead of splitting on spaces to preserve
+ * exact whitespace (repeated spaces, newlines, code-block indentation).
+ */
+async function* streamChunks(
   text: string,
   delayMs: number,
   signal?: AbortSignal,
+  chunkSize = 12,
 ): AsyncGenerator<V3SSEEvent> {
-  const words = text.split(' ');
-  for (const word of words) {
+  for (let i = 0; i < text.length; i += chunkSize) {
     if (signal?.aborted) return;
     await sleep(delayMs, signal);
-    yield { type: 'response_delta', content: word + ' ' };
+    yield { type: 'response_delta', content: text.slice(i, i + chunkSize) };
   }
 }
 
@@ -219,7 +223,7 @@ async function* scenarioStats(
   yield { type: 'thinking_delta', content: 'Tools returned successfully. Composing the final answer now.' };
   yield { type: 'thinking_end', iteration: 2, tool_calls: [] };
 
-  yield* streamWords(ANSWERS.stats, 30, signal);
+  yield* streamChunks(ANSWERS.stats, 30, signal);
 
   yield {
     type: 'run_complete',
@@ -285,7 +289,7 @@ async function* scenarioToolFail(
   yield { type: 'thinking_delta', content: 'demographics_lookup failed with timeout. I will use cached data to answer. ' };
   yield { type: 'thinking_end', iteration: 2, tool_calls: [] };
 
-  yield* streamWords(ANSWERS.tool_fail, 30, signal);
+  yield* streamChunks(ANSWERS.tool_fail, 30, signal);
 
   yield {
     type: 'run_complete',
@@ -310,7 +314,7 @@ async function* scenarioSimple(
   yield { type: 'thinking_delta', content: 'This is a general question about GovOn. No tools needed — I can answer directly. ' };
   yield { type: 'thinking_end', iteration: 1, tool_calls: [] };
 
-  yield* streamWords(ANSWERS.simple, 25, signal);
+  yield* streamChunks(ANSWERS.simple, 25, signal);
 
   yield {
     type: 'run_complete',
@@ -366,7 +370,7 @@ async function* scenarioLong(
   yield { type: 'thinking_end', iteration: 2, tool_calls: [] };
 
   // Stream the long answer more slowly to stress-test the display
-  yield* streamWords(ANSWERS.long, 20, signal);
+  yield* streamChunks(ANSWERS.long, 20, signal);
 
   yield {
     type: 'run_complete',
@@ -538,7 +542,52 @@ export class MockGovOnClient implements IClient {
     await sleep(500, _signal);
     const sid = sessionId ?? uuid();
     const scenario = resolveScenario(query);
+
+    // Error scenario throws to mirror what a real backend would do
+    if (scenario === 'error') {
+      throw new Error('[MockError] Backend service unavailable: connection to data source timed out after 30s');
+    }
+
     const text = ANSWERS[scenario] || ANSWERS.stats;
+
+    // Build scenario-appropriate trace
+    const traceByScenario: Record<ScenarioKey, { plan: string[]; tool_results: AgentRunResponse['trace']['tool_results'] }> = {
+      stats: {
+        plan: ['stats_lookup', 'keyword_analyzer'],
+        tool_results: [
+          { tool: 'stats_lookup', success: true, latency_ms: 150, data: { total: 12847 } },
+          { tool: 'keyword_analyzer', success: true, latency_ms: 120, data: {} },
+        ],
+      },
+      simple: {
+        plan: [],
+        tool_results: [],
+      },
+      tool_fail: {
+        plan: ['stats_lookup', 'demographics_lookup'],
+        tool_results: [
+          { tool: 'stats_lookup', success: true, latency_ms: 150, data: {} },
+          { tool: 'demographics_lookup', success: false, latency_ms: 500, data: {}, error: 'Timeout' },
+        ],
+      },
+      long: {
+        plan: ['stats_lookup', 'keyword_analyzer', 'demographics_lookup'],
+        tool_results: [
+          { tool: 'stats_lookup', success: true, latency_ms: 400, data: {} },
+          { tool: 'keyword_analyzer', success: true, latency_ms: 350, data: {} },
+          { tool: 'demographics_lookup', success: true, latency_ms: 500, data: {} },
+        ],
+      },
+      approval: {
+        plan: ['stats_lookup'],
+        tool_results: [
+          { tool: 'stats_lookup', success: true, latency_ms: 150, data: {} },
+        ],
+      },
+      error: { plan: [], tool_results: [] }, // unreachable — throws above
+    };
+
+    const trace = traceByScenario[scenario] ?? traceByScenario.stats;
 
     return {
       request_id: uuid(),
@@ -547,16 +596,18 @@ export class MockGovOnClient implements IClient {
       trace: {
         request_id: uuid(),
         session_id: sid,
-        plan: ['stats_lookup'],
+        plan: trace.plan,
         plan_reason: `Mock blocking run for scenario: ${scenario}`,
-        tool_results: [
-          { tool: 'stats_lookup', success: true, latency_ms: 150, data: {} },
-        ],
+        tool_results: trace.tool_results,
         total_latency_ms: 500,
       },
       thread_id: uuid(),
       evidence_items: [],
-      metadata: { total_iterations: 1, total_tool_calls: 1, total_latency_ms: 500 },
+      metadata: {
+        total_iterations: scenario === 'simple' ? 1 : 2,
+        total_tool_calls: trace.tool_results.length,
+        total_latency_ms: 500,
+      },
     };
   }
 

--- a/packages/npm/src/mockClient.ts
+++ b/packages/npm/src/mockClient.ts
@@ -478,11 +478,29 @@ export class MockGovOnClient implements IClient {
         },
       };
 
-      // Keep the generator alive until approve()/cancel() resolves it.
-      // The TUI shows ApprovalPrompt and waits for y/n; once the user
-      // decides, approve() resolves this promise and the stream ends.
-      await new Promise<void>((resolve) => {
-        this._pendingApprovals.set(tid, { sessionId: sid, resolve });
+      // Keep the generator alive until approve()/cancel() resolves it,
+      // or until the request is aborted (Esc). The TUI shows ApprovalPrompt
+      // and waits for y/n; once the user decides, approve() calls finish().
+      await new Promise<void>((resolve, reject) => {
+        const finish = () => {
+          _signal?.removeEventListener('abort', onAbort);
+          this._pendingApprovals.delete(tid);
+          resolve();
+        };
+
+        const onAbort = () => {
+          _signal?.removeEventListener('abort', onAbort);
+          this._pendingApprovals.delete(tid);
+          reject(new DOMException('Aborted', 'AbortError'));
+        };
+
+        if (_signal?.aborted) {
+          onAbort();
+          return;
+        }
+
+        this._pendingApprovals.set(tid, { sessionId: sid, resolve: finish });
+        _signal?.addEventListener('abort', onAbort, { once: true });
       });
 
       return;
@@ -548,7 +566,7 @@ export class MockGovOnClient implements IClient {
     _maxIterations?: number,
     _signal?: AbortSignal,
   ): Promise<Record<string, unknown>> {
-    const result = await this.run(query, sessionId);
+    const result = await this.run(query, sessionId, _signal);
     return result as unknown as Record<string, unknown>;
   }
 

--- a/packages/npm/src/mockClient.ts
+++ b/packages/npm/src/mockClient.ts
@@ -1,0 +1,537 @@
+/**
+ * MockGovOnClient — offline mock implementing IClient.
+ *
+ * Routes queries to different TUI scenarios so every UI branch can be
+ * exercised without a running backend.
+ *
+ * Activate via:  GOVON_MOCK=true node bin/govon.js
+ *
+ * ┌──────────────────────────────────────────────────────────────────┐
+ * │  Test Prompts                                                    │
+ * ├─────────────────┬────────────────────────────────────────────────┤
+ * │  민원 통계       │  v3 normal: thinking → tools → answer stream  │
+ * │  승인 테스트     │  v2 approval flow: ApprovalPrompt y/n         │
+ * │  에러 테스트     │  v3 server error event                        │
+ * │  도구 실패       │  v3 tool_end with success=false               │
+ * │  간단 질문       │  v3 direct answer, no tool calls              │
+ * │  긴 답변        │  v3 long markdown streaming stress test        │
+ * │  (anything else) │  v3 normal (same as 민원 통계)                │
+ * └─────────────────┴────────────────────────────────────────────────┘
+ */
+
+import type { IClient } from './client.interface.js';
+import type {
+  V3SSEEvent,
+  V2SSEEvent,
+  AgentRunResponse,
+  ApprovalResponse,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function uuid(): string {
+  return crypto.randomUUID();
+}
+
+/** Stream text word-by-word as response_delta events. */
+async function* streamWords(
+  text: string,
+  delayMs: number,
+  signal?: AbortSignal,
+): AsyncGenerator<V3SSEEvent> {
+  const words = text.split(' ');
+  for (const word of words) {
+    if (signal?.aborted) return;
+    await sleep(delayMs);
+    yield { type: 'response_delta', content: word + ' ' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: query → scenario key
+// ---------------------------------------------------------------------------
+
+type ScenarioKey = 'stats' | 'approval' | 'error' | 'tool_fail' | 'simple' | 'long';
+
+function resolveScenario(query: string): ScenarioKey {
+  const q = query.trim();
+  if (q.includes('승인')) return 'approval';
+  if (q.includes('에러') || q.includes('오류')) return 'error';
+  if (q.includes('실패') || q.includes('도구 실패')) return 'tool_fail';
+  if (q.includes('간단')) return 'simple';
+  if (q.includes('긴 답변') || q.includes('길게')) return 'long';
+  return 'stats';
+}
+
+// ---------------------------------------------------------------------------
+// Mock answer data per scenario
+// ---------------------------------------------------------------------------
+
+const ANSWERS: Record<ScenarioKey, string> = {
+  stats:
+    '2024년 1분기 민원 통계를 분석한 결과, 총 **12,847건**의 민원이 접수되었습니다.\n\n' +
+    '## 주요 카테고리\n\n' +
+    '| 카테고리 | 건수 | 비율 |\n' +
+    '|---------|------|------|\n' +
+    '| 도로·교통 | 3,241 | 25.2% |\n' +
+    '| 환경·위생 | 2,891 | 22.5% |\n' +
+    '| 건축·주택 | 2,104 | 16.4% |\n' +
+    '| 복지·보건 | 1,982 | 15.4% |\n' +
+    '| 기타 | 2,629 | 20.5% |\n\n' +
+    '전 분기 대비 **8.3%** 증가했으며, 도로·교통 분야의 증가율이 가장 높았습니다.',
+
+  approval:
+    '승인 후 실행한 결과, 해당 민원에 대한 상세 통계를 조회했습니다.\n\n' +
+    '**승인된 작업:** 민원 데이터베이스 직접 조회\n' +
+    '**결과:** 정상 처리 완료',
+
+  error: '', // not used — error event is emitted instead
+
+  tool_fail:
+    '도구 실행 중 일부 오류가 발생했으나, 캐시된 데이터로 응답합니다.\n\n' +
+    '> ⚠ `demographics_lookup` 도구가 타임아웃으로 실패했습니다.\n\n' +
+    '사용 가능한 데이터 기준으로, 2024년 상반기 민원 접수 건수는 약 **24,500건**입니다.',
+
+  simple:
+    'GovOn은 정부 민원 데이터를 분석하는 AI 에이전트입니다.\n\n' +
+    '주요 기능:\n' +
+    '- 민원 통계 조회 및 분석\n' +
+    '- 키워드 트렌드 분석\n' +
+    '- 인구통계 기반 민원 패턴 파악\n\n' +
+    '질문을 입력하면 적절한 도구를 선택하여 답변합니다.',
+
+  long:
+    '# 2024년 전국 민원 종합 분석 보고서\n\n' +
+    '## 1. 개요\n\n' +
+    '본 보고서는 2024년 1월부터 12월까지 접수된 전국 민원 데이터를 종합 분석한 결과입니다. ' +
+    '총 **156,284건**의 민원을 대상으로 카테고리별, 지역별, 시기별 분석을 수행했습니다.\n\n' +
+    '## 2. 카테고리별 분석\n\n' +
+    '### 2.1 도로·교통 (38,421건, 24.6%)\n\n' +
+    '도로·교통 분야는 전체 민원의 약 1/4을 차지하며, 특히 **보도블록 파손**(8,234건)과 ' +
+    '**불법 주정차**(6,891건)가 상위를 기록했습니다.\n\n' +
+    '```\n' +
+    '보도블록 파손    ████████████████████  8,234건\n' +
+    '불법 주정차      ████████████████     6,891건\n' +
+    '신호등 고장      ████████████         5,102건\n' +
+    '도로 포트홀      ██████████           4,567건\n' +
+    '기타            ████████████████████████████  13,627건\n' +
+    '```\n\n' +
+    '### 2.2 환경·위생 (35,192건, 22.5%)\n\n' +
+    '환경·위생 민원은 계절적 변동이 뚜렷합니다:\n\n' +
+    '| 분기 | 건수 | 전분기 대비 |\n' +
+    '|------|------|----------|\n' +
+    '| Q1 | 6,234 | - |\n' +
+    '| Q2 | 9,891 | +58.7% |\n' +
+    '| Q3 | 12,456 | +25.9% |\n' +
+    '| Q4 | 6,611 | -46.9% |\n\n' +
+    '여름철(Q2-Q3)에 **악취**, **해충**, **쓰레기 불법투기** 민원이 급증하는 패턴입니다.\n\n' +
+    '### 2.3 건축·주택 (25,604건, 16.4%)\n\n' +
+    '건축·주택 민원의 주요 유형:\n' +
+    '1. 층간소음 분쟁 — 9,234건 (36.1%)\n' +
+    '2. 불법 건축물 신고 — 5,891건 (23.0%)\n' +
+    '3. 주택 안전점검 요청 — 4,102건 (16.0%)\n' +
+    '4. 리모델링 허가 문의 — 3,567건 (13.9%)\n' +
+    '5. 기타 — 2,810건 (11.0%)\n\n' +
+    '## 3. 지역별 분석\n\n' +
+    '수도권(서울·경기·인천)이 전체의 **47.3%** 를 차지하며, ' +
+    '인구 대비 민원 발생률은 세종시가 가장 높았습니다.\n\n' +
+    '## 4. 결론 및 제언\n\n' +
+    '- 도로·교통 인프라 예방 정비 확대 필요\n' +
+    '- 여름철 환경·위생 민원 대응 체계 사전 구축\n' +
+    '- 층간소음 조정 서비스 접근성 개선\n' +
+    '- 데이터 기반 민원 예측 시스템 도입 검토\n\n' +
+    '---\n' +
+    '*이 보고서는 GovOn AI 에이전트가 자동 생성한 분석입니다.*',
+};
+
+// ---------------------------------------------------------------------------
+// V3 scenario generators
+// ---------------------------------------------------------------------------
+
+async function* scenarioStats(
+  query: string,
+  sessionId: string,
+  threadId: string,
+  signal?: AbortSignal,
+): AsyncGenerator<V3SSEEvent> {
+  // Iteration 1: thinking → 2 tool calls
+  yield { type: 'thinking_start', iteration: 1 };
+  for (const line of [
+    'Analyzing the user query to determine the appropriate tools... ',
+    'The query is about civil complaint statistics. I should use the stats_lookup tool. ',
+    'Let me also check for keyword analysis to provide additional context. ',
+  ]) {
+    if (signal?.aborted) return;
+    await sleep(80);
+    yield { type: 'thinking_delta', content: line };
+  }
+  yield {
+    type: 'thinking_end',
+    iteration: 1,
+    tool_calls: [
+      { name: 'stats_lookup', args: { period: '2024-Q1' } },
+      { name: 'keyword_analyzer', args: { query } },
+    ],
+  };
+
+  // Tool execution
+  yield { type: 'tool_start', tool: 'stats_lookup' };
+  if (signal?.aborted) return;
+  await sleep(300);
+  yield { type: 'tool_end', tool: 'stats_lookup', success: true };
+
+  yield { type: 'tool_start', tool: 'keyword_analyzer' };
+  if (signal?.aborted) return;
+  await sleep(200);
+  yield { type: 'tool_end', tool: 'keyword_analyzer', success: true };
+
+  // Iteration 2: compose final answer
+  yield { type: 'thinking_start', iteration: 2 };
+  await sleep(50);
+  yield { type: 'thinking_delta', content: 'Tools returned successfully. Composing the final answer now.' };
+  yield { type: 'thinking_end', iteration: 2, tool_calls: [] };
+
+  yield* streamWords(ANSWERS.stats, 30, signal);
+
+  yield {
+    type: 'run_complete',
+    thread_id: threadId,
+    session_id: sessionId,
+    text: ANSWERS.stats,
+    evidence_items: [
+      { source_type: 'api', content: '2024-Q1 civil complaint statistics (mock)', score: 0.95 },
+      { source_type: 'rag', content: 'Keyword frequency analysis for query (mock)', score: 0.87 },
+    ],
+    metadata: { total_iterations: 2, total_tool_calls: 2, total_latency_ms: 1200 },
+  };
+}
+
+async function* scenarioError(
+  _sessionId: string,
+  signal?: AbortSignal,
+): AsyncGenerator<V3SSEEvent> {
+  // Start thinking, then crash mid-stream
+  yield { type: 'thinking_start', iteration: 1 };
+  await sleep(100);
+  yield { type: 'thinking_delta', content: 'Processing the query... ' };
+  if (signal?.aborted) return;
+  await sleep(200);
+  yield { type: 'thinking_delta', content: 'Attempting to connect to data source... ' };
+  await sleep(300);
+  yield { type: 'error', error: '[MockError] Backend service unavailable: connection to data source timed out after 30s' };
+}
+
+async function* scenarioToolFail(
+  query: string,
+  sessionId: string,
+  threadId: string,
+  signal?: AbortSignal,
+): AsyncGenerator<V3SSEEvent> {
+  // Iteration 1: thinking → 2 tools, one fails
+  yield { type: 'thinking_start', iteration: 1 };
+  await sleep(60);
+  yield { type: 'thinking_delta', content: 'I need to look up demographics and statistics for this query. ' };
+  yield {
+    type: 'thinking_end',
+    iteration: 1,
+    tool_calls: [
+      { name: 'stats_lookup', args: { period: '2024-H1' } },
+      { name: 'demographics_lookup', args: { region: 'all', query } },
+    ],
+  };
+
+  yield { type: 'tool_start', tool: 'stats_lookup' };
+  if (signal?.aborted) return;
+  await sleep(250);
+  yield { type: 'tool_end', tool: 'stats_lookup', success: true };
+
+  yield { type: 'tool_start', tool: 'demographics_lookup' };
+  if (signal?.aborted) return;
+  await sleep(500);
+  // This one FAILS
+  yield { type: 'tool_end', tool: 'demographics_lookup', success: false };
+
+  // Iteration 2: recover and answer with partial data
+  yield { type: 'thinking_start', iteration: 2 };
+  await sleep(80);
+  yield { type: 'thinking_delta', content: 'demographics_lookup failed with timeout. I will use cached data to answer. ' };
+  yield { type: 'thinking_end', iteration: 2, tool_calls: [] };
+
+  yield* streamWords(ANSWERS.tool_fail, 30, signal);
+
+  yield {
+    type: 'run_complete',
+    thread_id: threadId,
+    session_id: sessionId,
+    text: ANSWERS.tool_fail,
+    evidence_items: [
+      { source_type: 'api', content: '2024-H1 statistics (partial, mock)', score: 0.72 },
+    ],
+    metadata: { total_iterations: 2, total_tool_calls: 2, total_latency_ms: 1800 },
+  };
+}
+
+async function* scenarioSimple(
+  sessionId: string,
+  threadId: string,
+  signal?: AbortSignal,
+): AsyncGenerator<V3SSEEvent> {
+  // Single iteration — no tool calls, direct answer
+  yield { type: 'thinking_start', iteration: 1 };
+  await sleep(60);
+  yield { type: 'thinking_delta', content: 'This is a general question about GovOn. No tools needed — I can answer directly. ' };
+  yield { type: 'thinking_end', iteration: 1, tool_calls: [] };
+
+  yield* streamWords(ANSWERS.simple, 25, signal);
+
+  yield {
+    type: 'run_complete',
+    thread_id: threadId,
+    session_id: sessionId,
+    text: ANSWERS.simple,
+    evidence_items: [],
+    metadata: { total_iterations: 1, total_tool_calls: 0, total_latency_ms: 400 },
+  };
+}
+
+async function* scenarioLong(
+  query: string,
+  sessionId: string,
+  threadId: string,
+  signal?: AbortSignal,
+): AsyncGenerator<V3SSEEvent> {
+  // Iteration 1: thinking → 3 tool calls (heavy workload)
+  yield { type: 'thinking_start', iteration: 1 };
+  await sleep(80);
+  yield { type: 'thinking_delta', content: 'User is requesting a comprehensive analysis. I need multiple data sources. ' };
+  yield { type: 'thinking_delta', content: 'Planning: stats_lookup for volume, keyword_analyzer for trends, demographics_lookup for regional breakdown. ' };
+  yield {
+    type: 'thinking_end',
+    iteration: 1,
+    tool_calls: [
+      { name: 'stats_lookup', args: { period: '2024-full', detail: 'category' } },
+      { name: 'keyword_analyzer', args: { query, depth: 'deep' } },
+      { name: 'demographics_lookup', args: { region: 'all', period: '2024' } },
+    ],
+  };
+
+  // 3 tools in sequence
+  yield { type: 'tool_start', tool: 'stats_lookup' };
+  if (signal?.aborted) return;
+  await sleep(400);
+  yield { type: 'tool_end', tool: 'stats_lookup', success: true };
+
+  yield { type: 'tool_start', tool: 'keyword_analyzer' };
+  if (signal?.aborted) return;
+  await sleep(350);
+  yield { type: 'tool_end', tool: 'keyword_analyzer', success: true };
+
+  yield { type: 'tool_start', tool: 'demographics_lookup' };
+  if (signal?.aborted) return;
+  await sleep(500);
+  yield { type: 'tool_end', tool: 'demographics_lookup', success: true };
+
+  // Iteration 2: compose long report
+  yield { type: 'thinking_start', iteration: 2 };
+  await sleep(60);
+  yield { type: 'thinking_delta', content: 'All three tools returned successfully. Composing a comprehensive report with tables and code blocks. ' };
+  yield { type: 'thinking_end', iteration: 2, tool_calls: [] };
+
+  // Stream the long answer more slowly to stress-test the display
+  yield* streamWords(ANSWERS.long, 20, signal);
+
+  yield {
+    type: 'run_complete',
+    thread_id: threadId,
+    session_id: sessionId,
+    text: ANSWERS.long,
+    evidence_items: [
+      { source_type: 'api', content: '2024 full-year complaint stats (mock)', score: 0.97 },
+      { source_type: 'rag', content: 'Keyword trend analysis 2024 (mock)', score: 0.91 },
+      { source_type: 'api', content: 'Regional demographics overlay (mock)', score: 0.88 },
+    ],
+    metadata: { total_iterations: 2, total_tool_calls: 3, total_latency_ms: 3200 },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// MockGovOnClient
+// ---------------------------------------------------------------------------
+
+export class MockGovOnClient implements IClient {
+  async health(): Promise<Record<string, unknown>> {
+    return { status: 'ok', mock: true };
+  }
+
+  async waitForReady(): Promise<boolean> {
+    return true;
+  }
+
+  async *streamV3(
+    query: string,
+    sessionId?: string,
+    _maxIterations?: number,
+    signal?: AbortSignal,
+  ): AsyncGenerator<V3SSEEvent> {
+    const sid = sessionId ?? uuid();
+    const tid = uuid();
+    const scenario = resolveScenario(query);
+
+    switch (scenario) {
+      case 'approval':
+        // v3 has no approval event — throw so useSSE falls through to v2
+        throw new Error('v3 not supported for approval flow');
+
+      case 'error':
+        yield* scenarioError(sid, signal);
+        return;
+
+      case 'tool_fail':
+        yield* scenarioToolFail(query, sid, tid, signal);
+        return;
+
+      case 'simple':
+        yield* scenarioSimple(sid, tid, signal);
+        return;
+
+      case 'long':
+        yield* scenarioLong(query, sid, tid, signal);
+        return;
+
+      case 'stats':
+      default:
+        yield* scenarioStats(query, sid, tid, signal);
+        return;
+    }
+  }
+
+  async *stream(
+    query: string,
+    sessionId?: string,
+    _signal?: AbortSignal,
+  ): AsyncGenerator<V2SSEEvent> {
+    const sid = sessionId ?? uuid();
+    const tid = uuid();
+    const scenario = resolveScenario(query);
+
+    if (scenario === 'approval') {
+      // --- V2 approval flow ---
+      yield { node: 'session_load', status: 'completed' };
+      await sleep(100);
+
+      yield {
+        node: 'agent',
+        status: 'completed',
+        planned_tools: ['stats_lookup'],
+        task_type: 'stats_query',
+      };
+      await sleep(150);
+
+      // Trigger the approval prompt
+      yield {
+        node: 'approval_wait',
+        status: 'awaiting_approval',
+        thread_id: tid,
+        session_id: sid,
+        approval_request: {
+          approval_id: uuid(),
+          task_type: 'stats_query',
+          description: '민원 데이터베이스에 직접 접근하여 통계를 조회합니다. 이 작업은 실시간 데이터를 사용하므로 승인이 필요합니다.',
+          planned_tools: ['stats_lookup', 'demographics_lookup'],
+        },
+      };
+
+      // The TUI will show ApprovalPrompt and wait for y/n.
+      // After the user approves via client.approve(), the stream ends.
+      // The approval response from approve() contains the final text.
+      return;
+    }
+
+    // Default v2 fallback for non-approval scenarios
+    yield { node: 'session_load', status: 'completed' };
+    await sleep(100);
+
+    yield {
+      node: 'agent',
+      status: 'completed',
+      planned_tools: ['stats_lookup'],
+    };
+    await sleep(200);
+
+    yield { node: 'tools', status: 'completed', tool_results: {} };
+    await sleep(100);
+
+    yield {
+      node: 'persist',
+      status: 'completed',
+      final_text: ANSWERS[scenario] || ANSWERS.stats,
+      evidence_items: [],
+      session_id: sid,
+      thread_id: tid,
+    };
+  }
+
+  async run(
+    query: string,
+    sessionId?: string,
+    _signal?: AbortSignal,
+  ): Promise<AgentRunResponse> {
+    await sleep(500);
+    const sid = sessionId ?? uuid();
+    const scenario = resolveScenario(query);
+    const text = ANSWERS[scenario] || ANSWERS.stats;
+
+    return {
+      request_id: uuid(),
+      session_id: sid,
+      text,
+      trace: {
+        request_id: uuid(),
+        session_id: sid,
+        plan: ['stats_lookup'],
+        plan_reason: `Mock blocking run for scenario: ${scenario}`,
+        tool_results: [
+          { tool: 'stats_lookup', success: true, latency_ms: 150, data: {} },
+        ],
+        total_latency_ms: 500,
+      },
+      thread_id: uuid(),
+      evidence_items: [],
+      metadata: { total_iterations: 1, total_tool_calls: 1, total_latency_ms: 500 },
+    };
+  }
+
+  async runV3(
+    query: string,
+    sessionId?: string,
+    _maxIterations?: number,
+    _signal?: AbortSignal,
+  ): Promise<Record<string, unknown>> {
+    const result = await this.run(query, sessionId);
+    return result as unknown as Record<string, unknown>;
+  }
+
+  async approve(_threadId: string, approved: boolean): Promise<ApprovalResponse> {
+    await sleep(200);
+    return {
+      status: approved ? 'approved' : 'rejected',
+      thread_id: _threadId,
+      session_id: uuid(),
+      text: approved ? ANSWERS.approval : undefined,
+      evidence_items: approved
+        ? [{ source_type: 'api', content: 'Direct DB query result (mock)', score: 0.93 }]
+        : [],
+      approval_status: approved ? 'approved' : 'rejected',
+    };
+  }
+
+  async cancel(_threadId: string): Promise<Record<string, unknown>> {
+    return { status: 'cancelled', thread_id: _threadId };
+  }
+}


### PR DESCRIPTION
## Summary
- Extract `IClient` interface from `GovOnClient` and introduce `MockGovOnClient` + `clientFactory` for offline TUI development
- 6 scenario-routed test prompts covering all major UI branches: normal v3 streaming, v2 approval flow, server error, tool failure, direct answer, long markdown stress test
- `npm run dev:mock` script added — activate with `GOVON_MOCK=true`

## Changed Files
| File | Change |
|------|--------|
| `src/client.interface.ts` | New — `IClient` shared interface |
| `src/mockClient.ts` | New — `MockGovOnClient` with 6 scenarios |
| `src/clientFactory.ts` | New — factory switching real/mock by env var |
| `src/hooks/useDaemon.ts` | `GovOnClient` → `IClient` type |
| `src/hooks/useSSE.ts` | `GovOnClient` → `IClient` type |
| `src/App.tsx` | Use `createClient()` factory, `[MOCK]` footer |
| `package.json` | Add `dev:mock` script |
| `MOCK_TEST_PROMPTS.md` | Test prompt documentation |

## Test plan
- [ ] `npm run build` passes with no type errors
- [ ] `GOVON_MOCK=true node bin/govon.js` launches TUI without server
- [ ] Each of the 6 test prompts triggers its expected UI flow
- [ ] Without `GOVON_MOCK`, TUI behaves identically to before (real client)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Offline mock mode for local development with deterministic scenarios (approval flows, errors, tool failures, long/streaming answers)
  * New npm command to start mock mode locally
  * Status footer shows “[MOCK]” when mock mode is active

* **Refactor**
  * Client abstraction allowing runtime switch between real and mock implementations
  * Internal hooks updated to use the new client contract

* **Documentation**
  * Guide added describing mock mode usage and the enabling flag
<!-- end of auto-generated comment: release notes by coderabbit.ai -->